### PR TITLE
Use Jira account IDs for first-class person filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ scry sql --csv "…"    # header row plus CSV
 -- Prefer issues_full for titles (summary comes from items.title).
 SELECT key, status, priority, summary
 FROM issues_full
-WHERE assignee_email = 'dana@example.com' AND status_category != 'done'
+WHERE assignee_id = 'account-id-from-the-mirror' AND status_category != 'done'
 ORDER BY priority_rank, updated_at DESC;
 
 -- 2. What regressed — reopens are the highest-signal quality metric available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Person filters no longer depend on Jira email visibility.** Assignee,
+  reporter, current-user, grouping, and configured user-field filters prefer
+  Jira account IDs while continuing to read email-valued saved views. Jira
+  Cloud sites that hide `emailAddress` now keep their full people facets, and
+  assigned issues no longer appear as unassigned merely because email is absent.
 - **`scry profiles` is an inventory now** — active marker, issue and document
   counts, last sync, and the site host (host only; never the URL, email or
   token), plus `--json`. There is deliberately no `switch`: the CLI writes to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 - **Person filters no longer depend on Jira email visibility.** Assignee,
-  reporter, current-user, grouping, and configured user-field filters prefer
-  Jira account IDs while continuing to read email-valued saved views. Jira
-  Cloud sites that hide `emailAddress` now keep their full people facets, and
-  assigned issues no longer appear as unassigned merely because email is absent.
+  reporter, current-user, and grouping filters prefer Jira account IDs while
+  still accepting email-valued saved views when the issue or member directory
+  retains that alias. Existing browser issue caches refresh once to receive the
+  additive reporter ID; current caches and write metadata stay warm. Jira Cloud
+  sites that hide `emailAddress` now keep their full people facets, and assigned
+  issues no longer appear as unassigned merely because email is absent.
 - **`scry profiles` is an inventory now** — active marker, issue and document
   counts, last sync, and the site host (host only; never the URL, email or
   token), plus `--json`. There is deliberately no `switch`: the CLI writes to

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -119,7 +119,9 @@ calls `store.Search`, so there is no match field or snippet to surface.
 
 - `status_category` → tab / category filter
 - `assignee_email` / `assignee` → assignee filter. The compatibility key accepts
-  either a Jira account ID (new web views) or an email (older saved views).
+  either a Jira account ID (new web views) or an email (older saved views). When
+  an issue no longer carries that email, configured members can map the legacy
+  email to its Jira account ID.
 - `q` / `text` → the `/` text filter
 - `unassigned` → unassigned-only
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -118,7 +118,8 @@ calls `store.Search`, so there is no match field or snippet to surface.
 **Filters**
 
 - `status_category` → tab / category filter
-- `assignee_email` / `assignee` → assignee filter
+- `assignee_email` / `assignee` → assignee filter. The compatibility key accepts
+  either a Jira account ID (new web views) or an email (older saved views).
 - `q` / `text` → the `/` text filter
 - `unassigned` → unassigned-only
 

--- a/e2e/cache-upgrade.spec.ts
+++ b/e2e/cache-upgrade.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test, type Page, type Request } from '@playwright/test'
+import { gotoApp } from './helpers'
+
+const DB_NAME = 'issue-navigator'
+
+interface CacheState {
+  version: number
+  count: number
+  hasLegacyRow: boolean
+  hasReporterID: boolean
+  syncVersion: number | null
+  writeCachedAt: string | null
+}
+
+async function deleteDatabase(page: Page): Promise<void> {
+  await page.goto('/healthz')
+  await page.evaluate(
+    (name) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(name)
+        request.onsuccess = () => resolve()
+        request.onerror = () => reject(request.error)
+        request.onblocked = () => reject(new Error('indexeddb-delete-blocked'))
+      }),
+    DB_NAME,
+  )
+}
+
+async function seedLegacyCache(page: Page): Promise<void> {
+  await deleteDatabase(page)
+  await page.evaluate(
+    (name) =>
+      new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open(name, 1)
+        request.onupgradeneeded = () => {
+          request.result.createObjectStore('issues', { keyPath: 'issue_key' })
+          request.result.createObjectStore('meta', { keyPath: 'key' })
+        }
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => {
+          const database = request.result
+          const transaction = database.transaction(['issues', 'meta'], 'readwrite')
+          transaction.objectStore('issues').put({ issue_key: 'LEGACY-1' })
+          transaction.objectStore('meta').put({
+            key: 'sync',
+            server_time: '2000-01-01T00:00:00.000Z',
+            sync_version: 999,
+            members: [],
+          })
+          transaction.objectStore('meta').put({
+            key: 'write',
+            transitions: {},
+            projects: [],
+            updated_at: null,
+            cached_at: 'legacy-write-meta',
+          })
+          transaction.oncomplete = () => {
+            database.close()
+            resolve()
+          }
+          transaction.onerror = () => reject(transaction.error)
+          transaction.onabort = () => reject(transaction.error)
+        }
+      }),
+    DB_NAME,
+  )
+}
+
+async function cacheState(page: Page): Promise<CacheState> {
+  return page.evaluate(
+    (name) =>
+      new Promise<CacheState>((resolve, reject) => {
+        const request = indexedDB.open(name)
+        request.onerror = () => reject(request.error)
+        request.onsuccess = () => {
+          const database = request.result
+          const transaction = database.transaction(['issues', 'meta'], 'readonly')
+          const issuesRequest = transaction.objectStore('issues').getAll()
+          const syncRequest = transaction.objectStore('meta').get('sync')
+          const writeRequest = transaction.objectStore('meta').get('write')
+          transaction.oncomplete = () => {
+            const rows = issuesRequest.result as Array<Record<string, unknown>>
+            resolve({
+              version: database.version,
+              count: rows.length,
+              hasLegacyRow: rows.some((row) => row.issue_key === 'LEGACY-1'),
+              hasReporterID: rows.some((row) => typeof row.reporter_id === 'string' && row.reporter_id !== ''),
+              syncVersion:
+                typeof syncRequest.result?.sync_version === 'number'
+                  ? syncRequest.result.sync_version
+                  : null,
+              writeCachedAt:
+                typeof writeRequest.result?.cached_at === 'string'
+                  ? writeRequest.result.cached_at
+                  : null,
+            })
+            database.close()
+          }
+          transaction.onerror = () => reject(transaction.error)
+        }
+      }),
+    DB_NAME,
+  )
+}
+
+function issueRequestLog(page: Page): { requests: Request[]; stop: () => void } {
+  const requests: Request[] = []
+  const listener = (request: Request) => {
+    if (request.url().includes('/api/v1/issues/')) requests.push(request)
+  }
+  page.on('request', listener)
+  return { requests, stop: () => page.off('request', listener) }
+}
+
+test.describe('IssueLite cache upgrade', () => {
+  test('legacy v1 cache invalidates once, then the v2 cache is reused', async ({ page }) => {
+    await seedLegacyCache(page)
+    await page.route('**/api/v1/issues/meta/write/', (route) => route.abort())
+    const log = issueRequestLog(page)
+
+    await gotoApp(page)
+
+    expect(log.requests.some((request) => request.url().includes('/bootstrap/'))).toBe(true)
+    expect(log.requests.some((request) => request.url().includes('/delta/'))).toBe(false)
+    const bootstrap = log.requests.find((request) => request.url().includes('/bootstrap/'))
+    expect(bootstrap?.headers()['if-none-match']).toBeUndefined()
+    await expect
+      .poll(() => cacheState(page), { timeout: 30_000 })
+      .toMatchObject({
+        version: 2,
+        hasLegacyRow: false,
+        hasReporterID: true,
+        writeCachedAt: 'legacy-write-meta',
+      })
+    const upgraded = await cacheState(page)
+    expect(upgraded.count).toBeGreaterThan(0)
+    expect(upgraded.syncVersion).not.toBe(999)
+
+    log.requests.length = 0
+
+    await page.reload()
+    await expect(page.getByTestId('issue-layout')).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText(/534 issues/).first()).toBeVisible({ timeout: 30_000 })
+    await expect
+      .poll(() => log.requests.some((request) => request.url().includes('/delta/')))
+      .toBe(true)
+
+    expect(log.requests.some((request) => request.url().includes('/bootstrap/'))).toBe(false)
+    const reopened = await cacheState(page)
+    expect(reopened).toMatchObject({ version: 2, hasReporterID: true })
+    expect(reopened.count).toBe(upgraded.count)
+    expect(reopened.syncVersion).not.toBe(999)
+
+    log.stop()
+  })
+
+  test('fresh install creates a v2 cache and bootstraps normally', async ({ page }) => {
+    await deleteDatabase(page)
+    const log = issueRequestLog(page)
+
+    await gotoApp(page)
+
+    expect(log.requests.some((request) => request.url().includes('/bootstrap/'))).toBe(true)
+    await expect
+      .poll(() => cacheState(page), { timeout: 30_000 })
+      .toMatchObject({ version: 2, hasLegacyRow: false, hasReporterID: true })
+    expect((await cacheState(page)).count).toBeGreaterThan(0)
+
+    log.stop()
+  })
+})

--- a/e2e/person.spec.ts
+++ b/e2e/person.spec.ts
@@ -12,6 +12,80 @@ import { attachConsoleErrors, gotoApp } from './helpers'
  * (2026-08-06 데모 저자 분산으로 전제 변경 — was single-member / 634 / 534).
  */
 test.describe('people axis', () => {
+  test('account IDs keep assigned and reported filters working when Jira hides emails', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
+      const response = await route.fetch()
+      const body = await response.json()
+      for (const issue of body.issues) {
+        if (issue.assignee_id === 'demo-alex') issue.assignee_email = null
+        if (issue.reporter_id === 'demo-alex') issue.reporter_email = null
+      }
+      await route.fulfill({ response, json: body })
+    })
+    await gotoApp(page)
+
+    const openAlex = async () => {
+      await page.keyboard.press('ControlOrMeta+k')
+      await page.keyboard.type('alex', { delay: 20 })
+      await page.keyboard.press('Enter')
+      await expect(page.getByTestId('person-panel')).toBeVisible()
+    }
+
+    await openAlex()
+    const panel = page.getByTestId('person-panel')
+    await expect(panel.getByTestId('person-link-assigned')).toContainText('72')
+    await panel.getByTestId('person-link-assigned').click()
+    await expect(page.getByText('72 issues')).toBeVisible()
+    expect(decodeURIComponent(page.url())).toContain('as=demo-alex')
+
+    await openAlex()
+    await expect(panel.getByTestId('person-link-reported')).toContainText('198')
+    await panel.getByTestId('person-link-reported').click()
+    await expect(page.getByText('198 issues')).toBeVisible()
+    expect(decodeURIComponent(page.url())).toContain('rp=demo-alex')
+
+    // Existing saved links keep their email token. The member directory maps
+    // it to the account ID even though the intercepted issue rows hide email.
+    await page.goto('/#/?as=Demo%40Example.com')
+    await expect(page.getByText('72 issues')).toBeVisible()
+    await page.goto('/#/?rp=DEMO%40example.com')
+    await expect(page.getByText('198 issues')).toBeVisible()
+  })
+
+  test('a configured user field filters by account ID while displaying the person name', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
+      const response = await route.fetch()
+      const body = await response.json()
+      body.field_specs = [
+        ...(body.field_specs ?? []),
+        { alias: 'reviewer', label: 'Reviewer', role: 'user' },
+      ]
+      const project = body.issues[0].project_key
+      body.field_usage ??= {}
+      body.field_usage[project] ??= {}
+      body.field_usage[project].reviewer = 3
+      for (const [index, issue] of body.issues.slice(0, 3).entries()) {
+        const first = index < 2
+        issue.reviewer = first ? 'Reviewer One' : 'Reviewer Two'
+        issue.reviewer_account_ids = [first ? 'acc-reviewer-1' : 'acc-reviewer-2']
+      }
+      await route.fulfill({ response, json: body })
+    })
+    await gotoApp(page)
+
+    await page.getByRole('button', { name: '+ Filter' }).click()
+    await page.getByRole('button', { name: 'Reviewer', exact: true }).click()
+    await page.getByRole('button', { name: /Reviewer One\s+2/ }).click()
+
+    await expect(page.getByText('2 issues')).toBeVisible()
+    await expect(page.getByRole('button', { name: /Reviewer: Reviewer One/ })).toBeVisible()
+    expect(decodeURIComponent(page.url())).toContain('f.reviewer=acc-reviewer-1')
+  })
+
   test('palette finds a person, the panel lists their comments, a quick link filters the list', async ({
     page,
   }) => {

--- a/e2e/person.spec.ts
+++ b/e2e/person.spec.ts
@@ -54,38 +54,6 @@ test.describe('people axis', () => {
     await expect(page.getByText('198 issues')).toBeVisible()
   })
 
-  test('a configured user field filters by account ID while displaying the person name', async ({
-    page,
-  }) => {
-    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
-      const response = await route.fetch()
-      const body = await response.json()
-      body.field_specs = [
-        ...(body.field_specs ?? []),
-        { alias: 'reviewer', label: 'Reviewer', role: 'user' },
-      ]
-      const project = body.issues[0].project_key
-      body.field_usage ??= {}
-      body.field_usage[project] ??= {}
-      body.field_usage[project].reviewer = 3
-      for (const [index, issue] of body.issues.slice(0, 3).entries()) {
-        const first = index < 2
-        issue.reviewer = first ? 'Reviewer One' : 'Reviewer Two'
-        issue.reviewer_account_ids = [first ? 'acc-reviewer-1' : 'acc-reviewer-2']
-      }
-      await route.fulfill({ response, json: body })
-    })
-    await gotoApp(page)
-
-    await page.getByRole('button', { name: '+ Filter' }).click()
-    await page.getByRole('button', { name: 'Reviewer', exact: true }).click()
-    await page.getByRole('button', { name: /Reviewer One\s+2/ }).click()
-
-    await expect(page.getByText('2 issues')).toBeVisible()
-    await expect(page.getByRole('button', { name: /Reviewer: Reviewer One/ })).toBeVisible()
-    expect(decodeURIComponent(page.url())).toContain('f.reviewer=acc-reviewer-1')
-  })
-
   test('palette finds a person, the panel lists their comments, a quick link filters the list', async ({
     page,
   }) => {

--- a/internal/fields/coalesce.go
+++ b/internal/fields/coalesce.go
@@ -6,6 +6,11 @@ import (
 	"github.com/midagedev/scry/internal/config"
 )
 
+// UserAccountIDsSuffix names the companion value stored beside a user-role
+// alias. The display value remains under the alias; IDs are always a []string
+// so single- and multi-user fields share one filter contract.
+const UserAccountIDsSuffix = "_account_ids"
+
 // SpecIDs is the flat shape store and sync use to coalesce without depending on
 // the full FieldSpec when only alias+ids+role are needed.
 type SpecIDs struct {
@@ -75,10 +80,11 @@ func Coalesce(specs []SpecIDs, extra map[string]json.RawMessage) map[string]any 
 			if !ok || !IsFilled(raw) {
 				continue
 			}
-			var v any
-			if json.Unmarshal(raw, &v) != nil {
+			var source any
+			if json.Unmarshal(raw, &source) != nil {
 				continue
 			}
+			v := source
 			if s.Role != "body" {
 				v = DisplayValue(v)
 				if !IsFilledAny(v) {
@@ -86,12 +92,40 @@ func Coalesce(specs []SpecIDs, extra map[string]json.RawMessage) map[string]any 
 				}
 			}
 			out[s.Alias] = v
+			if s.Role == "user" {
+				if ids := UserAccountIDs(source); len(ids) > 0 {
+					out[s.Alias+UserAccountIDsSuffix] = ids
+				}
+			}
 			break
 		}
 	}
 	if len(out) == 0 {
 		return nil
 	}
+	return out
+}
+
+// UserAccountIDs extracts Jira accountId values from one user object or an
+// array of users. Order is preserved and duplicates are removed.
+func UserAccountIDs(v any) []string {
+	seen := map[string]bool{}
+	var out []string
+	var visit func(any)
+	visit = func(value any) {
+		switch t := value.(type) {
+		case []any:
+			for _, el := range t {
+				visit(el)
+			}
+		case map[string]any:
+			if id, ok := t["accountId"].(string); ok && id != "" && !seen[id] {
+				seen[id] = true
+				out = append(out, id)
+			}
+		}
+	}
+	visit(v)
 	return out
 }
 

--- a/internal/fields/coalesce.go
+++ b/internal/fields/coalesce.go
@@ -6,11 +6,6 @@ import (
 	"github.com/midagedev/scry/internal/config"
 )
 
-// UserAccountIDsSuffix names the companion value stored beside a user-role
-// alias. The display value remains under the alias; IDs are always a []string
-// so single- and multi-user fields share one filter contract.
-const UserAccountIDsSuffix = "_account_ids"
-
 // SpecIDs is the flat shape store and sync use to coalesce without depending on
 // the full FieldSpec when only alias+ids+role are needed.
 type SpecIDs struct {
@@ -80,11 +75,10 @@ func Coalesce(specs []SpecIDs, extra map[string]json.RawMessage) map[string]any 
 			if !ok || !IsFilled(raw) {
 				continue
 			}
-			var source any
-			if json.Unmarshal(raw, &source) != nil {
+			var v any
+			if json.Unmarshal(raw, &v) != nil {
 				continue
 			}
-			v := source
 			if s.Role != "body" {
 				v = DisplayValue(v)
 				if !IsFilledAny(v) {
@@ -92,40 +86,12 @@ func Coalesce(specs []SpecIDs, extra map[string]json.RawMessage) map[string]any 
 				}
 			}
 			out[s.Alias] = v
-			if s.Role == "user" {
-				if ids := UserAccountIDs(source); len(ids) > 0 {
-					out[s.Alias+UserAccountIDsSuffix] = ids
-				}
-			}
 			break
 		}
 	}
 	if len(out) == 0 {
 		return nil
 	}
-	return out
-}
-
-// UserAccountIDs extracts Jira accountId values from one user object or an
-// array of users. Order is preserved and duplicates are removed.
-func UserAccountIDs(v any) []string {
-	seen := map[string]bool{}
-	var out []string
-	var visit func(any)
-	visit = func(value any) {
-		switch t := value.(type) {
-		case []any:
-			for _, el := range t {
-				visit(el)
-			}
-		case map[string]any:
-			if id, ok := t["accountId"].(string); ok && id != "" && !seen[id] {
-				seen[id] = true
-				out = append(out, id)
-			}
-		}
-	}
-	visit(v)
 	return out
 }
 

--- a/internal/fields/coalesce_test.go
+++ b/internal/fields/coalesce_test.go
@@ -54,6 +54,32 @@ func TestDisplayValueShapes(t *testing.T) {
 	}
 }
 
+func TestCoalesceUserAccountIDs(t *testing.T) {
+	specs := []config.FieldSpec{
+		{Alias: "owner", IDs: []string{"customfield_10"}, Role: "user"},
+		{Alias: "reviewers", IDs: []string{"customfield_20"}, Role: "user"},
+	}
+	extra := map[string]json.RawMessage{
+		"customfield_10": json.RawMessage(`{"accountId":"acc-1","displayName":"Ada"}`),
+		"customfield_20": json.RawMessage(`[
+			{"accountId":"acc-2","displayName":"Grace"},
+			{"accountId":"acc-3","displayName":"Linus"}
+		]`),
+	}
+	got := CoalesceSpecs(specs, extra)
+	if got["owner"] != "Ada" {
+		t.Fatalf("owner display = %#v", got["owner"])
+	}
+	ownerIDs, ok := got["owner"+UserAccountIDsSuffix].([]string)
+	if !ok || len(ownerIDs) != 1 || ownerIDs[0] != "acc-1" {
+		t.Fatalf("owner ids = %#v", got["owner"+UserAccountIDsSuffix])
+	}
+	reviewerIDs, ok := got["reviewers"+UserAccountIDsSuffix].([]string)
+	if !ok || len(reviewerIDs) != 2 || reviewerIDs[0] != "acc-2" || reviewerIDs[1] != "acc-3" {
+		t.Fatalf("reviewer ids = %#v", got["reviewers"+UserAccountIDsSuffix])
+	}
+}
+
 func TestIsFilled(t *testing.T) {
 	cases := []struct {
 		raw  string

--- a/internal/fields/coalesce_test.go
+++ b/internal/fields/coalesce_test.go
@@ -54,32 +54,6 @@ func TestDisplayValueShapes(t *testing.T) {
 	}
 }
 
-func TestCoalesceUserAccountIDs(t *testing.T) {
-	specs := []config.FieldSpec{
-		{Alias: "owner", IDs: []string{"customfield_10"}, Role: "user"},
-		{Alias: "reviewers", IDs: []string{"customfield_20"}, Role: "user"},
-	}
-	extra := map[string]json.RawMessage{
-		"customfield_10": json.RawMessage(`{"accountId":"acc-1","displayName":"Ada"}`),
-		"customfield_20": json.RawMessage(`[
-			{"accountId":"acc-2","displayName":"Grace"},
-			{"accountId":"acc-3","displayName":"Linus"}
-		]`),
-	}
-	got := CoalesceSpecs(specs, extra)
-	if got["owner"] != "Ada" {
-		t.Fatalf("owner display = %#v", got["owner"])
-	}
-	ownerIDs, ok := got["owner"+UserAccountIDsSuffix].([]string)
-	if !ok || len(ownerIDs) != 1 || ownerIDs[0] != "acc-1" {
-		t.Fatalf("owner ids = %#v", got["owner"+UserAccountIDsSuffix])
-	}
-	reviewerIDs, ok := got["reviewers"+UserAccountIDsSuffix].([]string)
-	if !ok || len(reviewerIDs) != 2 || reviewerIDs[0] != "acc-2" || reviewerIDs[1] != "acc-3" {
-		t.Fatalf("reviewer ids = %#v", got["reviewers"+UserAccountIDsSuffix])
-	}
-}
-
 func TestIsFilled(t *testing.T) {
 	cases := []struct {
 		raw  string

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -62,7 +62,7 @@ LIMIT or columns and retry. Never write to this database; writes go through Jira
 Examples:
 1) Open work for someone, most urgent first:
   SELECT key, status, priority, summary FROM issues_full
-  WHERE assignee_email = 'dana@example.com' AND status_category != 'done'
+  WHERE assignee_id = 'account-id-from-the-mirror' AND status_category != 'done'
   ORDER BY priority_rank, updated_at DESC LIMIT 20;
 
 2) Issues stuck in progress the longest:

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -776,6 +776,7 @@ type derivedView struct {
 	emailByAccount map[string]string
 	categories     map[string]string
 	groupByEmail   map[string]string
+	groupByAccount map[string]string
 	rules          []config.GroupRule
 	groupsEnabled  bool
 	// Plugin enrichments the list rows carry, by issue key. They are cached with
@@ -820,6 +821,7 @@ func (s *server) buildView(ctx context.Context, key string, lites []store.IssueL
 		emailByAccount: map[string]string{},
 		categories:     map[string]string{},
 		groupByEmail:   map[string]string{},
+		groupByAccount: map[string]string{},
 		rules:          cfg.GroupRules,
 		bodyAliases:    map[string]bool{},
 	}
@@ -836,16 +838,9 @@ func (s *server) buildView(ctx context.Context, key string, lites []store.IssueL
 		return nil, err
 	}
 	byEmail := map[string]*member{}
-	for i := range lites {
-		l := &lites[i]
-		if l.StatusID != "" && l.StatusCategory != "" {
-			v.categories[l.StatusID] = l.StatusCategory
-		}
-		// Only assignees carry an email in the mirror, so only they can seed the
-		// directory: members are keyed by email on the client.
-		email := deref(l.AssigneeEmail)
+	addMember := func(email string, name *string, accountID *string) {
 		if email == "" {
-			continue
+			return
 		}
 		m := byEmail[email]
 		if m == nil {
@@ -853,11 +848,21 @@ func (s *server) buildView(ctx context.Context, key string, lites []store.IssueL
 			byEmail[email] = m
 		}
 		if m.Name == "" {
-			m.Name = deref(l.Assignee)
+			m.Name = deref(name)
 		}
 		if m.JiraAccountID == nil {
-			m.JiraAccountID = nilIfEmpty(deref(l.AssigneeID))
+			m.JiraAccountID = nilIfEmpty(deref(accountID))
 		}
+	}
+	for i := range lites {
+		l := &lites[i]
+		if l.StatusID != "" && l.StatusCategory != "" {
+			v.categories[l.StatusID] = l.StatusCategory
+		}
+		// The client directory remains keyed by email for contact/avatar metadata,
+		// but both issue people can seed it when Jira supplies one.
+		addMember(deref(l.AssigneeEmail), l.Assignee, l.AssigneeID)
+		addMember(deref(l.ReporterEmail), l.Reporter, l.ReporterID)
 	}
 	// Configuration wins: group, department, job role and avatar exist nowhere
 	// else.
@@ -886,6 +891,9 @@ func (s *server) buildView(ctx context.Context, key string, lites []store.IssueL
 		}
 		if cm.Group != "" {
 			v.groupByEmail[cm.Email] = cm.Group
+			if cm.JiraAccountID != "" {
+				v.groupByAccount[cm.JiraAccountID] = cm.Group
+			}
 			v.groupsEnabled = true
 		}
 	}
@@ -992,6 +1000,9 @@ func (v *derivedView) group(l store.IssueLite) *string {
 		if ruleMatches(r, l) {
 			return nilIfEmpty(r.Group)
 		}
+	}
+	if group := v.groupByAccount[deref(l.AssigneeID)]; group != "" {
+		return nilIfEmpty(group)
 	}
 	return nilIfEmpty(v.groupByEmail[deref(l.AssigneeEmail)])
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -324,7 +324,7 @@ func (s *server) handleMe(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{"email": nil})
 		return
 	}
-	name, dept := cfg.Email, ""
+	name, dept, accountID := cfg.Email, "", cfg.AccountID
 	for _, m := range cfg.Members {
 		if m.Email != cfg.Email {
 			continue
@@ -335,10 +335,14 @@ func (s *server) handleMe(w http.ResponseWriter, r *http.Request) {
 			name = m.Name
 		}
 		dept = m.Department
+		if accountID == "" {
+			accountID = m.JiraAccountID
+		}
 		break
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"email":      cfg.Email,
+		"account_id": nilIfEmpty(accountID),
 		"name":       name,
 		"department": nilIfEmpty(dept),
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -65,7 +65,7 @@ func fixtureAt(t *testing.T) (*store.DB, *config.Config, string) {
 					Status: "진행 중", StatusID: "3", StatusCategory: "inprogress",
 					Priority: "High", Assignee: "김현철", AssigneeID: "acc-hc",
 					AssigneeEmail: "hc@example.com",
-					Reporter:      "박보고", ReporterEmail: "rp@example.com",
+					Reporter:      "박보고", ReporterID: "acc-rp", ReporterEmail: "rp@example.com",
 					Labels: []string{"batch"}, Components: []string{"api"},
 					DescriptionADF: json.RawMessage(`{"type":"doc","version":1,"content":[]}`),
 					// Aliases from the configured field map; the response spreads them.
@@ -282,6 +282,9 @@ func TestBootstrapShapeAndETag(t *testing.T) {
 	}
 	if cl, ok := byEmail["cl@example.com"]; !ok || cl.Name != "이클라" || cl.Group != nil {
 		t.Fatalf("derived member wrong: %+v ok=%v", cl, ok)
+	}
+	if rp, ok := byEmail["rp@example.com"]; !ok || rp.Name != "박보고" || deref(rp.JiraAccountID) != "acc-rp" {
+		t.Fatalf("reporter member wrong: %+v ok=%v", rp, ok)
 	}
 
 	// 304 on the tag we just got, and on the client's own `"in-<version>"` form.
@@ -520,7 +523,7 @@ func TestAttachmentProxyStreamsFromJira(t *testing.T) {
 func TestMe(t *testing.T) {
 	db, cfg := fixture(t)
 	got := decode[map[string]any](t, get(t, New(db, cfg), authBase+"me/", nil))
-	if got["email"] != "hc@example.com" || got["name"] != "현철" {
+	if got["email"] != "hc@example.com" || got["account_id"] != "acc-hc" || got["name"] != "현철" {
 		t.Fatalf("me %+v", got)
 	}
 	// No credential: 200 with a null identity, not 401 — the UI probes this on
@@ -703,8 +706,8 @@ func TestIssueLiteFieldNames(t *testing.T) {
 	// contract (contracts/api.md, "IssueLite").
 	for _, field := range []string{
 		"issue_key", "summary", "project_key", "issue_type", "status", "status_id",
-		"status_category", "priority", "priority_rank", "assignee", "assignee_email",
-		"reporter", "reporter_email", "labels", "components", "fix_versions", "epic_key",
+		"status_category", "priority", "priority_rank", "assignee", "assignee_id", "assignee_email",
+		"reporter", "reporter_id", "reporter_email", "labels", "components", "fix_versions", "epic_key",
 		"created_at", "updated_at", "status_changed_at", "resolved_at", "reopen_count",
 		"comment_count", "team_group",
 	} {
@@ -726,6 +729,20 @@ func TestIssueLiteFieldNames(t *testing.T) {
 	// An issue with no aliases still carries the stored fields.
 	if _, ok := rows["NMA-9"]["issue_key"]; !ok {
 		t.Errorf("row without aliases lost its fields: %v", rows["NMA-9"])
+	}
+}
+
+func TestGroupFallbackUsesAssigneeAccountID(t *testing.T) {
+	v := derivedView{
+		groupsEnabled:  true,
+		groupByAccount: map[string]string{"acc-hidden": "platform"},
+		groupByEmail:   map[string]string{"visible@example.com": "legacy"},
+	}
+	if got := deref(v.group(store.IssueLite{AssigneeID: nilIfEmpty("acc-hidden")})); got != "platform" {
+		t.Fatalf("account-id group = %q", got)
+	}
+	if got := deref(v.group(store.IssueLite{AssigneeEmail: nilIfEmpty("visible@example.com")})); got != "legacy" {
+		t.Fatalf("email fallback group = %q", got)
 	}
 }
 

--- a/internal/store/read.go
+++ b/internal/store/read.go
@@ -27,6 +27,7 @@ type IssueLite struct {
 	AssigneeID     *string `json:"assignee_id"`
 	AssigneeEmail  *string `json:"assignee_email"`
 	Reporter       *string `json:"reporter"`
+	ReporterID     *string `json:"reporter_id"`
 	ReporterEmail  *string `json:"reporter_email"`
 	// EpicKey is the nearest hierarchy_level==1 ancestor (derived). Nil when
 	// none. Distinct from ParentKey, which is the direct parent only.
@@ -61,7 +62,7 @@ const issueLiteSelect = `
 	       COALESCE(i.issue_type, ''), COALESCE(i.issue_type_id, ''),
 	       COALESCE(i.status, ''), COALESCE(i.status_id, ''), COALESCE(i.status_category, ''),
 	       i.priority, i.priority_rank,
-	       i.assignee, i.assignee_id, i.assignee_email, i.reporter, i.reporter_email,
+	       i.assignee, i.assignee_id, i.assignee_email, i.reporter, i.reporter_id, i.reporter_email,
 	       i.epic_key, i.parent_key,
 	       COALESCE(i.labels, '[]'), COALESCE(i.components, '[]'), COALESCE(i.fix_versions, '[]'),
 	       i.duedate, i.resolution, i.created_at, i.updated_at,
@@ -96,7 +97,7 @@ func (db *DB) issueLites(ctx context.Context, query string, args ...any) ([]Issu
 		var reopenReason, clonedFrom string
 		if err := rows.Scan(&v.IssueKey, &v.Summary, &v.ProjectKey, &v.IssueType, &v.IssueTypeID,
 			&v.Status, &v.StatusID, &v.StatusCategory, &v.Priority, &v.PriorityRank,
-			&v.Assignee, &v.AssigneeID, &v.AssigneeEmail, &v.Reporter, &v.ReporterEmail,
+			&v.Assignee, &v.AssigneeID, &v.AssigneeEmail, &v.Reporter, &v.ReporterID, &v.ReporterEmail,
 			&v.EpicKey, &v.ParentKey,
 			&labels, &components, &fixVersions,
 			&v.Duedate, &v.Resolution, &v.CreatedAt, &v.UpdatedAt,

--- a/internal/store/write_test.go
+++ b/internal/store/write_test.go
@@ -151,6 +151,9 @@ func TestUpsertAndReadBack(t *testing.T) {
 	if one.ReporterEmail == nil || *one.ReporterEmail != "reporter.one@example.invalid" {
 		t.Errorf("reporter_email = %v", one.ReporterEmail)
 	}
+	if one.ReporterID == nil || *one.ReporterID != "acc-r1" {
+		t.Errorf("reporter_id = %v", one.ReporterID)
+	}
 	// Configured field aliases ride along so the server can spread them.
 	if one.Custom["severity"] != "S2" {
 		t.Errorf("custom = %v, want severity S2", one.Custom)

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -39,7 +39,7 @@ type listFilter struct {
 	statusCategories []string // exact match any; empty → use tab
 	text             string   // lowercased haystack substring
 	unassigned       bool
-	assigneeEmail    string // lowercased; match IssueLite.AssigneeEmail
+	assigneeEmail    string // legacy saved-view key; value may be email or account id
 }
 
 // row is one list entry with a pre-lowercased haystack for filter matching.
@@ -128,7 +128,8 @@ func applyListFilter(all []row, f listFilter) []int {
 		}
 		if f.assigneeEmail != "" {
 			email := strings.ToLower(deref(r.lite.AssigneeEmail))
-			if email == "" || email != f.assigneeEmail {
+			accountID := strings.ToLower(deref(r.lite.AssigneeID))
+			if email != f.assigneeEmail && accountID != f.assigneeEmail {
 				continue
 			}
 		}

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/midagedev/scry/internal/config"
 	"github.com/midagedev/scry/internal/store"
 )
 
@@ -35,11 +36,12 @@ func (t Tab) Label() string {
 // listFilter is the full local filter applied to the issue list.
 // statusCategories, when non-empty, overrides tab for category matching.
 type listFilter struct {
-	tab              Tab
-	statusCategories []string // exact match any; empty → use tab
-	text             string   // lowercased haystack substring
-	unassigned       bool
-	assigneeEmail    string // legacy saved-view key; value may be email or account id
+	tab               Tab
+	statusCategories  []string // exact match any; empty → use tab
+	text              string   // lowercased haystack substring
+	unassigned        bool
+	assigneeEmail     string // legacy saved-view key; value may be email or account id
+	assigneeAccountID string // configured resolution for a legacy email token
 }
 
 // row is one list entry with a pre-lowercased haystack for filter matching.
@@ -127,9 +129,12 @@ func applyListFilter(all []row, f listFilter) []int {
 			}
 		}
 		if f.assigneeEmail != "" {
-			email := strings.ToLower(deref(r.lite.AssigneeEmail))
-			accountID := strings.ToLower(deref(r.lite.AssigneeID))
-			if email != f.assigneeEmail && accountID != f.assigneeEmail {
+			email := deref(r.lite.AssigneeEmail)
+			accountID := deref(r.lite.AssigneeID)
+			emailMatches := email != "" && strings.EqualFold(email, f.assigneeEmail)
+			idMatches := accountID == f.assigneeEmail ||
+				(f.assigneeAccountID != "" && accountID == f.assigneeAccountID)
+			if !emailMatches && !idMatches {
 				continue
 			}
 		}
@@ -139,6 +144,18 @@ func applyListFilter(all []row, f listFilter) []int {
 		out = append(out, i)
 	}
 	return out
+}
+
+func configuredAssigneeAccountID(members []config.Member, value string) string {
+	if !strings.Contains(value, "@") {
+		return ""
+	}
+	for _, member := range members {
+		if strings.EqualFold(member.Email, value) {
+			return member.JiraAccountID
+		}
+	}
+	return ""
 }
 
 // listSort is the list display sort from a saved view (display.sort / display.dir).
@@ -257,8 +274,9 @@ func parseSavedViewConfig(name string, raw json.RawMessage) appliedView {
 				}
 			}
 			if len(emails) > 0 {
-				// TUI applies the first email only (AND of multiple is rare).
-				av.filter.assigneeEmail = strings.ToLower(strings.TrimSpace(emails[0]))
+				// TUI applies the first person value only (AND of multiple is rare).
+				// Preserve account-ID case; email comparison is case-insensitive later.
+				av.filter.assigneeEmail = strings.TrimSpace(emails[0])
 				if len(emails) > 1 {
 					av.unsupported = append(av.unsupported, "assignee_email[1+]")
 				}
@@ -271,7 +289,7 @@ func parseSavedViewConfig(name string, raw json.RawMessage) appliedView {
 				if strings.EqualFold(s, "me") {
 					av.unsupported = append(av.unsupported, "assignee=me")
 				} else if strings.Contains(s, "@") {
-					av.filter.assigneeEmail = strings.ToLower(strings.TrimSpace(s))
+					av.filter.assigneeEmail = strings.TrimSpace(s)
 				} else {
 					av.filter.text = strings.ToLower(strings.TrimSpace(s))
 				}

--- a/internal/tui/filter_test.go
+++ b/internal/tui/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/midagedev/scry/internal/config"
 	"github.com/midagedev/scry/internal/store"
 )
 
@@ -111,6 +112,19 @@ func TestApplyListFilterUnassignedAndEmail(t *testing.T) {
 	got = applyListFilter(all, listFilter{tab: TabAll, assigneeEmail: "acc-bob"})
 	if len(got) != 1 || all[got[0]].lite.IssueKey != "A-3" {
 		t.Fatalf("account id: %#v", got)
+	}
+	got = applyListFilter(all, listFilter{tab: TabAll, assigneeEmail: "ACC-BOB"})
+	if len(got) != 0 {
+		t.Fatalf("account IDs must compare exactly: %#v", got)
+	}
+	resolved := configuredAssigneeAccountID([]config.Member{{
+		Email: "Bob@Example.com", JiraAccountID: "acc-bob",
+	}}, "bob@example.com")
+	got = applyListFilter(all, listFilter{
+		tab: TabAll, assigneeEmail: "bob@example.com", assigneeAccountID: resolved,
+	})
+	if len(got) != 1 || all[got[0]].lite.IssueKey != "A-3" {
+		t.Fatalf("configured legacy email: %#v", got)
 	}
 }
 

--- a/internal/tui/filter_test.go
+++ b/internal/tui/filter_test.go
@@ -96,9 +96,9 @@ func TestBuildRowsPreLowercases(t *testing.T) {
 
 func TestApplyListFilterUnassignedAndEmail(t *testing.T) {
 	all := buildRows([]store.IssueLite{
-		{IssueKey: "A-1", Summary: "one", StatusCategory: "new", Assignee: strp("Ada"), AssigneeEmail: strp("ada@x.com")},
+		{IssueKey: "A-1", Summary: "one", StatusCategory: "new", Assignee: strp("Ada"), AssigneeID: strp("acc-ada"), AssigneeEmail: strp("ada@x.com")},
 		{IssueKey: "A-2", Summary: "two", StatusCategory: "new"},
-		{IssueKey: "A-3", Summary: "three", StatusCategory: "done", AssigneeEmail: strp("bob@x.com")},
+		{IssueKey: "A-3", Summary: "three", StatusCategory: "done", AssigneeID: strp("acc-bob")},
 	})
 	got := applyListFilter(all, listFilter{tab: TabAll, unassigned: true})
 	if len(got) != 1 || all[got[0]].lite.IssueKey != "A-2" {
@@ -107,6 +107,10 @@ func TestApplyListFilterUnassignedAndEmail(t *testing.T) {
 	got = applyListFilter(all, listFilter{tab: TabAll, assigneeEmail: "ada@x.com"})
 	if len(got) != 1 || all[got[0]].lite.IssueKey != "A-1" {
 		t.Fatalf("email: %#v", got)
+	}
+	got = applyListFilter(all, listFilter{tab: TabAll, assigneeEmail: "acc-bob"})
+	if len(got) != 1 || all[got[0]].lite.IssueKey != "A-3" {
+		t.Fatalf("account id: %#v", got)
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -777,6 +777,9 @@ func (m *Model) refilter() {
 	needle := strings.ToLower(strings.TrimSpace(m.filter))
 	f := m.extraFilter
 	f.tab = m.tab
+	if m.cfg != nil && f.assigneeEmail != "" {
+		f.assigneeAccountID = configuredAssigneeAccountID(m.cfg.Members, f.assigneeEmail)
+	}
 	// Free-text from / merges with any text baked into the saved view.
 	if needle != "" {
 		f.text = needle

--- a/specs/000-product/contracts/api.md
+++ b/specs/000-product/contracts/api.md
@@ -55,9 +55,10 @@ Request header: `If-None-Match: "sv-<version>"` (optional).
   the same clock that writes `items.synced_at`. That cursor bound is inclusive,
   so a poll in the same millisecond as a write legitimately re-sends the row.
 - `members` is keyed by email: the mirror supplies the name and account id of
-  everyone who appears as an assignee, and `config.members` supplies
-  `group`, `department`, `job_role` and the avatar, winning on every conflict. A
-  reporter who is never an assignee cannot be keyed and is absent. `avatar_url`
+  everyone who appears as an assignee or reporter with a visible email, and
+  `config.members` supplies `group`, `department`, `job_role` and the avatar,
+  winning on every conflict. A person whose email Jira hides can still appear
+  when configured explicitly. `avatar_url`
   and `profile_image` carry the same value — the client reads the latter.
 - `sync_health.status` is one of `healthy` / `stale` / `failed` / `missing`, and
   `message` is `"ok"` when nothing is wrong (the client suppresses that line).
@@ -167,7 +168,7 @@ renaming or removing is not.
 ```
 issue_key, summary, project_key, issue_type, issue_type_id, status, status_id,
 status_category, priority, priority_rank, assignee, assignee_id, assignee_email,
-reporter, reporter_email, epic_key, labels[], components[], fix_versions[],
+reporter, reporter_id, reporter_email, epic_key, labels[], components[], fix_versions[],
 duedate, resolution, created_at, updated_at, status_changed_at, resolved_at,
 reopen_count, reopened_at, comment_count
 ```
@@ -183,7 +184,9 @@ configuration:
 - every `fieldMap` alias present in `issues.custom`, spread as a top-level key
   (`severity`, `solution`, `environment`, …). Aliases are serialized before the
   stored fields, so a stored field of the same name wins in the client's
-  `JSON.parse`.
+  `JSON.parse`. A user-role alias also carries `<alias>_account_ids` as an array
+  of stable Jira account IDs; the alias itself remains the display string (or
+  string array) so existing detail rendering and saved views remain readable.
 
 A third group comes from plugin enrichments: `deploy_status` from kind `deploy`,
 and `qa_impact_state` / `qa_impact_label` / `qa_runs` / `qa_suites` from kind
@@ -522,13 +525,13 @@ cannot bring the filter back.
 scry is a single-user local tool. There are no scry accounts and no session
 tokens. **Identity is the stored Jira credential** (`site` / email / API token in
 `~/.scry/config.json`, managed via `credential/`). `GET me/` projects that
-credential into `{email, name, department}` for the UI; when nothing is
+credential into `{email, account_id, name, department}` for the UI; when nothing is
 configured it answers `200 {"email": null}` so the boot probe never 4xxes.
 Writes that need Jira call out with that same credential. The UI has no login
 dialog — if identity is missing it opens the credential settings dialog instead.
 
 | Endpoint | Method | v0.1 behavior |
 | --- | --- | --- |
-| `me/` | GET | `{email, name, department}` from the stored credential and the configured member directory, with no call to Jira. `200 {"email": null}` when nothing is configured |
+| `me/` | GET | `{email, account_id, name, department}` from the stored credential and the configured member directory, with no call to Jira. `account_id` is null for credentials verified by an older build; `200 {"email": null}` when nothing is configured |
 | `login/` | POST | `404`. There are no scry accounts; use `PUT credential/` |
 | `logout/` | POST | `404`. Clear credentials with `DELETE credential/` instead |

--- a/specs/000-product/contracts/api.md
+++ b/specs/000-product/contracts/api.md
@@ -165,6 +165,11 @@ The row shape used by `bootstrap`, `delta`, and every write response. Stored
 verbatim in IndexedDB, so **field names are a contract** — adding is safe,
 renaming or removing is not.
 
+Browser cache schema v2 clears v1 `issues` rows and the `sync` cursor once so
+the additive `reporter_id` projection reaches unchanged issues through a full
+bootstrap. The independent `write` metadata record is preserved, and v2 caches
+are reused without another invalidation.
+
 ```
 issue_key, summary, project_key, issue_type, issue_type_id, status, status_id,
 status_category, priority, priority_rank, assignee, assignee_id, assignee_email,
@@ -184,9 +189,7 @@ configuration:
 - every `fieldMap` alias present in `issues.custom`, spread as a top-level key
   (`severity`, `solution`, `environment`, …). Aliases are serialized before the
   stored fields, so a stored field of the same name wins in the client's
-  `JSON.parse`. A user-role alias also carries `<alias>_account_ids` as an array
-  of stable Jira account IDs; the alias itself remains the display string (or
-  string array) so existing detail rendering and saved views remain readable.
+  `JSON.parse`.
 
 A third group comes from plugin enrichments: `deploy_status` from kind `deploy`,
 and `qa_impact_state` / `qa_impact_label` / `qa_runs` / `qa_suites` from kind

--- a/web/src/components/detail/PersonPanel.svelte
+++ b/web/src/components/detail/PersonPanel.svelte
@@ -22,10 +22,10 @@
   import { issues } from '../../stores/issues.svelte'
   import { pages } from '../../stores/pages.svelte'
   import { selection } from '../../stores/selection.svelte'
-  import { filters } from '../../stores/filters.svelte'
+  import { filters, issueMatchesPerson } from '../../stores/filters.svelte'
   import { me } from '../../stores/me.svelte'
   import { emptyConfig, type ViewConfig } from '../../lib/view-config'
-  import type { AuthorComment } from '../../lib/types'
+  import type { AuthorComment, IssueLite } from '../../lib/types'
   import { onEscape } from '../../lib/dom-actions'
   // The list's Avatar, not detail/'s: the panel owner must wear the same
   // name-derived color the rows repeat, or the identity link breaks.
@@ -35,15 +35,22 @@
 
   const email = $derived(person.selectedEmail)
   const member = $derived(person.member)
+  const identity = $derived(member?.jira_account_id ?? email)
+  const matches = (issue: IssueLite, role: 'assignee' | 'reporter') =>
+    issueMatchesPerson(issue, role, member?.jira_account_id) || issueMatchesPerson(issue, role, email)
   // What this person is called on screen. Falls back to the email so a member
   // the directory has lost still gets a header rather than a blank one.
   const name = $derived(member?.display_name || member?.name || email || '')
 
   const assignedCount = $derived(
-    email ? issues.allIssues.reduce((n, i) => (i.assignee_email === email ? n + 1 : n), 0) : 0,
+    identity
+      ? issues.allIssues.reduce((n, i) => (matches(i, 'assignee') ? n + 1 : n), 0)
+      : 0,
   )
   const reportedCount = $derived(
-    email ? issues.allIssues.reduce((n, i) => (i.reporter_email === email ? n + 1 : n), 0) : 0,
+    identity
+      ? issues.allIssues.reduce((n, i) => (matches(i, 'reporter') ? n + 1 : n), 0)
+      : 0,
   )
   // Pages are grouped by author name, not by account id, so this is the count
   // the By-author tab will actually show. Zero hides the link: sending someone
@@ -59,16 +66,16 @@
   }
 
   function openAssigned(): void {
-    if (!email) return
+    if (!identity) return
     const c = emptyConfig()
-    c.filters.assignee_email = [email]
+    c.filters.assignee_email = [identity]
     applyView(c)
   }
 
   function openReported(): void {
-    if (!email) return
+    if (!identity) return
     const c = emptyConfig()
-    c.filters.reporter_email = [email]
+    c.filters.reporter_email = [identity]
     applyView(c)
   }
 

--- a/web/src/components/detail/QaFieldEditor.svelte
+++ b/web/src/components/detail/QaFieldEditor.svelte
@@ -143,7 +143,9 @@
   }
 
   const meMember = $derived(me.identified && me.email ? issues.members.get(me.email) : undefined)
-  const reporterMember = $derived(issues.memberOf(issue.reporter_email))
+  const reporterMember = $derived(
+    issues.memberOfAccountId(issue.reporter_id) ?? issues.memberOf(issue.reporter_email),
+  )
 
   /** Local members (personalized) — me → reporter → name. Only with jira_account_id. */
   const localCands = $derived.by<Cand[]>(() => {
@@ -195,10 +197,10 @@
 
   async function pickUser(c: Cand | null) {
     busy = true
-    const ok = await write.setField(key, 'development_test_assignee', c ? c.account_id : null, {
-      development_test_assignee: c ? c.display_name : null,
-      development_test_assignee_email: c ? c.email : null,
-    })
+    const ok = await write.setField(key, field, c ? c.account_id : null, {
+      [field]: c ? c.display_name : null,
+      [`${field}_account_ids`]: c ? [c.account_id] : [],
+    } as Partial<IssueLite>)
     busy = false
     if (ok) open = false
   }
@@ -361,7 +363,9 @@
           <button
             type="button"
             role="option"
-            aria-selected={c.email != null && c.email === issue.development_test_assignee_email}
+            aria-selected={((issue as unknown as Record<string, unknown>)[`${field}_account_ids`] as
+              | string[]
+              | undefined)?.includes(c.account_id) ?? false}
             onclick={() => pickUser(c)}
             disabled={busy}
             class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus:bg-bg-hover focus:outline-none disabled:opacity-50"

--- a/web/src/components/detail/QaFieldEditor.svelte
+++ b/web/src/components/detail/QaFieldEditor.svelte
@@ -197,10 +197,10 @@
 
   async function pickUser(c: Cand | null) {
     busy = true
-    const ok = await write.setField(key, field, c ? c.account_id : null, {
-      [field]: c ? c.display_name : null,
-      [`${field}_account_ids`]: c ? [c.account_id] : [],
-    } as Partial<IssueLite>)
+    const ok = await write.setField(key, 'development_test_assignee', c ? c.account_id : null, {
+      development_test_assignee: c ? c.display_name : null,
+      development_test_assignee_email: c ? c.email : null,
+    })
     busy = false
     if (ok) open = false
   }
@@ -363,9 +363,7 @@
           <button
             type="button"
             role="option"
-            aria-selected={((issue as unknown as Record<string, unknown>)[`${field}_account_ids`] as
-              | string[]
-              | undefined)?.includes(c.account_id) ?? false}
+            aria-selected={c.email != null && c.email === issue.development_test_assignee_email}
             onclick={() => pickUser(c)}
             disabled={busy}
             class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[12px] text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary focus:bg-bg-hover focus:outline-none disabled:opacity-50"

--- a/web/src/components/list/IssueRow.svelte
+++ b/web/src/components/list/IssueRow.svelte
@@ -374,8 +374,8 @@
       type="button"
       class="hidden max-w-[90px] flex-none truncate rounded px-1.5 py-0.5 text-micro text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-secondary md:inline-flex"
       title={t('list.fieldValue', { field: t('common.reporter'), value: issue.reporter })}
-      onclick={issue.reporter_email
-        ? stop(() => filters.addValue('reporter_email', issue.reporter_email!))
+      onclick={issue.reporter_id || issue.reporter_email
+        ? stop(() => filters.addValue('reporter_email', issue.reporter_id ?? issue.reporter_email!))
         : undefined}
     >
       {issue.reporter}
@@ -483,8 +483,8 @@
     <Avatar
       email={issue.assignee_email}
       name={issue.assignee}
-      onclick={issue.assignee_email
-        ? stop(() => filters.addValue('assignee_email', issue.assignee_email!))
+      onclick={issue.assignee_id || issue.assignee_email
+        ? stop(() => filters.addValue('assignee_email', issue.assignee_id ?? issue.assignee_email!))
         : undefined}
     />
   {/if}

--- a/web/src/components/palette/CommandPalette.svelte
+++ b/web/src/components/palette/CommandPalette.svelte
@@ -169,6 +169,7 @@
       chosungQuery,
       now: Date.now(),
       myEmail: me.email,
+      myAccountId: me.accountId,
       recentKeys: new Set(me.recentIssues.map((v) => v.key)),
     }
     return sortIssues(filterIssues(issues.allIssues, f), 'relevance', 'desc', ctx)

--- a/web/src/components/personal/MyIssuesNav.svelte
+++ b/web/src/components/personal/MyIssuesNav.svelte
@@ -3,38 +3,40 @@
    * My Issues sidebar section ([personal]).
    *  Rows: assigned to me N / reported by me N / mentioned me (feed) N.
    *   - Assigned: filters.applyConfig(assignee + active statuses) → main list.
-   *   - Reported: reporter isn't in explore filter schema (assignee_email only) —
-   *     open personal feed on the "reported" focus tab (feed computes reporter).
+   *   - Reported: open personal feed on the "reported" focus tab.
    *   - Mentions/feed: open personal feed (all focus).
    *  Counts are $derived from the local pool (mentions = API result count).
    *  Without identity: prompt to set credentials.
    */
   import { t } from '../../lib/i18n'
-  import { filters } from '../../stores/filters.svelte'
+  import { filters, issueMatchesPerson } from '../../stores/filters.svelte'
   import { issues } from '../../stores/issues.svelte'
   import { me } from '../../stores/me.svelte'
   import { write } from '../../stores/write.svelte'
   import { effectiveCategory, emptyConfig, type ViewConfig } from '../../lib/view-config'
   import { feature } from '../../lib/config'
   import { isHostedDemo } from '../../lib/config'
+  import type { IssueLite } from '../../lib/types'
   import Icon from '../ui/Icon.svelte'
 
-  const myEmail = $derived(me.email)
+  const myIdentity = $derived(me.accountId ?? me.email)
+  const isMe = (issue: IssueLite, role: 'assignee' | 'reporter') =>
+    issueMatchesPerson(issue, role, me.accountId) || issueMatchesPerson(issue, role, me.email)
   // Without feed, hide "reported by me" / "feed" — no panel to open.
   const feedOn = feature('feed')
 
   // Counts use active (non-done) issues.
   const assignedCount = $derived(
-    myEmail
+    myIdentity
       ? issues.allIssues.filter(
-          (i) => i.assignee_email === myEmail && effectiveCategory(i) !== 'done',
+          (i) => isMe(i, 'assignee') && effectiveCategory(i) !== 'done',
         ).length
       : 0,
   )
   const reportedCount = $derived(
-    myEmail
+    myIdentity
       ? issues.allIssues.filter(
-          (i) => i.reporter_email === myEmail && effectiveCategory(i) !== 'done',
+          (i) => isMe(i, 'reporter') && effectiveCategory(i) !== 'done',
         ).length
       : 0,
   )
@@ -42,7 +44,7 @@
 
   function assigneeConfig(): ViewConfig {
     const c = emptyConfig()
-    c.filters.assignee_email = [myEmail!]
+    c.filters.assignee_email = [myIdentity!]
     c.filters.status_category = ['new', 'inprogress']
     return c
   }

--- a/web/src/components/write/AssigneePicker.svelte
+++ b/web/src/components/write/AssigneePicker.svelte
@@ -53,7 +53,7 @@
   const serverUsers = $derived(userSearch.results)
   let inputEl: HTMLInputElement | null = $state(null)
 
-  const hasAssignee = $derived(Boolean(issue.assignee || issue.assignee_email))
+  const hasAssignee = $derived(Boolean(issue.assignee_id || issue.assignee || issue.assignee_email))
 
   function candOf(m: Member, label?: string): Cand {
     return {
@@ -97,7 +97,9 @@
       return r
     }
     const g1 = take([meMember], t('write.assignToMe'))
-    const g2 = take([issue.reporter_email ? issues.members.get(issue.reporter_email) : undefined])
+    const g2 = take([
+      issues.memberOfAccountId(issue.reporter_id) ?? issues.memberOf(issue.reporter_email),
+    ])
     const g3 = take(recentOf('assignee').map((acc) => memberByAccount.get(acc)))
     const g4 = take(
       assignableMembers.filter((m) => issue.team_group && m.group === issue.team_group).sort(byName),

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -16,7 +16,10 @@ import type { CacheMeta, IssueLite, WriteMetaCache } from './types'
 // Workspace mounts get their own database: two mirrors on one origin would
 // otherwise overwrite each other's cached issue pool.
 const DB_NAME = workspaceName() ? `issue-navigator:ws:${workspaceName()}` : 'issue-navigator'
-const DB_VERSION = 1
+// v2 invalidates IssueLite rows written before reporter_id joined the row
+// contract. SQLite already has the IDs, so one fresh bootstrap is sufficient;
+// write metadata is independent and remains warm.
+const DB_VERSION = 2
 
 interface IssueDB extends DBSchema {
   issues: {
@@ -42,12 +45,20 @@ let dbPromise: Promise<IDBPDatabase<IssueDB>> | null = null
 function db(): Promise<IDBPDatabase<IssueDB>> {
   if (!dbPromise) {
     const opening = openDB<IssueDB>(DB_NAME, DB_VERSION, {
-      upgrade(database) {
+      upgrade(database, oldVersion, _newVersion, transaction) {
         if (!database.objectStoreNames.contains('issues')) {
           database.createObjectStore('issues', { keyPath: 'issue_key' })
         }
         if (!database.objectStoreNames.contains('meta')) {
           database.createObjectStore('meta', { keyPath: 'key' })
+        }
+        // Existing v1 rows may not carry reporter_id. Clear only that legacy
+        // issue snapshot and its sync cursor: keeping the cursor could make an
+        // empty cache send If-None-Match and accept a 304. Fresh v2 databases
+        // and every later v2 reopen skip this branch entirely.
+        if (oldVersion > 0 && oldVersion < 2) {
+          void transaction.objectStore('issues').clear()
+          void transaction.objectStore('meta').delete('sync')
         }
       },
       // Yield the connection when another tab wants a higher-version upgrade (or delete).

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,8 +58,12 @@ export interface IssueLite {
   severity: string | null
 
   assignee: string | null
+  /** Stable Jira accountId. Older cached rows may omit it. */
+  assignee_id?: string | null
   assignee_email: string | null
   reporter: string | null
+  /** Stable Jira accountId. Older servers/cached rows may omit it. */
+  reporter_id?: string | null
   reporter_email: string | null
 
   labels: string[]

--- a/web/src/lib/view-config.ts
+++ b/web/src/lib/view-config.ts
@@ -22,7 +22,9 @@ import type { DeployState, IssueLite } from './types'
 export interface ViewFilters {
   status_category: string[] // new | inprogress | done (effective buckets)
   status: string[] // Raw Jira status strings
+  /** Compatibility name: values are Jira account IDs when available, legacy emails otherwise. */
   assignee_email: string[]
+  /** Compatibility name: values are Jira account IDs when available, legacy emails otherwise. */
   reporter_email: string[]
   team_group: string[]
   labels: string[]

--- a/web/src/stores/filters.svelte.ts
+++ b/web/src/stores/filters.svelte.ts
@@ -16,7 +16,7 @@ import { router, setParams } from '../lib/router.svelte'
 import { issues } from './issues.svelte'
 import { me } from './me.svelte'
 import { extractChosung, isChosungQuery } from '../lib/korean'
-import type { IssueLite, SearchMatch } from '../lib/types'
+import type { IssueLite, Member, SearchMatch } from '../lib/types'
 import {
   configToParams,
   defaultColumns,
@@ -200,10 +200,17 @@ class FiltersStore {
     const axes = this.dynamicAxes
     if (!axes.length) return {}
     const counters: Record<string, Map<string, number>> = {}
-    for (const a of axes) counters[a.key] = new Map()
+    const labels: Record<string, Map<string, string>> = {}
+    for (const a of axes) {
+      counters[a.key] = new Map()
+      labels[a.key] = new Map()
+    }
     for (const it of issues.allIssues) {
       for (const a of axes) {
-        for (const value of rowFieldValues(it, a.key)) bump(counters[a.key], value)
+        for (const entry of rowFieldEntries(it, a.key)) {
+          bump(counters[a.key], entry.value)
+          if (!labels[a.key].has(entry.value)) labels[a.key].set(entry.value, entry.label)
+        }
       }
     }
     const out: Record<string, FacetValue[]> = {}
@@ -211,7 +218,7 @@ class FiltersStore {
       const values: FacetValue[] = [...counters[a.key].entries()].map(([value, count]) => ({
         value,
         count,
-        label: value,
+        label: labels[a.key].get(value) ?? value,
       }))
       values.sort((x, y) => y.count - x.count || (x.label < y.label ? -1 : 1))
       out[a.key] = values
@@ -232,25 +239,23 @@ class FiltersStore {
   hasFilters = $derived(hasAnyFilter(this.#config.filters))
 
   /**
-   * Whether the current view is already scoped to "my issues" (my email in
+   * Whether the current view is already scoped to "my issues" (my account ID or email in
    *  assignee or reporter filters). Whole list is then mine, so per-row highlight
    *  is noise — turn it off.
    */
   scopedToMe = $derived.by(() => {
-    const e = me.email?.toLowerCase()
-    if (!e) return false
+    const mine = [me.accountId, me.email].filter((v): v is string => !!v)
+    if (!mine.length) return false
     const f = this.#config.filters
-    const has = (arr: string[]) => arr.some((x) => x.toLowerCase() === e)
+    const has = (arr: string[]) => arr.some((x) => mine.some((v) => sameIdentity(x, v)))
     return has(f.assignee_email) || has(f.reporter_email)
   })
 
-  /** Whether this issue is assigned to me (highlight check). Case-insensitive. */
+  /** Whether this issue is assigned to me (account ID first, email compatibility fallback). */
   isMine(issue: IssueLite): boolean {
-    const e = me.email
     return (
-      !!e &&
-      !!issue.assignee_email &&
-      issue.assignee_email.toLowerCase() === e.toLowerCase()
+      issueMatchesPerson(issue, 'assignee', me.accountId) ||
+      issueMatchesPerson(issue, 'assignee', me.email)
     )
   }
 
@@ -527,12 +532,34 @@ export function rowFieldValues(issue: IssueLite, alias: string): string[] {
   return []
 }
 
+const USER_ACCOUNT_IDS_SUFFIX = '_account_ids'
+
+interface FieldEntry {
+  value: string
+  label: string
+}
+
+/** Stable filter values for a custom user field, with display values as labels. */
+function rowFieldEntries(issue: IssueLite, alias: string): FieldEntry[] {
+  const labels = rowFieldValues(issue, alias)
+  const ids = rowFieldValues(issue, alias + USER_ACCOUNT_IDS_SUFFIX)
+  if (!ids.length) return labels.map((value) => ({ value, label: value }))
+  return ids.map((value, i) => ({ value, label: labels[i] ?? value }))
+}
+
+function rowFieldFilterValues(issue: IssueLite, alias: string): string[] {
+  const entries = rowFieldEntries(issue, alias)
+  const values = entries.map((entry) => entry.value)
+  for (const label of rowFieldValues(issue, alias)) if (!values.includes(label)) values.push(label)
+  return values
+}
+
 /** AND across dynamic axes, OR within one — same semantics as the static fields. */
 function matchesDynamicFields(fields: Record<string, string[]>, it: IssueLite): boolean {
   for (const alias in fields) {
     const selected = fields[alias]
     if (!selected.length) continue
-    if (!matchesSelected(selected, rowFieldValues(it, alias))) return false
+    if (!matchesSelected(selected, rowFieldFilterValues(it, alias))) return false
   }
   return true
 }
@@ -591,9 +618,9 @@ export function filterIssues(all: IssueLite[], f: ViewFilters): IssueLite[] {
   for (const it of all) {
     if (f.status_category.length && !f.status_category.includes(effectiveCategory(it))) continue
     if (f.status.length && !f.status.includes(it.status)) continue
-    if (f.assignee_email.length && !(it.assignee_email && f.assignee_email.includes(it.assignee_email)))
+    if (f.assignee_email.length && !f.assignee_email.some((v) => issueMatchesPerson(it, 'assignee', v)))
       continue
-    if (f.reporter_email.length && !(it.reporter_email && f.reporter_email.includes(it.reporter_email)))
+    if (f.reporter_email.length && !f.reporter_email.some((v) => issueMatchesPerson(it, 'reporter', v)))
       continue
     if (f.team_group.length && !(it.team_group && f.team_group.includes(it.team_group))) continue
     if (f.priority.length && !(it.priority && f.priority.includes(it.priority))) continue
@@ -624,7 +651,7 @@ export function filterIssues(all: IssueLite[], f: ViewFilters): IssueLite[] {
     if (f.labels.length && !it.labels.some((l) => f.labels.includes(l))) continue
 
     if (f.reopened && !(it.reopen_count > 0)) continue
-    if (f.unassigned && it.assignee_email) continue
+    if (f.unassigned && hasIssuePerson(it, 'assignee')) continue
     if (f.stale && !isStale(it)) continue
 
     if ((f.created_from || f.created_to) && !inRange(it.created_at, f.created_from, f.created_to))
@@ -653,6 +680,7 @@ export interface RelevanceContext {
   chosungQuery: boolean
   now: number
   myEmail: string | null
+  myAccountId: string | null
   recentKeys: Set<string>
 }
 
@@ -664,6 +692,7 @@ function buildRelevanceContext(rawQuery: string): RelevanceContext {
     chosungQuery: raw ? isChosungQuery(raw) : false,
     now: Date.now(),
     myEmail: me.email,
+    myAccountId: me.accountId,
     recentKeys: new Set(me.recentIssues.map((v) => v.key)),
   }
 }
@@ -707,7 +736,11 @@ function relevanceScore(issue: IssueLite, ctx: RelevanceContext): number {
   }
 
   // Personalization: assigned to me / recently viewed.
-  if (ctx.myEmail && issue.assignee_email === ctx.myEmail) score += 40
+  if (
+    issueMatchesPerson(issue, 'assignee', ctx.myAccountId) ||
+    issueMatchesPerson(issue, 'assignee', ctx.myEmail)
+  )
+    score += 40
   if (ctx.recentKeys.has(issue.issue_key)) score += 25
 
   return score
@@ -773,8 +806,11 @@ function groupKeyOf(
     case 'status':
       return { key: issue.status || '(none)', label: issue.status || t('group.noStatus') }
     case 'assignee':
-      return issue.assignee_email
-        ? { key: issue.assignee_email, label: issue.assignee || issue.assignee_email }
+      return personIdentity(issue, 'assignee')
+        ? {
+            key: personIdentity(issue, 'assignee')!,
+            label: issue.assignee || issue.assignee_email || personIdentity(issue, 'assignee')!,
+          }
         : { key: '', label: t('common.unassigned') }
     case 'priority':
       return { key: issue.priority || '', label: issue.priority || t('group.noPriority') }
@@ -921,7 +957,7 @@ function CATEGORY_LABEL(value: string): string {
 
 function buildChips(
   f: ViewFilters,
-  members: Map<string, { name: string }>,
+  members: Map<string, Member>,
   all: IssueLite[],
   fieldLabels: Map<string, string>,
 ): ActiveChip[] {
@@ -931,7 +967,7 @@ function buildChips(
       let label = value
       if (field === 'status_category') label = CATEGORY_LABEL(value)
       else if (field === 'assignee_email' || field === 'reporter_email')
-        label = members.get(value)?.name ?? value
+        label = facetLabel(field, value, all, members)
       else if (
         field === 'qa_run' ||
         field === 'qa_suite' ||
@@ -945,7 +981,8 @@ function buildChips(
   for (const [alias, values] of Object.entries(f.fields)) {
     const name = fieldLabels.get(alias) ?? FIELD_LABEL(alias)
     for (const value of values) {
-      chips.push({ kind: 'field', field: alias, value, label: t('filter.chipFieldValue', { field: name, value }) })
+      const display = dynamicFieldLabel(alias, value, all)
+      chips.push({ kind: 'field', field: alias, value, label: t('filter.chipFieldValue', { field: name, value: display }) })
     }
   }
   if (f.reopened) chips.push({ kind: 'flag', field: 'reopened', label: t('filter.flagReopened') })
@@ -962,7 +999,7 @@ function buildChips(
 
 function buildFacets(
   all: IssueLite[],
-  members: Map<string, { name: string }>,
+  members: Map<string, Member>,
 ): Record<MultiField, FacetValue[]> {
   const counters: Record<string, Map<string, number>> = {}
   for (const field of MULTI_FIELDS) counters[field] = new Map()
@@ -970,8 +1007,8 @@ function buildFacets(
   for (const it of all) {
     bump(counters.status_category, effectiveCategory(it))
     bump(counters.status, it.status)
-    if (it.assignee_email) bump(counters.assignee_email, it.assignee_email)
-    if (it.reporter_email) bump(counters.reporter_email, it.reporter_email)
+    bump(counters.assignee_email, personIdentity(it, 'assignee'))
+    bump(counters.reporter_email, personIdentity(it, 'reporter'))
     if (it.team_group) bump(counters.team_group, it.team_group)
     if (it.priority) bump(counters.priority, it.priority)
     if (it.severity) bump(counters.severity, it.severity)
@@ -1008,11 +1045,22 @@ function facetLabel(
   field: MultiField,
   value: string,
   all: IssueLite[],
-  members: Map<string, { name: string }>,
+  members: Map<string, Member>,
 ): string {
   if (field === 'status_category') return CATEGORY_LABEL(value)
-  if (field === 'assignee_email' || field === 'reporter_email')
-    return members.get(value)?.name ?? value
+  if (field === 'assignee_email' || field === 'reporter_email') {
+    const role = field === 'assignee_email' ? 'assignee' : 'reporter'
+    for (const issue of all) {
+      if (!issueMatchesPerson(issue, role, value)) continue
+      return issue[role] || issue[`${role}_email`] || value
+    }
+    const direct = members.get(value)
+    if (direct) return direct.name
+    for (const member of members.values()) {
+      if (member.jira_account_id === value) return member.name
+    }
+    return value
+  }
   if (field === 'qa_impact') {
     const labels: Record<string, string> = {
       blocking: t('filter.qaBlocking'),
@@ -1036,6 +1084,44 @@ function facetLabel(
       const found = (issue.qa_suites ?? []).find((suite) => suite.key === value)
       if (found) return found.path || found.label
     }
+  }
+  return value
+}
+
+type PersonRole = 'assignee' | 'reporter'
+
+export function personIdentity(issue: IssueLite, role: PersonRole): string | null {
+  return issue[`${role}_id`] ?? issue[`${role}_email`] ?? null
+}
+
+function sameIdentity(a: string, b: string): boolean {
+  return a === b || (a.includes('@') && b.includes('@') && a.toLowerCase() === b.toLowerCase())
+}
+
+export function issueMatchesPerson(
+  issue: IssueLite,
+  role: PersonRole,
+  value: string | null | undefined,
+): boolean {
+  if (!value) return false
+  const id = issue[`${role}_id`]
+  const email = issue[`${role}_email`]
+  if ((id && sameIdentity(id, value)) || (email && sameIdentity(email, value))) return true
+  // Saved views created before the ID migration carry email values. When Jira
+  // later hides that email on issue rows, the configured member directory can
+  // still resolve the legacy token to the stable account ID without a network call.
+  const configuredID = issues.memberOf(value)?.jira_account_id
+  return Boolean(id && configuredID && sameIdentity(id, configuredID))
+}
+
+function hasIssuePerson(issue: IssueLite, role: PersonRole): boolean {
+  return Boolean(issue[`${role}_id`] || issue[role] || issue[`${role}_email`])
+}
+
+function dynamicFieldLabel(alias: string, value: string, all: IssueLite[]): string {
+  for (const issue of all) {
+    const found = rowFieldEntries(issue, alias).find((entry) => entry.value === value)
+    if (found) return found.label
   }
   return value
 }

--- a/web/src/stores/filters.svelte.ts
+++ b/web/src/stores/filters.svelte.ts
@@ -200,17 +200,10 @@ class FiltersStore {
     const axes = this.dynamicAxes
     if (!axes.length) return {}
     const counters: Record<string, Map<string, number>> = {}
-    const labels: Record<string, Map<string, string>> = {}
-    for (const a of axes) {
-      counters[a.key] = new Map()
-      labels[a.key] = new Map()
-    }
+    for (const a of axes) counters[a.key] = new Map()
     for (const it of issues.allIssues) {
       for (const a of axes) {
-        for (const entry of rowFieldEntries(it, a.key)) {
-          bump(counters[a.key], entry.value)
-          if (!labels[a.key].has(entry.value)) labels[a.key].set(entry.value, entry.label)
-        }
+        for (const value of rowFieldValues(it, a.key)) bump(counters[a.key], value)
       }
     }
     const out: Record<string, FacetValue[]> = {}
@@ -218,7 +211,7 @@ class FiltersStore {
       const values: FacetValue[] = [...counters[a.key].entries()].map(([value, count]) => ({
         value,
         count,
-        label: labels[a.key].get(value) ?? value,
+        label: value,
       }))
       values.sort((x, y) => y.count - x.count || (x.label < y.label ? -1 : 1))
       out[a.key] = values
@@ -532,34 +525,12 @@ export function rowFieldValues(issue: IssueLite, alias: string): string[] {
   return []
 }
 
-const USER_ACCOUNT_IDS_SUFFIX = '_account_ids'
-
-interface FieldEntry {
-  value: string
-  label: string
-}
-
-/** Stable filter values for a custom user field, with display values as labels. */
-function rowFieldEntries(issue: IssueLite, alias: string): FieldEntry[] {
-  const labels = rowFieldValues(issue, alias)
-  const ids = rowFieldValues(issue, alias + USER_ACCOUNT_IDS_SUFFIX)
-  if (!ids.length) return labels.map((value) => ({ value, label: value }))
-  return ids.map((value, i) => ({ value, label: labels[i] ?? value }))
-}
-
-function rowFieldFilterValues(issue: IssueLite, alias: string): string[] {
-  const entries = rowFieldEntries(issue, alias)
-  const values = entries.map((entry) => entry.value)
-  for (const label of rowFieldValues(issue, alias)) if (!values.includes(label)) values.push(label)
-  return values
-}
-
 /** AND across dynamic axes, OR within one — same semantics as the static fields. */
 function matchesDynamicFields(fields: Record<string, string[]>, it: IssueLite): boolean {
   for (const alias in fields) {
     const selected = fields[alias]
     if (!selected.length) continue
-    if (!matchesSelected(selected, rowFieldFilterValues(it, alias))) return false
+    if (!matchesSelected(selected, rowFieldValues(it, alias))) return false
   }
   return true
 }
@@ -981,8 +952,7 @@ function buildChips(
   for (const [alias, values] of Object.entries(f.fields)) {
     const name = fieldLabels.get(alias) ?? FIELD_LABEL(alias)
     for (const value of values) {
-      const display = dynamicFieldLabel(alias, value, all)
-      chips.push({ kind: 'field', field: alias, value, label: t('filter.chipFieldValue', { field: name, value: display }) })
+      chips.push({ kind: 'field', field: alias, value, label: t('filter.chipFieldValue', { field: name, value }) })
     }
   }
   if (f.reopened) chips.push({ kind: 'flag', field: 'reopened', label: t('filter.flagReopened') })
@@ -1003,12 +973,20 @@ function buildFacets(
 ): Record<MultiField, FacetValue[]> {
   const counters: Record<string, Map<string, number>> = {}
   for (const field of MULTI_FIELDS) counters[field] = new Map()
+  const assigneeLabels = new Map<string, string>()
+  const reporterLabels = new Map<string, string>()
 
   for (const it of all) {
     bump(counters.status_category, effectiveCategory(it))
     bump(counters.status, it.status)
-    bump(counters.assignee_email, personIdentity(it, 'assignee'))
-    bump(counters.reporter_email, personIdentity(it, 'reporter'))
+    const assignee = personIdentity(it, 'assignee')
+    const reporter = personIdentity(it, 'reporter')
+    bump(counters.assignee_email, assignee)
+    bump(counters.reporter_email, reporter)
+    if (assignee && !assigneeLabels.has(assignee))
+      assigneeLabels.set(assignee, it.assignee || it.assignee_email || assignee)
+    if (reporter && !reporterLabels.has(reporter))
+      reporterLabels.set(reporter, it.reporter || it.reporter_email || reporter)
     if (it.team_group) bump(counters.team_group, it.team_group)
     if (it.priority) bump(counters.priority, it.priority)
     if (it.severity) bump(counters.severity, it.severity)
@@ -1030,11 +1008,15 @@ function buildFacets(
 
   const out = {} as Record<MultiField, FacetValue[]>
   for (const field of MULTI_FIELDS) {
-    const values: FacetValue[] = [...counters[field].entries()].map(([value, count]) => ({
-      value,
-      count,
-      label: facetLabel(field, value, all, members),
-    }))
+    const values: FacetValue[] = [...counters[field].entries()].map(([value, count]) => {
+      const personLabel =
+        field === 'assignee_email'
+          ? assigneeLabels.get(value)
+          : field === 'reporter_email'
+            ? reporterLabels.get(value)
+            : undefined
+      return { value, count, label: personLabel ?? facetLabel(field, value, all, members) }
+    })
     values.sort((a, b) => b.count - a.count || (a.label < b.label ? -1 : 1))
     out[field] = values
   }
@@ -1091,7 +1073,7 @@ function facetLabel(
 type PersonRole = 'assignee' | 'reporter'
 
 export function personIdentity(issue: IssueLite, role: PersonRole): string | null {
-  return issue[`${role}_id`] ?? issue[`${role}_email`] ?? null
+  return issue[`${role}_id`] || issue[`${role}_email`] || null
 }
 
 function sameIdentity(a: string, b: string): boolean {
@@ -1107,23 +1089,17 @@ export function issueMatchesPerson(
   const id = issue[`${role}_id`]
   const email = issue[`${role}_email`]
   if ((id && sameIdentity(id, value)) || (email && sameIdentity(email, value))) return true
-  // Saved views created before the ID migration carry email values. When Jira
-  // later hides that email on issue rows, the configured member directory can
-  // still resolve the legacy token to the stable account ID without a network call.
-  const configuredID = issues.memberOf(value)?.jira_account_id
-  return Boolean(id && configuredID && sameIdentity(id, configuredID))
+  // During a cache upgrade either side can temporarily carry only one identity
+  // shape. The member directory bridges a known email alias and its account ID
+  // without adding a network call to the filter path.
+  const member = value.includes('@') ? issues.memberOf(value) : issues.memberOfAccountId(value)
+  if (!member) return false
+  if (id && member.jira_account_id && sameIdentity(id, member.jira_account_id)) return true
+  return Boolean(email && sameIdentity(email, member.email))
 }
 
 function hasIssuePerson(issue: IssueLite, role: PersonRole): boolean {
   return Boolean(issue[`${role}_id`] || issue[role] || issue[`${role}_email`])
-}
-
-function dynamicFieldLabel(alias: string, value: string, all: IssueLite[]): string {
-  for (const issue of all) {
-    const found = rowFieldEntries(issue, alias).find((entry) => entry.value === value)
-    if (found) return found.label
-  }
-  return value
 }
 
 function bump(m: Map<string, number>, key: string | null | undefined): void {

--- a/web/src/stores/issues.svelte.ts
+++ b/web/src/stores/issues.svelte.ts
@@ -48,6 +48,8 @@ class IssuesStore {
   pool = new SvelteMap<string, IssueLite>()
   /** email → Member (avatar/part). */
   members = new SvelteMap<string, Member>()
+  /** normalized email → Member, for case-insensitive legacy filter tokens. */
+  #membersByNormalizedEmail = new SvelteMap<string, Member>()
 
   /** True once cache hydration or first bootstrap finishes and the UI can run. */
   ready = $state(false)
@@ -161,7 +163,7 @@ class IssuesStore {
     try {
       const [cached, meta] = await Promise.all([db.getAllIssues(), db.getMeta()])
       if (meta) {
-        for (const m of meta.members) this.members.set(m.email, m)
+        for (const m of meta.members) this.#setMember(m)
         this.lastSync = meta.server_time
         this.#syncVersion = meta.sync_version
         this.#membersVersion = meta.members_version ?? ''
@@ -226,7 +228,8 @@ class IssuesStore {
     this.pool.clear()
     for (const it of data.issues) this.pool.set(it.issue_key, it)
     this.members.clear()
-    for (const m of data.members) this.members.set(m.email, m)
+    this.#membersByNormalizedEmail.clear()
+    for (const m of data.members) this.#setMember(m)
 
     this.lastSync = data.server_time
     this.#syncVersion = data.sync_version
@@ -281,7 +284,8 @@ class IssuesStore {
     // members arrive only when changed (omit → keep existing). Refresh hash when present.
     if (members) {
       this.members.clear()
-      for (const member of members) this.members.set(member.email, member)
+      this.#membersByNormalizedEmail.clear()
+      for (const member of members) this.#setMember(member)
     }
     if (membersVersion !== undefined) this.#membersVersion = membersVersion
     if (syncHealth) this.syncHealth = syncHealth
@@ -423,8 +427,23 @@ class IssuesStore {
     return this.pool.get(issueKey)
   }
 
+  #setMember(member: Member): void {
+    this.members.set(member.email, member)
+    this.#membersByNormalizedEmail.set(member.email.toLowerCase(), member)
+  }
+
   memberOf(email: string | null | undefined): Member | undefined {
-    return email ? this.members.get(email) : undefined
+    return email
+      ? (this.members.get(email) ?? this.#membersByNormalizedEmail.get(email.toLowerCase()))
+      : undefined
+  }
+
+  memberOfAccountId(accountId: string | null | undefined): Member | undefined {
+    if (!accountId) return undefined
+    for (const member of this.members.values()) {
+      if (member.jira_account_id === accountId) return member
+    }
+    return undefined
   }
 }
 

--- a/web/src/stores/me.svelte.ts
+++ b/web/src/stores/me.svelte.ts
@@ -121,6 +121,7 @@ const EVENT_NOTIFY_KIND: Record<FeedItem['event_type'], MessageKey> = {
 class MeStore {
   /* ── Identity (from stored credential via auth/me/) ── */
   email = $state<string | null>(null)
+  accountId = $state<string | null>(null)
   name = $state<string | null>(null)
   department = $state<string | null>(null)
   /** init() finished — personalization UI can branch without a flash. */
@@ -208,12 +209,13 @@ class MeStore {
     if (!res.ok) return
     const data = (await res.json()) as {
       email: string | null
+      account_id?: string | null
       name?: string
       department?: string
     }
     if (data.email) {
       const wasIdentified = this.email !== null
-      this.#setUser(data.email, data.name ?? null, data.department ?? null)
+      this.#setUser(data.email, data.account_id ?? null, data.name ?? null, data.department ?? null)
       if (opts.loadPersonal && !wasIdentified) {
         await Promise.all([watches.load(), this.loadFeed(), push.load()])
         this.#startFeedPolling()
@@ -223,8 +225,14 @@ class MeStore {
     }
   }
 
-  #setUser(email: string, name: string | null, department: string | null): void {
+  #setUser(
+    email: string,
+    accountId: string | null,
+    name: string | null,
+    department: string | null,
+  ): void {
     this.email = email
+    this.accountId = accountId
     this.name = name
     this.department = department
   }
@@ -232,6 +240,7 @@ class MeStore {
   /** Drop identity and personal server state; keep favorites/recent. */
   #clearIdentity(): void {
     this.email = null
+    this.accountId = null
     this.name = null
     this.department = null
     watches.clear()

--- a/web/src/stores/write.svelte.ts
+++ b/web/src/stores/write.svelte.ts
@@ -387,6 +387,7 @@ class WriteStore {
       key,
       {
         assignee: user ? user.display_name : null,
+        assignee_id: user ? user.account_id : null,
         assignee_email: user ? user.email || null : null,
       },
       () => api.setAssignee(key, user ? user.account_id : null),


### PR DESCRIPTION
## What / why

- Jira Cloud may omit `emailAddress` while still returning a stable `accountId`. Scry's assignee and reporter facets previously depended on email, so most people could disappear from filtering and assigned issues could be classified as unassigned.
- Use Jira account IDs as the canonical identity for first-class assignee, reporter, current-user, and grouping paths while retaining names/emails as display and compatibility data.
- Keep the existing `assignee_email` / `reporter_email` properties and `as` / `rp` URL keys so saved views and shared URLs remain readable. Their values may now be account IDs; legacy email values still match when the issue row or configured member directory retains the alias.

Generic custom user-field identity is intentionally not part of this PR. It needs a separate backfill, namespace, and delta-visibility contract.

## Cache and migration behavior

- No SQLite migration or Jira resync is required: the mirror already stores first-class assignee/reporter account IDs.
- IndexedDB schema v2 clears only legacy v1 `issues` rows and the stale `sync` cursor once, forcing one current bootstrap so unchanged rows receive `reporter_id`.
- The independent `write` metadata record is preserved.
- Fresh v2 databases and subsequent v2 reopens do not invalidate again; they reuse the cache and continue with delta requests.

## How to test

```bash
gofmt -l internal/fields/coalesce.go internal/fields/coalesce_test.go internal/tui/filter.go internal/tui/filter_test.go internal/tui/model.go
make build
go vet ./...
go test ./...
npm run typecheck
npm run build
npm run test:e2e
scripts/scan-internal.sh
git diff --check
```

- Full Playwright suite: 93/93 passed.
- Cache regression coverage includes legacy v1 to v2 invalidation, preserved write metadata, same-v2 reload/delta reuse, and fresh-v2 bootstrap.
- Manual dogfood used an isolated copy of a real mirror: incremental sync completed, the built API and Vite UI loaded, assignee/reporter facets were populated, selected filters serialized account IDs, reload preserved filter state, the detail assignee picker opened read-only, and browser console errors remained at zero.
- Development note: opening detail from a raw `127.0.0.1:5173` Vite origin caused the read-marker POST to fail the API origin check. It did not affect these filters or Jira data; the production-style `scry.localhost` origin and full E2E server were clean.

## Checks

- [x] `make build && go vet ./... && go test ./...`
- [x] `npm run typecheck && npm run build`
- [x] `npm run test:e2e` (93/93)
- [x] `scripts/scan-internal.sh`
- [x] Nothing installation-specific (site URL, token, real issue data, company string)
