### PR TITLE
Windows: ship the app, and make its surfaces tell the truth there

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -247,3 +247,122 @@ jobs:
           done
           echo "cask push failed after 5 attempts" >&2
           exit 1
+
+  # Unsigned Windows portable zip. No certificate in 0.16 (GDK-211), so this
+  # job never looks for one. An installer would add SmartScreen/SAC friction
+  # without making the bytes more trustworthy, so the asset is a zip of the
+  # directory desktop/build-windows.ps1 already builds.
+  desktop-windows:
+    name: Windows app + zip
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: desktop/go.mod
+          cache-dependency-path: desktop/go.sum
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Build web UI
+        shell: pwsh
+        run: |
+          npm ci
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm run build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath dist/app)) { throw "dist/app missing" }
+
+      - name: Pack Windows portable zips
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./desktop/build-windows.ps1 --arch x64 --archive
+          ./desktop/build-windows.ps1 --arch arm64 --archive
+
+      # Recurrence gate (same decision as the macOS job, 2026-08-15):
+      # v0.14.0 apps match gadak-desktop-<os>-<arch>.zip exactly and would
+      # self-swap. The Windows asset is Gadak-<ver>-windows-<x64|arm64>.zip
+      # so it cannot be that name (different prefix, version in the middle,
+      # pack label x64 not amd64). It also cannot collide with the CLI zip
+      # gadak_<ver>_windows_<amd64|arm64>.zip from goreleaser.
+      - name: Notify-only — no updater zip name
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bad = @(Get-ChildItem -Path desktop/build -File -Filter 'gadak-desktop-*.zip' -ErrorAction SilentlyContinue)
+          if ($bad.Count -ne 0) {
+            Write-Host 'desktop/build contains zip(s) in the updater namespace:'
+            $bad | ForEach-Object { Write-Host $_.FullName }
+            exit 1
+          }
+          $zips = @(Get-ChildItem -Path desktop/build -File -Filter 'Gadak-*-windows-*.zip')
+          if ($zips.Count -eq 0) {
+            Write-Host 'no Gadak-*-windows-*.zip produced'
+            exit 1
+          }
+          foreach ($exe in @('gadak-desktop.exe', 'gadak.exe')) {
+            $hits = @(Get-ChildItem -Path desktop/build -Recurse -File -Filter $exe)
+            if ($hits.Count -eq 0) {
+              Write-Host "packed tree is missing $exe"
+              exit 1
+            }
+          }
+          Write-Host ("windows assets: {0}" -f ($zips.Name -join ', '))
+
+      - name: Upload Windows zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gadak-desktop-windows
+          path: |
+            desktop/build/Gadak-*-windows-*.zip
+          if-no-files-found: error
+
+      - name: Attach zip to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $tag = $env:GITHUB_REF_NAME
+          $zips = @(Get-ChildItem -Path desktop/build -File -Filter 'Gadak-*-windows-*.zip')
+          if ($zips.Count -eq 0) {
+            Write-Host 'no Windows zip produced' -ForegroundColor Red
+            exit 1
+          }
+          foreach ($z in $zips) {
+            if ($z.Name -like 'gadak-desktop-*.zip') {
+              Write-Host ("refusing to upload {0}: v0.14.0 apps match gadak-desktop-<os>-<arch>.zip" -f $z.Name)
+              exit 1
+            }
+          }
+          $found = $false
+          foreach ($i in 1..60) {
+            gh release view $tag 1>$null 2>$null
+            if ($LASTEXITCODE -eq 0) {
+              $found = $true
+              break
+            }
+            Write-Host "waiting for release $tag ($i/60)…"
+            Start-Sleep -Seconds 10
+          }
+          if (-not $found) {
+            Write-Host "release $tag not found after wait — creating shell release for the zip"
+            gh release create $tag --title $tag --generate-notes
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+          }
+          $paths = @($zips | ForEach-Object { $_.FullName })
+          gh release upload $tag @paths --clobber
+          if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,7 +19,7 @@
 gadak은 Jira *그리고* Confluence를 로컬 SQLite 파일 하나로 미러링합니다 —
 이슈, 코멘트, 히스토리, 위키 문서가 한 인덱스에 들어가고, 검색은 네트워크
 없이 로컬에서 끝납니다. 그 데이터가 내 머신에서 사는 자리가 이 창입니다:
-[macOS 앱](docs/DESKTOP.md)이나 브라우저 탭에서 트리아지하고, 코딩
+[데스크톱 앱](docs/DESKTOP.md)이나 브라우저 탭에서 트리아지하고, 코딩
 에이전트가 SQL로 묻고 같은 창에 답을 띄우게 하세요. 바이너리 하나,
 앱 하나, gadak 계정은 없습니다.
 
@@ -71,12 +71,20 @@ SQL은 브라우저 안에서 돌아갑니다.
 
 </details>
 
-[`Gadak-<version>-arm64.dmg`](https://github.com/midagedev/gadak/releases/latest)를
-받아 창을 열거나, 터미널에서:
+macOS: [`Gadak-<version>-arm64.dmg`](https://github.com/midagedev/gadak/releases/latest)를
+받아 창을 엽니다.
+
+Windows (0.16부터): [`Gadak-<version>-windows-x64.zip`](https://github.com/midagedev/gadak/releases/latest)
+(또는 `windows-arm64`)을 받아 압축을 풀고 `gadak-desktop.exe`를 실행합니다.
+이 빌드는 서명되어 있지 않습니다 — Windows가 막으면 아래 CLI 경로를
+쓰세요. 자세한 내용:
+[`docs/INSTALL.md`](docs/INSTALL.md#desktop-app-windows).
+
+또는 터미널에서:
 
 ```bash
-brew install midagedev/tap/gadak        # 앱 — 번들된 CLI도 PATH에 올라갑니다
-# 또는 CLI만 (macOS + Linux):
+brew install midagedev/tap/gadak        # macOS 앱 — 번들된 CLI도 PATH에 올라갑니다
+# CLI만 (macOS + Linux는 brew; Windows는 릴리스 zip):
 brew install midagedev/tap/gadak-cli
 gadak init && gadak sync    # Jira (그리고 Confluence) -> ~/.gadak/gadak.db
 gadak serve                # http://gadak.localhost:7777
@@ -107,7 +115,7 @@ Jira 검색은 네트워크 왕복이고, 위키는 두 번째 검색입니다. 
 
 | | 용도 | 모습 |
 | --- | --- | --- |
-| **앱 + 웹 UI** | 종일 트리아지 | [macOS 앱](docs/DESKTOP.md)(포트 없음) 또는 `gadak serve`. `j`/`k`로 이동, `x`로 선택, `s`/`a`/`l`/`c`로 리스트에서 바로 상태·담당자·라벨·코멘트 변경 |
+| **앱 + 웹 UI** | 종일 트리아지 | [데스크톱 앱](docs/DESKTOP.md)(포트 없음) 또는 `gadak serve`. `j`/`k`로 이동, `x`로 선택, `s`/`a`/`l`/`c`로 리스트에서 바로 상태·담당자·라벨·코멘트 변경 |
 | **CLI + SQL** | 에이전트, 스크립트 | `gadak issue`, `gadak search`(FTS, `--jql`, Jira URL), `gadak sql`, 그리고 파일 그 자체 |
 
 쓰기는 Jira로 통과된 뒤 미러가 갱신됩니다. 앱·웹: 코멘트, 상태 전이,
@@ -213,8 +221,9 @@ JQL로 여전히 물을 수 없는 것은 `gadak sql`과
 Atlassian Cloud 전용입니다. [API 토큰](https://id.atlassian.com/manage-profile/security/api-tokens)
 하나로 같은 사이트의 Jira와 Confluence를 모두 커버합니다.
 
-**1. [macOS 앱](docs/DESKTOP.md).**
-[최신 릴리스](https://github.com/midagedev/gadak/releases/latest)에서
+**1. [데스크톱 앱](docs/DESKTOP.md).**
+
+macOS: [최신 릴리스](https://github.com/midagedev/gadak/releases/latest)에서
 `Gadak-<version>-arm64.dmg`를 받아 Applications로 드래그하세요. 서명·공증
 완료. 첫 실행이 사이트, 이메일, 토큰, 프로젝트 선택을 안내합니다. CLI는
 번들 안에 있습니다 — macOS는 앱을 `PATH`에 올려 주지 않으므로:
@@ -223,13 +232,28 @@ Atlassian Cloud 전용입니다. [API 토큰](https://id.atlassian.com/manage-pr
 /Applications/Gadak.app/Contents/Resources/bin/gadak install-cli
 ```
 
-**2. CLI** — 리눅스에서, 또는 같은 UI를 브라우저 탭으로:
+Windows (0.16부터): 같은 릴리스에서 `Gadak-<version>-windows-x64.zip`(또는
+`windows-arm64`)을 받아 압축을 풀고 `gadak-desktop.exe`를 실행하세요. 서명은
+없습니다(GDK-211). Windows가 **Windows protected your
+PC** 또는 **Smart App Control blocked an app that may be unsafe**를 보여
+주면 바이러스 탐지가 아닙니다 — 아래 CLI 경로를 쓰세요. Smart App Control을
+끄지 마세요.
+[`docs/INSTALL.md`](docs/INSTALL.md#desktop-app-windows).
+
+**2. CLI** — 리눅스, Windows, 또는 같은 UI를 브라우저 탭으로:
 
 ```bash
 brew install midagedev/tap/gadak-cli     # macOS + Linux
 gadak init && gadak sync
 gadak serve      # http://gadak.localhost:7777
 ```
+
+Homebrew 없이 Windows에 설치하려면
+[최신 릴리스](https://github.com/midagedev/gadak/releases/latest)에서
+`gadak_<version>_windows_amd64.zip`(또는 `windows_arm64`)과 `checksums.txt`를
+받으세요. 압축을 풀고 `gadak.exe`를 `PATH`에 둔 뒤
+`gadak init && gadak sync && gadak serve`. 서명되지 않은 데스크톱 exe가
+막히면 0.16에서 믿을 수 있는 Windows 경로입니다.
 
 Homebrew 없이 리눅스에 설치하려면
 [최신 릴리스](https://github.com/midagedev/gadak/releases/latest)에서
@@ -277,7 +301,7 @@ Forge 앱이 아닌가: [`docs/decisions/0003-local-process.md`](docs/decisions/
 
 ## 문서
 
-- [`docs/INSTALL.md`](docs/INSTALL.md) · [`docs/DESKTOP.md`](docs/DESKTOP.md) — 설치, 첫 실행, macOS 앱
+- [`docs/INSTALL.md`](docs/INSTALL.md) · [`docs/DESKTOP.md`](docs/DESKTOP.md) — 설치, 첫 실행, 데스크톱 앱
 - [`AGENTS.md`](AGENTS.md) · [`docs/MCP.md`](docs/MCP.md) · [`docs/AGENT_SETUP.md`](docs/AGENT_SETUP.md) — SQL, CLI, REST, MCP, 호스트별 붙여넣기 한 번
 - [`docs/RECIPES.md`](docs/RECIPES.md) — JQL이 못 묻는 질문들, SQL로
 - [`SECURITY.md`](SECURITY.md) · [`docs/FAQ.md`](docs/FAQ.md) · [`MAINTENANCE.md`](MAINTENANCE.md) — 위협 모델, 사이트 부하, 누가 유지하는가

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A local SQLite file of your Jira — so "which epic is stuck?" is one query, not
 gadak mirrors Jira *and* Confluence into one local SQLite file — issues,
 comments, history, wiki pages — indexed together and searchable locally.
 This window is where that work lives on your machine: triage
-it in the [macOS app](docs/DESKTOP.md) or a browser tab, or let a coding
+it in the [desktop app](docs/DESKTOP.md) or a browser tab, or let a coding
 agent ask in plain SQL and point the same window at the answer. One binary,
 one app, no gadak account.
 
@@ -70,12 +70,19 @@ sync interval.
 
 </details>
 
-Download [`Gadak-<version>-arm64.dmg`](https://github.com/midagedev/gadak/releases/latest)
-and open the window — or, from a terminal:
+macOS: download [`Gadak-<version>-arm64.dmg`](https://github.com/midagedev/gadak/releases/latest)
+and open the window.
+
+Windows (from 0.16): download [`Gadak-<version>-windows-x64.zip`](https://github.com/midagedev/gadak/releases/latest)
+(or `windows-arm64`), unzip, run `gadak-desktop.exe`. The build is unsigned —
+if Windows blocks it, use the CLI path below. Details:
+[`docs/INSTALL.md`](docs/INSTALL.md#desktop-app-windows).
+
+Or, from a terminal:
 
 ```bash
-brew install midagedev/tap/gadak        # the app — the bundled CLI lands on PATH too
-# or, CLI only (macOS + Linux):
+brew install midagedev/tap/gadak        # the macOS app — the bundled CLI lands on PATH too
+# CLI only (macOS + Linux via brew; Windows from the release zip):
 brew install midagedev/tap/gadak-cli
 gadak init && gadak sync    # Jira (and Confluence) -> ~/.gadak/gadak.db
 gadak serve                # http://gadak.localhost:7777
@@ -103,7 +110,7 @@ on the list do not apply. That is why a comment-only word still finds the row.
 
 | | For | Looks like |
 | --- | --- | --- |
-| **App + Web UI** | all-day triage | [macOS app](docs/DESKTOP.md) (no port) or `gadak serve`. `j`/`k` walk, `x` selects, `s`/`a`/`l`/`c` change status, assignee, labels, or comment from the list. |
+| **App + Web UI** | all-day triage | [desktop app](docs/DESKTOP.md) (no port) or `gadak serve`. `j`/`k` walk, `x` selects, `s`/`a`/`l`/`c` change status, assignee, labels, or comment from the list. |
 | **CLI + SQL** | agents, scripts | `gadak issue`, `gadak search` (FTS, `--jql`, or a Jira URL), `gadak sql`, plus the file |
 
 Writes go through to Jira, then the mirror refreshes. App and web: comment,
@@ -208,23 +215,39 @@ the mirror to what the agent should see.
 Atlassian Cloud only. One [API token](https://id.atlassian.com/manage-profile/security/api-tokens)
 covers Jira and Confluence on the same site.
 
-**1. The [macOS app](docs/DESKTOP.md).** Download `Gadak-<version>-arm64.dmg`
-from the [latest release](https://github.com/midagedev/gadak/releases/latest),
-drag to Applications. Signed and notarized. First launch walks through site,
-email, token, and projects. The CLI is inside the bundle; macOS does not put
-an app on your `PATH`:
+**1. The [desktop app](docs/DESKTOP.md).**
+
+macOS: download `Gadak-<version>-arm64.dmg` from the
+[latest release](https://github.com/midagedev/gadak/releases/latest), drag to
+Applications. Signed and notarized. First launch walks through site, email,
+token, and projects. The CLI is inside the bundle; macOS does not put an app
+on your `PATH`:
 
 ```bash
 /Applications/Gadak.app/Contents/Resources/bin/gadak install-cli
 ```
 
-**2. The CLI**, on Linux or for the same UI in a browser tab:
+Windows (from 0.16): download `Gadak-<version>-windows-x64.zip` (or
+`windows-arm64`) from the same release, unzip, run `gadak-desktop.exe`.
+Unsigned (signing is GDK-211). If Windows shows **Windows protected your PC**
+or **Smart App Control blocked an app that may be unsafe**, that is not a
+virus finding — use the CLI path below. Do not turn Smart App Control off.
+[`docs/INSTALL.md`](docs/INSTALL.md#desktop-app-windows).
+
+**2. The CLI**, on Linux, Windows, or for the same UI in a browser tab:
 
 ```bash
 brew install midagedev/tap/gadak-cli     # macOS + Linux
 gadak init && gadak sync
 gadak serve      # http://gadak.localhost:7777
 ```
+
+Windows without Homebrew: from the
+[latest release](https://github.com/midagedev/gadak/releases/latest), download
+`gadak_<version>_windows_amd64.zip` (or `windows_arm64`) and `checksums.txt`.
+Unzip, put `gadak.exe` on `PATH`, then `gadak init && gadak sync && gadak serve`.
+This is the reliable Windows route in 0.16 if the unsigned desktop exe is
+blocked.
 
 Linux without Homebrew: from the
 [latest release](https://github.com/midagedev/gadak/releases/latest),
@@ -272,7 +295,7 @@ ranked by demand: [`docs/ROADMAP.md`](docs/ROADMAP.md#more-sources-later).
 
 ## Documentation
 
-- [`docs/INSTALL.md`](docs/INSTALL.md) · [`docs/DESKTOP.md`](docs/DESKTOP.md) — install, first run, the macOS app
+- [`docs/INSTALL.md`](docs/INSTALL.md) · [`docs/DESKTOP.md`](docs/DESKTOP.md) — install, first run, the desktop app
 - [`AGENTS.md`](AGENTS.md) · [`docs/MCP.md`](docs/MCP.md) · [`docs/AGENT_SETUP.md`](docs/AGENT_SETUP.md) — SQL, CLI, REST, MCP, one paste per host
 - [`docs/RECIPES.md`](docs/RECIPES.md) — questions JQL cannot ask, as SQL
 - [`SECURITY.md`](SECURITY.md) · [`docs/FAQ.md`](docs/FAQ.md) · [`MAINTENANCE.md`](MAINTENANCE.md) — threat model, site load, who maintains this

--- a/cmd/gadak/views.go
+++ b/cmd/gadak/views.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -648,9 +649,16 @@ const (
 	desktopFocusError
 )
 
+// desktopFocusGOOS is the platform seam for focusDesktopApp. Production is
+// runtime.GOOS; tests inject "windows" on a Linux/macOS host.
+var desktopFocusGOOS = runtime.GOOS
+
 // desktopAppExists / startOpen / listServes are the D5 seams. Production
 // talks to the real app bundle and loopback probes; tests replace them.
 var desktopAppExists = func() bool {
+	if desktopFocusGOOS == "windows" {
+		return findWindowsDesktopExe() != ""
+	}
 	_, err := os.Stat("/Applications/Gadak.app")
 	return err == nil
 }
@@ -678,9 +686,13 @@ var startOpenWait = func(args ...string) error {
 // lookDesktopProcess(desktopProcessName).
 const desktopProcessName = "gadak-desktop"
 
-// lookDesktopProcess is the pgrep seam. Production runs `pgrep -xq <name>`;
-// tests replace it so they can assert the name without touching a live process.
+// lookDesktopProcess is the process-census seam. Production uses pgrep on
+// Unix and tasklist on Windows (inbox, not PowerShell); tests replace it
+// so they can assert the name without touching a live process.
 var lookDesktopProcess = func(name string) bool {
+	if desktopFocusGOOS == "windows" {
+		return lookWindowsProcess(name)
+	}
 	return exec.Command("pgrep", "-xq", name).Run() == nil
 }
 
@@ -787,12 +799,15 @@ func noProfileWindowMsg(name string, running []string) string {
 // on `open`: an unregistered scheme is reported through the exit status and
 // nowhere else.
 func focusDesktopApp(link string) (bool, error) {
-	if runtime.GOOS != "darwin" {
+	if desktopFocusGOOS != "darwin" && desktopFocusGOOS != "windows" {
 		return false, nil
 	}
 	act, msg := decideDesktopFocus(desktopAppExists(), desktopAppRunning(), config.Profile(), listServes())
 	switch act {
 	case desktopFocusRaise:
+		if desktopFocusGOOS == "windows" {
+			return raiseDesktopWindows(link)
+		}
 		if link != "" && startOpenWait(link) == nil {
 			return true, nil
 		}
@@ -805,4 +820,85 @@ func focusDesktopApp(link string) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+// startWindowsDesktop launches the portable gadak-desktop.exe. A second
+// instance is forwarded by wails SingleInstance (raise + applyDeepLink);
+// a first instance reads the gadak:// arg after the window is ready.
+var startWindowsDesktop = startWindowsDesktopImpl
+
+// raiseWindowsWindow brings the existing Gadak window forward by title.
+var raiseWindowsWindow = raiseWindowsWindowImpl
+
+func raiseDesktopWindows(link string) (bool, error) {
+	err := startWindowsDesktop(link)
+	raised := raiseWindowsWindow()
+	if err != nil {
+		if raised && link == "" {
+			return true, nil
+		}
+		if raised && link != "" {
+			return false, fmt.Errorf("raised Gadak but could not deliver the link: %w", err)
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func startWindowsDesktopImpl(link string) error {
+	exe := findWindowsDesktopExe()
+	if exe == "" {
+		return fmt.Errorf("gadak-desktop.exe not found next to this CLI or on PATH")
+	}
+	var args []string
+	if link != "" {
+		args = []string{link}
+	}
+	return exec.Command(exe, args...).Start()
+}
+
+// findWindowsDesktopExe is the portable-bundle layout: gadak.exe and
+// gadak-desktop.exe sit in the same directory (desktop/build-windows.ps1).
+func findWindowsDesktopExe() string {
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		for _, name := range []string{"gadak-desktop.exe", "gadak-desktop"} {
+			p := filepath.Join(dir, name)
+			if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+				return p
+			}
+		}
+	}
+	if p, err := exec.LookPath("gadak-desktop.exe"); err == nil {
+		return p
+	}
+	if p, err := exec.LookPath("gadak-desktop"); err == nil {
+		return p
+	}
+	return ""
+}
+
+func lookWindowsProcess(name string) bool {
+	image := name
+	if !strings.HasSuffix(strings.ToLower(image), ".exe") {
+		image += ".exe"
+	}
+	// tasklist is the inbox census. golang.org/x/sys/windows is
+	// GOOS-constrained and this file is compiled on every platform; we do
+	// not shell out to PowerShell.
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq "+image, "/NH").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(out)), strings.ToLower(image))
+}
+
+func raiseWindowsWindowImpl() bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+	return raiseGadakWindowByTitle("Gadak")
 }

--- a/cmd/gadak/views_other.go
+++ b/cmd/gadak/views_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func raiseGadakWindowByTitle(string) bool { return false }

--- a/cmd/gadak/views_test.go
+++ b/cmd/gadak/views_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -106,12 +105,16 @@ func stubViewsLaunchSeams(t *testing.T, hits []serveHit) (openedWeb *bool, opene
 // paths, so a test can assert which one ran.
 func stubFocusSeams(t *testing.T) (deepLinked *[]string, raised *[]string, deepLinkErr *error) {
 	t.Helper()
+	savedGOOS := desktopFocusGOOS
 	savedExists, savedRunning, savedList := desktopAppExists, desktopAppRunning, listServes
 	savedOpen, savedWait := startOpen, startOpenWait
 	t.Cleanup(func() {
+		desktopFocusGOOS = savedGOOS
 		desktopAppExists, desktopAppRunning, listServes = savedExists, savedRunning, savedList
 		startOpen, startOpenWait = savedOpen, savedWait
 	})
+	// These tests pin the macOS `open` path; the Windows path has its own cases.
+	desktopFocusGOOS = "darwin"
 	desktopAppExists = func() bool { return true }
 	desktopAppRunning = func() bool { return true }
 	listServes = func() []gadakProbe { return nil }
@@ -132,9 +135,6 @@ func stubFocusSeams(t *testing.T) (deepLinked *[]string, raised *[]string, deepL
 // the uifocus file did in two, and without the file's two-minute window or
 // its per-mount consumption.
 func TestFocusDesktopAppPrefersTheDeepLink(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("focusDesktopApp is a no-op off darwin")
-	}
 	viaLink, viaRaise, _ := stubFocusSeams(t)
 	const link = "gadak://view/w/work?ks=NMA-1"
 	ok, err := focusDesktopApp(link)
@@ -154,9 +154,6 @@ func TestFocusDesktopAppPrefersTheDeepLink(t *testing.T) {
 // answers kLSApplicationNotFoundErr, and without this fallback the user
 // watches nothing happen.
 func TestFocusDesktopAppFallsBackWhenTheSchemeIsUnregistered(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("focusDesktopApp is a no-op off darwin")
-	}
 	viaLink, viaRaise, linkErr := stubFocusSeams(t)
 	*linkErr = errors.New("No application knows how to open URL")
 	ok, err := focusDesktopApp("gadak://view/w/work?ks=NMA-1")
@@ -174,9 +171,6 @@ func TestFocusDesktopAppFallsBackWhenTheSchemeIsUnregistered(t *testing.T) {
 // No link to offer — `views open` composes "" only when there is no hash —
 // so the old path is the whole path.
 func TestFocusDesktopAppWithoutALinkRaisesOnly(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("focusDesktopApp is a no-op off darwin")
-	}
 	viaLink, viaRaise, _ := stubFocusSeams(t)
 	if ok, err := focusDesktopApp(""); err != nil || !ok {
 		t.Fatalf("focusDesktopApp(\"\") = %v, %v; want true, nil", ok, err)
@@ -556,11 +550,16 @@ func TestDecideDesktopFocusDefaultLaunchesWhenIdle(t *testing.T) {
 }
 
 func TestFocusDesktopAppWrongProfileDoesNotOpen(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
 	savedExists, savedRunning, savedList, savedOpen := desktopAppExists, desktopAppRunning, listServes, startOpen
+	savedWin := startWindowsDesktop
 	t.Cleanup(func() {
 		config.SetProfile("")
+		desktopFocusGOOS = savedGOOS
 		desktopAppExists, desktopAppRunning, listServes, startOpen = savedExists, savedRunning, savedList, savedOpen
+		startWindowsDesktop = savedWin
 	})
+	desktopFocusGOOS = "darwin"
 	config.SetProfile("work")
 	desktopAppExists = func() bool { return true }
 	desktopAppRunning = func() bool { return false }
@@ -573,13 +572,11 @@ func TestFocusDesktopAppWrongProfileDoesNotOpen(t *testing.T) {
 		t.Errorf("must not call open: %v", args)
 		return nil
 	}
-	ok, err := focusDesktopApp("")
-	if runtime.GOOS != "darwin" {
-		if ok || err != nil {
-			t.Fatalf("non-darwin: focused=%v err=%v", ok, err)
-		}
-		return
+	startWindowsDesktop = func(link string) error {
+		t.Errorf("must not launch windows desktop: %s", link)
+		return nil
 	}
+	ok, err := focusDesktopApp("")
 	if err != nil {
 		t.Fatalf("other serve is not a hard error (web path handles it): %v", err)
 	}
@@ -592,11 +589,14 @@ func TestFocusDesktopAppWrongProfileDoesNotOpen(t *testing.T) {
 }
 
 func TestFocusDesktopAppNamedNoServeRaises(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
 	savedExists, savedRunning, savedList, savedOpen := desktopAppExists, desktopAppRunning, listServes, startOpen
 	t.Cleanup(func() {
 		config.SetProfile("")
+		desktopFocusGOOS = savedGOOS
 		desktopAppExists, desktopAppRunning, listServes, startOpen = savedExists, savedRunning, savedList, savedOpen
 	})
+	desktopFocusGOOS = "darwin"
 	config.SetProfile("work")
 	desktopAppExists = func() bool { return true }
 	desktopAppRunning = func() bool { return true }
@@ -607,12 +607,6 @@ func TestFocusDesktopAppNamedNoServeRaises(t *testing.T) {
 		return nil
 	}
 	ok, err := focusDesktopApp("")
-	if runtime.GOOS != "darwin" {
-		if ok || err != nil {
-			t.Fatalf("non-darwin: focused=%v err=%v", ok, err)
-		}
-		return
-	}
 	if err != nil {
 		t.Fatalf("desktop-only named profile must raise, not error: %v", err)
 	}
@@ -625,11 +619,14 @@ func TestFocusDesktopAppNamedNoServeRaises(t *testing.T) {
 }
 
 func TestFocusDesktopAppSameProfileOpensWithoutEnv(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
 	savedExists, savedRunning, savedList, savedOpen := desktopAppExists, desktopAppRunning, listServes, startOpen
 	t.Cleanup(func() {
 		config.SetProfile("")
+		desktopFocusGOOS = savedGOOS
 		desktopAppExists, desktopAppRunning, listServes, startOpen = savedExists, savedRunning, savedList, savedOpen
 	})
+	desktopFocusGOOS = "darwin"
 	config.SetProfile("work")
 	desktopAppExists = func() bool { return true }
 	desktopAppRunning = func() bool { return true }
@@ -642,12 +639,6 @@ func TestFocusDesktopAppSameProfileOpensWithoutEnv(t *testing.T) {
 		return nil
 	}
 	ok, err := focusDesktopApp("")
-	if runtime.GOOS != "darwin" {
-		if ok || err != nil {
-			t.Fatalf("non-darwin: focused=%v err=%v", ok, err)
-		}
-		return
-	}
 	if err != nil {
 		t.Fatalf("same-profile raise: %v", err)
 	}
@@ -661,6 +652,77 @@ func TestFocusDesktopAppSameProfileOpensWithoutEnv(t *testing.T) {
 	}
 	if len(got) < 2 || got[0] != "-a" || got[1] != "Gadak" {
 		t.Fatalf("open args = %v, want -a Gadak", got)
+	}
+}
+
+// Windows is no longer a silent false (GDK-244): decideDesktopFocus still
+// owns the table, and a raise launches the portable exe with the gadak://
+// link so the running app navigates. The GOOS seam lets this run on Linux CI.
+func TestFocusDesktopAppWindowsLaunchesExeWithLink(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
+	savedExists, savedRunning, savedList := desktopAppExists, desktopAppRunning, listServes
+	savedStart := startWindowsDesktop
+	savedRaise := raiseWindowsWindow
+	t.Cleanup(func() {
+		desktopFocusGOOS = savedGOOS
+		desktopAppExists, desktopAppRunning, listServes = savedExists, savedRunning, savedList
+		startWindowsDesktop, raiseWindowsWindow = savedStart, savedRaise
+	})
+	desktopFocusGOOS = "windows"
+	desktopAppExists = func() bool { return true }
+	desktopAppRunning = func() bool { return true }
+	listServes = func() []gadakProbe { return nil }
+	var started string
+	startWindowsDesktop = func(link string) error {
+		started = link
+		return nil
+	}
+	raiseWindowsWindow = func() bool { return true }
+
+	const link = "gadak://view?ks=NMA-1"
+	ok, err := focusDesktopApp(link)
+	if err != nil || !ok {
+		t.Fatalf("windows focus = %v, %v; want true, nil", ok, err)
+	}
+	if started != link {
+		t.Fatalf("started %q, want the gadak:// link", started)
+	}
+}
+
+func TestFocusDesktopAppWindowsRespectsDecideNone(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
+	savedExists, savedRunning, savedList := desktopAppExists, desktopAppRunning, listServes
+	savedStart := startWindowsDesktop
+	t.Cleanup(func() {
+		config.SetProfile("")
+		desktopFocusGOOS = savedGOOS
+		desktopAppExists, desktopAppRunning, listServes = savedExists, savedRunning, savedList
+		startWindowsDesktop = savedStart
+	})
+	desktopFocusGOOS = "windows"
+	config.SetProfile("work")
+	desktopAppExists = func() bool { return true }
+	desktopAppRunning = func() bool { return false }
+	listServes = func() []gadakProbe {
+		return []gadakProbe{{IsGadak: true, Profile: "default"}}
+	}
+	startWindowsDesktop = func(link string) error {
+		t.Errorf("must not launch when decide says none (link %s)", link)
+		return nil
+	}
+	ok, err := focusDesktopApp("gadak://view/w/work?ks=NMA-1")
+	if ok || err != nil {
+		t.Fatalf("wrong-profile windows focus = %v, %v; want false, nil", ok, err)
+	}
+}
+
+func TestFocusDesktopAppLinuxStillNoop(t *testing.T) {
+	savedGOOS := desktopFocusGOOS
+	t.Cleanup(func() { desktopFocusGOOS = savedGOOS })
+	desktopFocusGOOS = "linux"
+	ok, err := focusDesktopApp("gadak://view?ks=NMA-1")
+	if ok || err != nil {
+		t.Fatalf("linux focus = %v, %v; want false, nil", ok, err)
 	}
 }
 

--- a/cmd/gadak/views_windows.go
+++ b/cmd/gadak/views_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// raiseGadakWindowByTitle finds the native window the smoke harness already
+// locates (title "Gadak") and restores + focuses it. user32 is the inbox
+// API; we do not shell out to PowerShell.
+func raiseGadakWindowByTitle(title string) bool {
+	user32 := syscall.NewLazyDLL("user32.dll")
+	findWindow := user32.NewProc("FindWindowW")
+	setForeground := user32.NewProc("SetForegroundWindow")
+	showWindow := user32.NewProc("ShowWindow")
+	isIconic := user32.NewProc("IsIconic")
+	ptr, err := syscall.UTF16PtrFromString(title)
+	if err != nil {
+		return false
+	}
+	hwnd, _, _ := findWindow.Call(0, uintptr(unsafe.Pointer(ptr)))
+	if hwnd == 0 {
+		return false
+	}
+	const swRestore = 9
+	iconic, _, _ := isIconic.Call(hwnd)
+	if iconic != 0 {
+		_, _, _ = showWindow.Call(hwnd, swRestore)
+	}
+	_, _, _ = setForeground.Call(hwnd)
+	return true
+}

--- a/desktop/build-windows.ps1
+++ b/desktop/build-windows.ps1
@@ -1,19 +1,27 @@
 # Build a Windows portable directory from the desktop module.
 #
 # Prerequisites: `npm run build` at the repo root (the app embeds dist/app),
-# a Windows host, Go. No wails3 CLI: plain `go build`, same contract as
-# desktop/build-app.sh and desktop/build-linux.sh.
+# Go. No wails3 CLI: plain `go build`, same contract as desktop/build-app.sh
+# and desktop/build-linux.sh. Compiling is a cross-compile (CGO_ENABLED=0,
+# GOOS=windows) and does not need a Windows host — measured from macOS.
+# What still needs Windows is Authenticode signing (GDK-211) and any
+# WebView2 runtime/bootstrap installer work; this script does neither.
 #
-# Usage: desktop/build-windows.ps1
+# Usage: desktop/build-windows.ps1 [--arch x64|arm64] [--archive]
 #
 # Exit 64 = usage / unknown argument
 #      69 = a required tool is missing
-#       1 = dist/app missing, not Windows, or a build step failed
-#       0 = portable directory written
+#       1 = dist/app missing or a build step failed
+#       0 = portable directory written (and the zip, if --archive)
 #
-# This script must not emit a zip — v0.14.0 apps match
-# gadak-desktop-*-<arch>.zip and would self-swap (same rule as
+# This script must not emit gadak-desktop-<os>-<arch>.zip — v0.14.0 apps
+# match that name exactly and would self-swap (same rule as
 # desktop/build-app.sh --dmg and desktop/build-linux.sh).
+# --archive writes Gadak-<ver>-windows-<x64|arm64>.zip instead: a portable
+# directory zip, not an installer. An unsigned installer is more Windows
+# friction than a zip, and 0.16 has no Authenticode certificate (GDK-211).
+# That name also cannot collide with the goreleaser CLI zip
+# (gadak_<ver>_windows_<amd64|arm64>.zip).
 #
 # WebView2 (decision, 2026-08-18):
 #   Evergreen runtime, not a Fixed Version bundle. A Fixed Version tree is
@@ -33,7 +41,7 @@
 $ErrorActionPreference = 'Stop'
 
 function Usage {
-    [Console]::Error.WriteLine('usage: desktop/build-windows.ps1')
+    [Console]::Error.WriteLine('usage: desktop/build-windows.ps1 [--arch x64|arm64] [--archive]')
     exit 64
 }
 
@@ -45,9 +53,21 @@ function Need {
     }
 }
 
-foreach ($arg in $args) {
+$wantArchive = $false
+$archArg = $null
+for ($i = 0; $i -lt $args.Count; $i++) {
+    $arg = [string]$args[$i]
     switch ($arg) {
         { $_ -in @('-h', '--help') } { Usage }
+        { $_ -in @('--archive', '-Archive', '-archive') } { $wantArchive = $true }
+        { $_ -in @('--arch', '-Arch', '-arch') } {
+            if ($i + 1 -ge $args.Count) {
+                [Console]::Error.WriteLine('build-windows: --arch needs x64 or arm64')
+                Usage
+            }
+            $i++
+            $archArg = [string]$args[$i]
+        }
         default {
             [Console]::Error.WriteLine("build-windows: unknown argument: $arg")
             Usage
@@ -104,14 +124,9 @@ function Get-GadakVersion {
     }
 }
 
-$onWindows = ($env:OS -eq 'Windows_NT') -or ($IsWindows -eq $true)
-if (-not $onWindows) {
-    $uname = 'unknown'
-    if ($IsMacOS -eq $true) { $uname = 'Darwin' }
-    elseif ($IsLinux -eq $true) { $uname = 'Linux' }
-    [Console]::Error.WriteLine("build-windows: this runner is $uname; compiling the wails v3 Windows host needs Windows")
-    exit 1
-}
+# Compiling the unsigned portable pack is CGO_ENABLED=0 GOOS=windows and
+# works off Windows (measured from macOS). Signing and WebView2 bootstrap
+# still need a Windows host — this script does not do those.
 
 Need go
 
@@ -124,18 +139,43 @@ $verStamp = $version -replace '^v', ''
 
 # Windows pack labels (x64, arm64), not the macOS dmg labels (amd64, arm64)
 # or the AppImage / uname labels (x86_64, aarch64).
-# Filename: Gadak-<ver>-<this>/
-$rawArch = $env:PROCESSOR_ARCHITECTURE
-if (-not [string]::IsNullOrEmpty($env:PROCESSOR_ARCHITEW6432)) {
-    $rawArch = $env:PROCESSOR_ARCHITEW6432
-}
-switch ($rawArch.ToUpperInvariant()) {
-    'AMD64' { $fileArch = 'x64'; $goarch = 'amd64' }
-    'X86_64' { $fileArch = 'x64'; $goarch = 'amd64' }
-    'ARM64' { $fileArch = 'arm64'; $goarch = 'arm64' }
-    default {
-        [Console]::Error.WriteLine("build-windows: unsupported architecture: $rawArch")
+# Directory: Gadak-<ver>-<this>/
+# Archive (optional): Gadak-<ver>-windows-<this>.zip
+$fileArch = $null
+$goarch = $null
+if (-not [string]::IsNullOrEmpty($archArg)) {
+    switch ($archArg.ToLowerInvariant()) {
+        'x64' { $fileArch = 'x64'; $goarch = 'amd64' }
+        'arm64' { $fileArch = 'arm64'; $goarch = 'arm64' }
+        default {
+            [Console]::Error.WriteLine("build-windows: --arch must be x64 or arm64 (got $archArg)")
+            exit 64
+        }
+    }
+} else {
+    $rawArch = $env:PROCESSOR_ARCHITECTURE
+    if (-not [string]::IsNullOrEmpty($env:PROCESSOR_ARCHITEW6432)) {
+        $rawArch = $env:PROCESSOR_ARCHITEW6432
+    }
+    if ([string]::IsNullOrEmpty($rawArch)) {
+        $unameCmd = Get-Command uname -ErrorAction SilentlyContinue
+        if ($null -ne $unameCmd) {
+            $rawArch = (& $unameCmd.Source -m 2>$null)
+        }
+    }
+    if ([string]::IsNullOrEmpty($rawArch)) {
+        [Console]::Error.WriteLine('build-windows: cannot detect architecture; pass --arch x64 or --arch arm64')
         exit 1
+    }
+    switch ($rawArch.ToUpperInvariant()) {
+        'AMD64' { $fileArch = 'x64'; $goarch = 'amd64' }
+        'X86_64' { $fileArch = 'x64'; $goarch = 'amd64' }
+        'ARM64' { $fileArch = 'arm64'; $goarch = 'arm64' }
+        'AARCH64' { $fileArch = 'arm64'; $goarch = 'arm64' }
+        default {
+            [Console]::Error.WriteLine("build-windows: unsupported architecture: $rawArch")
+            exit 1
+        }
     }
 }
 
@@ -189,3 +229,58 @@ finally {
 }
 
 Write-Host "built $bundle ($version, $fileArch)"
+
+if (-not $wantArchive) {
+    exit 0
+}
+
+# Asset name is Gadak-<ver>-windows-<x64|arm64>.zip on purpose:
+# v0.14.0 apps match gadak-desktop-<os>-<arch>.zip exactly (see
+# desktop/build-app.sh --dmg). A zip of that pattern would be treated
+# as an update. This name also cannot collide with the CLI archive
+# gadak_<ver>_windows_<amd64|arm64>.zip from .goreleaser.yaml.
+$zipName = 'Gadak-{0}-windows-{1}.zip' -f $verStamp, $fileArch
+if ($zipName -like 'gadak-desktop-*-*.zip') {
+    [Console]::Error.WriteLine("build-windows: internal error: archive name $zipName matches the updater namespace")
+    exit 1
+}
+$updaterZips = @(Get-ChildItem -LiteralPath $out -File -Filter 'gadak-desktop-*.zip' -ErrorAction SilentlyContinue)
+if ($updaterZips.Count -ne 0) {
+    [Console]::Error.WriteLine('build-windows: desktop/build contains gadak-desktop-*.zip; notify-only releases must not ship that name')
+    foreach ($z in $updaterZips) {
+        [Console]::Error.WriteLine($z.FullName)
+    }
+    exit 1
+}
+if (-not (Test-Path -LiteralPath $out)) {
+    New-Item -ItemType Directory -Path $out | Out-Null
+}
+$zipPath = Join-Path $out $zipName
+if (Test-Path -LiteralPath $zipPath) {
+    Remove-Item -LiteralPath $zipPath -Force
+}
+$compress = Get-Command Compress-Archive -ErrorAction SilentlyContinue
+if ($null -ne $compress) {
+    Compress-Archive -Path $bundle -DestinationPath $zipPath
+} else {
+    $zipCmd = Get-Command zip -ErrorAction SilentlyContinue
+    if ($null -eq $zipCmd) {
+        [Console]::Error.WriteLine('build-windows: missing Compress-Archive and zip')
+        exit 69
+    }
+    Push-Location $out
+    try {
+        & $zipCmd.Source -r -q $zipName (Split-Path -Leaf $bundle)
+        if ($LASTEXITCODE -ne 0) {
+            exit 1
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+if (-not (Test-Path -LiteralPath $zipPath) -or ((Get-Item -LiteralPath $zipPath).Length -le 0)) {
+    [Console]::Error.WriteLine("build-windows: archive was not written: $zipPath")
+    exit 1
+}
+Write-Host "archived $zipPath"

--- a/desktop/chrome_test.go
+++ b/desktop/chrome_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -74,5 +76,30 @@ func TestPrintWindowChromeFlag(t *testing.T) {
 	}
 	if !printWindowChromeIfRequested([]string{"--print-window-chrome"}) {
 		t.Fatal("flag not recognized")
+	}
+}
+
+func TestPrintIntegrationsFlag(t *testing.T) {
+	if printIntegrationsIfRequested(nil) {
+		t.Fatal("empty args should not print")
+	}
+	if printIntegrationsIfRequested([]string{"--print-window-chrome"}) {
+		t.Fatal("chrome flag is not the integrations query")
+	}
+	if printIntegrationsIfRequested([]string{"gadak://view"}) {
+		t.Fatal("deeplink is not the integrations query")
+	}
+	if !printIntegrationsIfRequested([]string{"--print-integrations"}) {
+		t.Fatal("flag not recognized")
+	}
+}
+
+func TestWebView2MissingMessageNamesRuntimeAndInstaller(t *testing.T) {
+	msg := webview2UserMessage(errors.New("no webview2 found"))
+	if !strings.Contains(msg, "WebView2") {
+		t.Fatalf("message must name WebView2:\n%s", msg)
+	}
+	if !strings.Contains(msg, webview2EvergreenURL) {
+		t.Fatalf("message must point at the Evergreen installer:\n%s", msg)
 	}
 }

--- a/desktop/fatal_other.go
+++ b/desktop/fatal_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func windowsMessageBox(string, string) {}

--- a/desktop/fatal_windows.go
+++ b/desktop/fatal_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// windowsMessageBox is user32 MessageBoxW. wails has no dialog helper for
+// a missing-runtime path (the webview is what failed).
+// MB_OK | MB_ICONERROR | MB_SETFOREGROUND.
+func windowsMessageBox(title, text string) {
+	user32 := syscall.NewLazyDLL("user32.dll")
+	proc := user32.NewProc("MessageBoxW")
+	tptr, err := syscall.UTF16PtrFromString(title)
+	if err != nil {
+		return
+	}
+	sptr, err := syscall.UTF16PtrFromString(text)
+	if err != nil {
+		return
+	}
+	const mbOK, mbIconError, mbSetForeground = 0x00000000, 0x00000010, 0x00010000
+	_, _, _ = proc.Call(0, uintptr(unsafe.Pointer(sptr)), uintptr(unsafe.Pointer(tptr)), mbOK|mbIconError|mbSetForeground)
+}

--- a/desktop/integrations.go
+++ b/desktop/integrations.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -69,8 +70,9 @@ func endInstall(id string) {
 }
 
 // resolveDesktopCLI is the bundled gadak used to run install verbs.
-// Order: GADAK_DESKTOP_CLI (test override, exclusive), then
-// <os.Executable>/../Resources/bin/gadak, LookPath("gadak"),
+// Order: GADAK_DESKTOP_CLI (test override, exclusive), then the
+// candidates next to this executable (macOS app-bundle Resources/bin,
+// Windows portable sibling gadak.exe), LookPath("gadak"),
 // /opt/homebrew/bin/gadak, /usr/local/bin/gadak.
 func resolveDesktopCLI() (string, error) {
 	if p := os.Getenv("GADAK_DESKTOP_CLI"); p != "" {
@@ -80,9 +82,10 @@ func resolveDesktopCLI() (string, error) {
 		return "", fmt.Errorf("gadak CLI not found at GADAK_DESKTOP_CLI=%s", p)
 	}
 	if exe, err := os.Executable(); err == nil {
-		p := filepath.Join(filepath.Dir(exe), "..", "Resources", "bin", "gadak")
-		if desktopCLIOK(p) {
-			return p, nil
+		for _, p := range desktopCLICandidates(filepath.Dir(exe), runtime.GOOS) {
+			if desktopCLIOK(p) {
+				return p, nil
+			}
 		}
 	}
 	if p, err := exec.LookPath("gadak"); err == nil && p != "" {
@@ -96,10 +99,30 @@ func resolveDesktopCLI() (string, error) {
 	return "", fmt.Errorf("gadak CLI not found")
 }
 
+// desktopCLICandidates is every path we try next to the desktop executable
+// before falling back to PATH. goos is explicit so tests can pin the
+// Windows sibling without running there.
+func desktopCLICandidates(exeDir, goos string) []string {
+	out := []string{filepath.Join(exeDir, "..", "Resources", "bin", "gadak")}
+	if goos == "windows" {
+		out = append(out, filepath.Join(exeDir, "gadak.exe"), filepath.Join(exeDir, "gadak"))
+	} else {
+		out = append(out, filepath.Join(exeDir, "gadak"))
+	}
+	return out
+}
+
 func desktopCLIOK(p string) bool {
+	return desktopCLIOKFor(p, runtime.GOOS)
+}
+
+func desktopCLIOKFor(p, goos string) bool {
 	fi, err := os.Stat(p)
 	if err != nil || fi.IsDir() {
 		return false
+	}
+	if goos == "windows" {
+		return true
 	}
 	return fi.Mode()&0o111 != 0
 }

--- a/desktop/integrations_test.go
+++ b/desktop/integrations_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -39,8 +40,12 @@ func TestIntegrationsGETOrderAndDetect(t *testing.T) {
 		if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
 			t.Fatalf("json: %v\n%s", err, rec.Body.String())
 		}
-		if len(doc.Items) != 4 {
-			t.Fatalf("len(items)=%d want 4: %s", len(doc.Items), rec.Body.String())
+		wantN := 4
+		if runtime.GOOS == "windows" {
+			wantN = 3
+		}
+		if len(doc.Items) != wantN {
+			t.Fatalf("len(items)=%d want %d: %s", len(doc.Items), wantN, rec.Body.String())
 		}
 		return doc.Items
 	}
@@ -48,6 +53,10 @@ func TestIntegrationsGETOrderAndDetect(t *testing.T) {
 	items := get()
 	wantIDs := []string{"command-line-tool", "raycast", "skill", "mcp-claude"}
 	wantCmd := []string{"gadak install-cli", "gadak raycast install", "gadak skill install claude", "gadak mcp install claude"}
+	if runtime.GOOS == "windows" {
+		wantIDs = []string{"command-line-tool", "skill", "mcp-claude"}
+		wantCmd = []string{"gadak install-cli", "gadak skill install claude", "gadak mcp install claude"}
+	}
 	for i, id := range wantIDs {
 		if items[i]["id"] != id {
 			t.Fatalf("items[%d].id=%v want %s", i, items[i]["id"], id)
@@ -56,17 +65,26 @@ func TestIntegrationsGETOrderAndDetect(t *testing.T) {
 			t.Fatalf("items[%d].command=%v want %s", i, items[i]["command"], wantCmd[i])
 		}
 	}
-	if items[1]["installed"] != false {
-		t.Fatalf("raycast installed=%v want false", items[1]["installed"])
+	byID := map[string]map[string]any{}
+	for _, it := range items {
+		id, _ := it["id"].(string)
+		byID[id] = it
 	}
-	if items[2]["installed"] != false {
-		t.Fatalf("skill installed=%v want false", items[2]["installed"])
+	if runtime.GOOS != "windows" {
+		if byID["raycast"]["installed"] != false {
+			t.Fatalf("raycast installed=%v want false", byID["raycast"]["installed"])
+		}
+		if byID["raycast"]["detail"] != "~/.gadak/raycast-extension" {
+			t.Fatalf("raycast detail=%v", byID["raycast"]["detail"])
+		}
+	} else if _, ok := byID["raycast"]; ok {
+		t.Fatal("windows GET must not include raycast")
 	}
-	if items[2]["prerequisite"] != nil {
-		t.Fatalf("skill prerequisite=%v want null", items[2]["prerequisite"])
+	if byID["skill"]["installed"] != false {
+		t.Fatalf("skill installed=%v want false", byID["skill"]["installed"])
 	}
-	if items[1]["detail"] != "~/.gadak/raycast-extension" {
-		t.Fatalf("raycast detail=%v", items[1]["detail"])
+	if byID["skill"]["prerequisite"] != nil {
+		t.Fatalf("skill prerequisite=%v want null", byID["skill"]["prerequisite"])
 	}
 
 	if err := os.MkdirAll(filepath.Join(gadakHome, "raycast-extension"), 0o755); err != nil {
@@ -84,11 +102,48 @@ func TestIntegrationsGETOrderAndDetect(t *testing.T) {
 	}
 
 	items = get()
-	if items[1]["installed"] != true {
-		t.Fatalf("raycast after touch: installed=%v want true", items[1]["installed"])
+	byID = map[string]map[string]any{}
+	for _, it := range items {
+		id, _ := it["id"].(string)
+		byID[id] = it
 	}
-	if items[2]["installed"] != true {
-		t.Fatalf("skill after touch: installed=%v want true", items[2]["installed"])
+	if runtime.GOOS != "windows" {
+		if byID["raycast"]["installed"] != true {
+			t.Fatalf("raycast after touch: installed=%v want true", byID["raycast"]["installed"])
+		}
+	}
+	if byID["skill"]["installed"] != true {
+		t.Fatalf("skill after touch: installed=%v want true", byID["skill"]["installed"])
+	}
+}
+
+func TestDesktopCLICandidatesWindowsSibling(t *testing.T) {
+	got := desktopCLICandidates(`C:\bundle`, "windows")
+	want := []string{
+		filepath.Join(`C:\bundle`, "..", "Resources", "bin", "gadak"),
+		filepath.Join(`C:\bundle`, "gadak.exe"),
+		filepath.Join(`C:\bundle`, "gadak"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestDesktopCLIOKForWindowsIgnoresUnixMode(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "gadak.exe")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !desktopCLIOKFor(p, "windows") {
+		t.Fatal("windows must accept a regular file without a POSIX execute bit")
+	}
+	if desktopCLIOKFor(p, "darwin") {
+		t.Fatal("darwin must still require the execute bit")
 	}
 }
 
@@ -125,6 +180,19 @@ func TestIntegrationsPOSTUnknownID(t *testing.T) {
 	integrationsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/desktop/integrations/nope/install", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("got %d want 404 body %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIntegrationsPOSTRaycastOnWindowsIsUnknown(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// The GOOS seam lives in InstallArgsFor; pin it there. This test
+		// is the handler-level check for a Windows process.
+		t.Skip("handler uses runtime.GOOS; InstallArgsFor is pinned in integrations_test")
+	}
+	rec := httptest.NewRecorder()
+	integrationsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/desktop/integrations/raycast/install", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("windows raycast POST: %d want 404 body %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -185,7 +253,7 @@ func TestIntegrationsPOSTConflict(t *testing.T) {
 func TestIntegrationsPOSTMissingCLI(t *testing.T) {
 	t.Setenv("GADAK_DESKTOP_CLI", filepath.Join(t.TempDir(), "no-such-gadak"))
 	rec := httptest.NewRecorder()
-	integrationsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/desktop/integrations/raycast/install", nil))
+	integrationsMux().ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/desktop/integrations/skill/install", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("POST: %d %s", rec.Code, rec.Body.String())
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -29,6 +29,7 @@ import (
 	gadak "github.com/midagedev/gadak"
 	"github.com/midagedev/gadak/internal/attachcache"
 	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/integrations"
 	"github.com/midagedev/gadak/internal/server"
 	"github.com/midagedev/gadak/internal/store"
 	syncer "github.com/midagedev/gadak/internal/sync"
@@ -43,6 +44,9 @@ var appVersion = "dev"
 
 func main() {
 	if printWindowChromeIfRequested(os.Args[1:]) {
+		return
+	}
+	if printIntegrationsIfRequested(os.Args[1:]) {
 		return
 	}
 	// Same assignment cmd/gadak/main.go makes. "dev" is this file's default;
@@ -111,6 +115,9 @@ func run() error {
 		// About panel shows.
 		Name:        "Gadak",
 		Description: "Jira and Confluence, mirrored to your disk.",
+		// wails still os.Exit(1) after this returns. We show a dialog and
+		// write stderr first so a missing WebView2 is not a silent death.
+		ErrorHandler: handleDesktopFatal,
 		Mac: application.MacOptions{
 			// v2 quit when the only window closed; keep that.
 			ApplicationShouldTerminateAfterLastWindowClosed: true,
@@ -219,6 +226,14 @@ func run() error {
 	window = app.Window.NewWithOptions(mainWindowOptions())
 	window.OnWindowEvent(events.Common.WindowRuntimeReady, func(*application.WindowEvent) {
 		log.Print("wails runtime ready — --wails-draggable listeners are attached")
+		// Windows (and Linux) deliver a first-launch gadak:// as argv. macOS
+		// uses ApplicationLaunchedWithUrl for that; applying argv there too
+		// would navigate twice.
+		if runtime.GOOS != "darwin" && applyDeepLink != nil {
+			if raw := firstDeepLinkArg(os.Args[1:]); raw != "" {
+				applyDeepLink(raw)
+			}
+		}
 	})
 
 	applyDeepLink = deepLinkNavigator(config.Profile(), func(path string) {
@@ -329,6 +344,68 @@ func printWindowChromeIfRequested(args []string) bool {
 		}
 	}
 	return false
+}
+
+// printIntegrationsIfRequested is the one-command probe for "what would
+// Settings → Integrations show on this host". Same shape as
+// --print-window-chrome: match the exact flag, print, exit, no window.
+func printIntegrationsIfRequested(args []string) bool {
+	for _, a := range args {
+		if a == "--print-integrations" {
+			enc := json.NewEncoder(os.Stdout)
+			_ = enc.Encode(map[string]any{"items": integrations.List()})
+			return true
+		}
+	}
+	return false
+}
+
+// webview2EvergreenURL is Microsoft's Evergreen Runtime installer page.
+// Named in the missing-runtime dialog and on stderr.
+const webview2EvergreenURL = "https://developer.microsoft.com/en-us/microsoft-edge/webview2/"
+
+func isMissingWebView2(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "no webview2 found") {
+		return true
+	}
+	if !strings.Contains(s, "webview2") {
+		return false
+	}
+	return strings.Contains(s, "not found") ||
+		strings.Contains(s, "does not exist") ||
+		strings.Contains(s, "runtime version")
+}
+
+func webview2UserMessage(err error) string {
+	var b strings.Builder
+	if isMissingWebView2(err) {
+		b.WriteString("Gadak needs the Microsoft Edge WebView2 Runtime, which was not found on this PC.")
+	} else if err != nil {
+		b.WriteString("Gadak could not start its window.\n\n")
+		b.WriteString(err.Error())
+	} else {
+		b.WriteString("Gadak could not start its window.")
+	}
+	b.WriteString("\n\nInstall the Evergreen Runtime from:\n")
+	b.WriteString(webview2EvergreenURL)
+	return b.String()
+}
+
+func handleDesktopFatal(err error) {
+	msg := webview2UserMessage(err)
+	fmt.Fprintln(os.Stderr, msg)
+	showNativeError("Gadak", msg)
+}
+
+func showNativeError(title, text string) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	windowsMessageBox(title, text)
 }
 
 func applyWindowChrome(opts *application.WebviewWindowOptions, chrome string) {

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -86,7 +86,7 @@ Steps 5 and 6 are what make it worth publishing: SQL answers; views present.
 
 | | For | Looks like |
 | --- | --- | --- |
-| **App + Web UI** | all-day triage | the [macOS app](DESKTOP.md) — no port, no local server — or the same UI in a browser tab (`gadak serve`) |
+| **App + Web UI** | all-day triage | the [desktop app](DESKTOP.md) — no port, no local server — or the same UI in a browser tab (`gadak serve`) |
 | **CLI + SQL** | agents, scripts, one-off questions | `gadak issue`, `gadak search` (FTS, or `--jql` / a Jira URL), `gadak sql`, plus the file itself |
 
 `j`/`k` walk the list, `x` selects, `s`/`a`/`l`/`c` change status, assignee,

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -1,10 +1,15 @@
 # The desktop app
 
-Gadak.app is the same gadak — the web UI in its own macOS window, over the same
+The desktop app is the same gadak — the web UI in its own window, over the same
 mirror, with one structural difference from `gadak serve`: **there is no local
 server.** The window talks to the mirror in-process, so there is no port, no
-address, no port conflict, and nothing new listening on your machine. Launch
-it twice and the running window comes forward instead.
+address, no port conflict, and nothing new listening on your machine
+(`desktop/main.go`). Launch it twice and the running window comes forward
+instead.
+
+On macOS the window is `Gadak.app` (no title bar: the traffic lights sit in
+the sidebar). On Windows it is `gadak-desktop.exe` from the portable zip,
+with ordinary Windows chrome.
 
 If you already use the CLI, nothing changes underneath: the app reads and
 writes the same `~/.gadak` profiles, and WAL means the app, a
@@ -16,11 +21,19 @@ instead — which is also where you grab the window to move it.
 
 ## Install
 
-Download `Gadak-<version>-arm64.dmg` from the
+**macOS.** Download `Gadak-<version>-arm64.dmg` from the
 [latest release](https://github.com/midagedev/gadak/releases/latest), drag
 Gadak.app to Applications. The dmg is Developer ID-signed and notarized
-(macOS, Apple Silicon; Intel and other platforms use the
-[CLI](../README.md#install)).
+(Apple Silicon).
+
+**Windows (from 0.16).** Download `Gadak-<version>-windows-x64.zip` or
+`Gadak-<version>-windows-arm64.zip` from the same release, unzip, run
+`gadak-desktop.exe`. Unsigned — signing is GDK-211. If Windows blocks the
+exe, use the CLI zip and `gadak serve`. Do not turn Smart App Control off.
+The wording and the CLI fallback live in
+[INSTALL.md](INSTALL.md#desktop-app-windows).
+
+Intel Macs and Linux use the [CLI](../README.md#install).
 
 First launch walks you through setup in the window — Jira site, email, API
 token (from <https://id.atlassian.com/manage-profile/security/api-tokens>),
@@ -143,10 +156,12 @@ an action that is not a plain word, carry a profile or subject that is not a
 plain name, try to traverse a path, or exceed the size limits
 (`internal/deeplink`). Actions that submit or write will not be added.
 
-macOS only: it is the bundle's `Info.plist` that registers the scheme, and
-there is no Linux or Windows desktop app. Elsewhere, the `web` field from
+macOS registers the scheme from the bundle's `Info.plist`. The Windows
+portable zip does not write `HKCU\SOFTWARE\Classes\gadak` (that registration
+is not part of the pack). On Linux, and on Windows when you are using
+`gadak serve` instead of the exe, the `web` field from
 `gadak views open --json` is the link to hand over — it needs a running
-`serve`, which those platforms have.
+`serve`.
 
 ## Profiles
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -95,6 +95,51 @@ its own window with **no local server at all**: no port, no address, nothing
 new listening. First launch walks through setup in the window.
 [`DESKTOP.md`](DESKTOP.md) has the details.
 
+### Desktop app (Windows)
+
+From 0.16, the same GitHub Release attaches a Windows portable zip:
+`Gadak-<version>-windows-x64.zip` or `Gadak-<version>-windows-arm64.zip`.
+Unzip and run `gadak-desktop.exe`. The pack is a directory (the two exes at
+the root), not an installer — 0.16 has no Authenticode certificate, and an
+unsigned installer is more friction than a zip.
+
+It is the same web UI in a native Windows window with **no local server**:
+no port, no address, nothing new listening (`desktop/main.go`). First launch
+walks through setup in the window. The window needs the Evergreen WebView2
+runtime (Microsoft documents that Windows 11 includes it, and that many
+Windows 10 machines already have it via Edge). If the window never appears,
+install the runtime from
+<https://developer.microsoft.com/en-us/microsoft-edge/webview2/>.
+
+The build is **unsigned**. Signing is planned (GDK-211); this page does not
+name a date.
+
+Windows may show one of two dialogs. Neither is a virus finding:
+
+- **Microsoft Defender SmartScreen:** **Windows protected your PC**, then
+  **More info** / **Run anyway**. SmartScreen has a per-file override.
+- **Smart App Control:** **Smart App Control blocked an app that may be
+  unsafe.** Microsoft's FAQ says there is currently **no way to bypass
+  Smart App Control for one app**
+  ([Smart App Control FAQ](https://support.microsoft.com/en-us/windows/smart-app-control-frequently-asked-questions-285ea03d-fa88-4d56-882e-6698afdb7003)).
+  Do **not** turn Smart App Control off.
+
+If the desktop exe is blocked, use the CLI path that has been shipping on
+every release: download `gadak_<version>_windows_amd64.zip` (or
+`windows_arm64`) and `checksums.txt` from the same release, unzip, put
+`gadak.exe` on `PATH`, then:
+
+```powershell
+gadak init
+gadak sync
+gadak serve      # http://gadak.localhost:7777
+```
+
+That CLI zip is the reliable Windows route for 0.16. The measured unsigned
+CLI (`gadak.exe`) has run without this block.
+
+[`DESKTOP.md`](DESKTOP.md) has the rest of the window.
+
 ### Install script
 
 ```bash
@@ -109,7 +154,11 @@ Downloads the latest GitHub Release for your OS/arch, verifies `checksums.txt`
 
 Download the archive for your OS/arch from
 [GitHub Releases](https://github.com/midagedev/gadak/releases), verify against
-`checksums.txt`, unpack, and put `gadak` on your `PATH`.
+`checksums.txt`, unpack, and put `gadak` on your `PATH`. Windows CLI archives
+are `gadak_<version>_windows_amd64.zip` and `gadak_<version>_windows_arm64.zip`
+(goreleaser). The desktop pack is a different file —
+`Gadak-<version>-windows-x64.zip` / `windows-arm64` — and is not in
+`checksums.txt` (same as the macOS dmg).
 
 ### Build from source
 
@@ -134,8 +183,9 @@ gadak serve                    # http://gadak.localhost:7777
 
 The first run walks you through it in the browser: paste your site, email, and
 token, pick projects from your site's own list, and watch the first sync fill
-the mirror. (The desktop app runs the same setup in its own window — no
-terminal at any point.) If you would rather stay in the terminal,
+the mirror. (The desktop app — macOS dmg or the Windows portable zip — runs
+the same setup in its own window — no terminal at any point.) If you would
+rather stay in the terminal,
 `gadak init && gadak sync` does the same thing. `gadak serve` keeps the mirror
 fresh in the background whenever a credential is configured (`--no-sync` opts
 out). To survive reboot:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -307,14 +307,14 @@ type-scale sweep that used to sit here was the clearest example of the trap
   notification is the natural surface. Quiet by default: this is a mirror,
   not another thing that interrupts you. Worth doing once someone other than
   the author leaves the app running all day.
-- **Windows and Linux shells** — **not until 10 people have asked.** Wails
-  builds all three and the no-listener architecture ports unchanged, so this
-  is not a technical wall; it is WebView2 bootstrap and an installer on
-  Windows (plus a code-signing decision, or SmartScreen greets every
-  download), webkit2gtk and AppImage/.deb on Linux, and splitting the
-  macOS-only menu code — three platforms of packaging and bug surface for a
-  maintainer whose macOS build has not yet carried a real user. Linux first
-  when the bar is met; it overlaps the agent audience most.
+- **Windows and Linux shells** — 0.16 ships an **unsigned Windows portable
+  zip** (`Gadak-<ver>-windows-x64.zip` / `windows-arm64`) attached by
+  `.github/workflows/desktop-release.yml`. No installer (unsigned MSI/setup
+  is more friction than a zip) and no Authenticode cert (signing is
+  GDK-211). Linux remains held: webkit2gtk and AppImage/.deb, and splitting
+  the macOS-only menu code, for a maintainer whose macOS build has not yet
+  carried a real user. Linux first when the earlier "10 people have asked"
+  bar is met; it overlaps the agent audience most.
 - **Jira-less workspace (a local-only source).** The appeal is real — no
   token, no approval, an agent-readable local tracker; the demo already
   proves the read surface without a live site. But every write path gadak

--- a/docs/STATE_OF_PLAY.md
+++ b/docs/STATE_OF_PLAY.md
@@ -151,6 +151,11 @@ secret scan (T7.4), Docker and the release pipeline (T7.5/T7.6), the MCP server
 - Live-site verification uses a throwaway Atlassian site through a named profile
   (`gadak --profile demo …`). Credentials live outside the repo by construction —
   see [SECURITY.md](../SECURITY.md).
+- From this tree, `.github/workflows/desktop-release.yml` attaches an unsigned
+  Windows portable zip (`Gadak-<ver>-windows-<x64|arm64>.zip`) on `v*` tags,
+  next to the macOS dmg. Signing is GDK-211. The first release that carries
+  the zip is 0.16. `tools/winsmoke.ps1` is the real-machine startup gate;
+  it is not a CI job (`windows-latest` has no interactive desktop).
 
 ## Hard-won knowledge (do not rediscover these)
 

--- a/internal/calendar/calendar.go
+++ b/internal/calendar/calendar.go
@@ -113,10 +113,10 @@ func Day(raw string, kind Kind, z Zone) (string, bool) {
 }
 
 // InRange is an inclusive YYYY-MM-DD compare after Day.
-// An empty raw passes only when from is empty (same as the old inRange).
+// An empty raw fails when any bound is set; with no bounds it still passes.
 func InRange(raw string, kind Kind, from, to string, z Zone) bool {
 	if strings.TrimSpace(raw) == "" {
-		return strings.TrimSpace(from) == ""
+		return strings.TrimSpace(from) == "" && strings.TrimSpace(to) == ""
 	}
 	day, ok := Day(raw, kind, z)
 	if !ok {

--- a/internal/calendar/calendar_test.go
+++ b/internal/calendar/calendar_test.go
@@ -60,8 +60,17 @@ func TestInRangeEmptyRaw(t *testing.T) {
 	if InRange("", Instant, "2026-08-18", "", seoul(t)) {
 		t.Fatal("empty timestamp with a lower bound must fail")
 	}
+	if InRange("", Date, "", "2026-09-01", seoul(t)) {
+		t.Fatal("undated value with only an upper bound must fail")
+	}
+	if InRange("", Instant, "", "2026-09-01", seoul(t)) {
+		t.Fatal("empty timestamp with only an upper bound must fail")
+	}
 	if !InRange("", Instant, "", "", seoul(t)) {
-		t.Fatal("empty timestamp with no lower bound must pass")
+		t.Fatal("empty timestamp with no bounds must pass")
+	}
+	if !InRange("", Date, "", "", seoul(t)) {
+		t.Fatal("undated value with no bounds must pass")
 	}
 }
 

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -17,7 +18,7 @@ import (
 )
 
 // IDs are part of the GET/POST contract. Order of List is fixed:
-// command-line-tool, raycast, skill, mcp-claude.
+// command-line-tool, raycast (omitted on Windows), skill, mcp-claude.
 const (
 	IDCommandLineTool = "command-line-tool"
 	IDRaycast         = "raycast"
@@ -63,18 +64,46 @@ type Item struct {
 	Prerequisite *Prerequisite `json:"prerequisite"`
 }
 
-// List returns the four catalog rows in contract order:
-// command-line-tool, raycast, skill, mcp-claude.
+// List returns the catalog rows for this host's GOOS, in contract order:
+// command-line-tool, raycast (darwin/linux only), skill, mcp-claude.
+// Windows omits raycast — Raycast does not exist there, and a row whose
+// Install button can run would lie (GDK-244).
 func List() []Item {
-	return []Item{commandLineToolItem(), raycastItem(), skillItem(), mcpClaudeItem()}
+	return ListFor(runtime.GOOS)
 }
 
-// InstallArgs is the argv tail for the bundled gadak CLI. ok is false for an unknown id.
+// ListFor is List with an explicit GOOS so the Windows catalog can be
+// pinned on any host (same shape as clitool.ResolveFor).
+func ListFor(goos string) []Item {
+	items := []Item{commandLineToolItem()}
+	if raycastOffered(goos) {
+		items = append(items, raycastItem())
+	}
+	items = append(items, skillItem(), mcpClaudeItem())
+	return items
+}
+
+// raycastOffered is the single owner of "does this OS get a Raycast row".
+// The install endpoint uses the same predicate via InstallArgsFor.
+func raycastOffered(goos string) bool {
+	return goos != "windows"
+}
+
+// InstallArgs is the argv tail for the bundled gadak CLI. ok is false for an
+// unknown id, and for raycast on Windows.
 func InstallArgs(id string) ([]string, bool) {
+	return InstallArgsFor(id, runtime.GOOS)
+}
+
+// InstallArgsFor is InstallArgs with an explicit GOOS.
+func InstallArgsFor(id, goos string) ([]string, bool) {
 	switch id {
 	case IDCommandLineTool:
 		return []string{"install-cli"}, true
 	case IDRaycast:
+		if !raycastOffered(goos) {
+			return nil, false
+		}
 		return []string{"raycast", "install"}, true
 	case IDSkill:
 		return []string{"skill", "install", "claude"}, true
@@ -297,6 +326,10 @@ func isExecutable(path string) bool {
 	fi, err := os.Stat(path)
 	if err != nil || fi.IsDir() {
 		return false
+	}
+	// Windows file modes are not POSIX execute bits; a regular file is enough.
+	if runtime.GOOS == "windows" {
+		return true
 	}
 	return fi.Mode()&0o111 != 0
 }

--- a/internal/integrations/integrations_test.go
+++ b/internal/integrations/integrations_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -296,4 +297,65 @@ func TestLookPathDefaultIsExecLookPath(t *testing.T) {
 		t.Fatal("lookPath is nil")
 	}
 	_, _ = exec.LookPath("true")
+}
+
+// Raycast does not exist on Windows. The catalog must not offer a row whose
+// Install button can run (GDK-244). ListFor is the GOOS seam so this pins
+// the Windows catalog on a Linux/macOS CI host.
+func TestListForWindowsOmitsRaycast(t *testing.T) {
+	items := ListFor("windows")
+	ids := make([]string, len(items))
+	for i, it := range items {
+		ids[i] = it.ID
+		if it.ID == IDRaycast {
+			t.Fatalf("windows catalog must not include raycast: %+v", it)
+		}
+	}
+	want := []string{IDCommandLineTool, IDSkill, IDMCPClaude}
+	if len(ids) != len(want) {
+		t.Fatalf("windows ids=%v want %v", ids, want)
+	}
+	for i, id := range want {
+		if ids[i] != id {
+			t.Fatalf("windows ids=%v want %v", ids, want)
+		}
+	}
+}
+
+func TestListForDarwinKeepsRaycast(t *testing.T) {
+	items := ListFor("darwin")
+	if len(items) != 4 {
+		t.Fatalf("darwin len=%d want 4", len(items))
+	}
+	if items[1].ID != IDRaycast {
+		t.Fatalf("darwin order %v", []string{items[0].ID, items[1].ID, items[2].ID, items[3].ID})
+	}
+}
+
+func TestInstallArgsForWindowsRejectsRaycast(t *testing.T) {
+	if args, ok := InstallArgsFor(IDRaycast, "windows"); ok {
+		t.Fatalf("windows must not install raycast, args=%v", args)
+	}
+	if _, ok := InstallArgsFor(IDSkill, "windows"); !ok {
+		t.Fatal("skill must still be installable on windows")
+	}
+	if _, ok := InstallArgsFor(IDCommandLineTool, "windows"); !ok {
+		t.Fatal("command-line-tool must still be installable on windows")
+	}
+	if _, ok := InstallArgsFor(IDRaycast, "darwin"); !ok {
+		t.Fatal("darwin must still install raycast")
+	}
+}
+
+func TestListMatchesListForThisGOOS(t *testing.T) {
+	got := List()
+	want := ListFor(runtime.GOOS)
+	if len(got) != len(want) {
+		t.Fatalf("List len=%d ListFor(%s) len=%d", len(got), runtime.GOOS, len(want))
+	}
+	for i := range got {
+		if got[i].ID != want[i].ID {
+			t.Fatalf("List[%d]=%q ListFor=%q", i, got[i].ID, want[i].ID)
+		}
+	}
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -144,6 +144,26 @@ no file is written.
 `.github/workflows/stats.yml` runs this weekly (Monday 06:00 UTC) and on
 `workflow_dispatch`, and commits `stats/<stamp>.json` on the `stats` branch.
 
+## `winsmoke.ps1`
+
+Manual / real-machine Windows startup gate (GDK-244). **Not a CI job** —
+GitHub `windows-latest` has no interactive desktop, so a capture there is
+black. Run it on a real Windows session (or `schtasks /create /it`).
+
+Launches `gadak-desktop.exe` from a portable pack directory, waits for the
+window, records hwnd/rect/style, counts WebView2 children, captures the
+screen, asserts it is not black, closes the app, and checks `GADAK_HOME`
+did not touch `%USERPROFILE%\.gadak`. Exit 0 / 1 / 64 / 69. The app has no
+TCP listener by design; "no port open" is a pass.
+
+The file is UTF-8 **with BOM** (Windows PowerShell 5.1 otherwise reads it
+as the system ANSI page).
+
+```powershell
+# After desktop/build-windows.ps1 has written the portable directory:
+tools/winsmoke.ps1 -BundleDir desktop\\build\\Gadak-<ver>-x64 -OutDir $env:TEMP\\gadak-winsmoke\\out
+```
+
 Per-release cumulative downloads:
 
 ```bash

--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -271,4 +271,44 @@ if [[ -n "$rule_table_hits" ]]; then
 fi
 ok "derived-field rule table lives only in docs/DERIVE.md"
 
+# ── 13. Windows install exists; never tell a user to turn SAC off ────────
+# GDK-244/245: 0.16 ships an unsigned Windows desktop zip. README used to
+# say "CLI only (macOS + Linux)" and "the macOS app" as if that were the
+# only window. A check that only pins the version (check 6) would stay
+# green while those sentences came back. The SAC rule is sharper: Microsoft
+# documents no per-app override, and this project must not offer "turn
+# Smart App Control off" as a workaround (once offered, someone will).
+win_zip_missing=""
+for f in README.md README.ko.md docs/INSTALL.md docs/DESKTOP.md; do
+  grep -q 'windows-x64' "$f" || win_zip_missing+="  $f: no windows-x64 asset name"$'\n'
+done
+if [[ -n "$win_zip_missing" ]]; then
+  fail "Windows desktop zip is not named in the install docs (GDK-245):"$'\n'"$win_zip_missing"
+fi
+if ! grep -q 'Smart App Control' docs/INSTALL.md; then
+  fail "docs/INSTALL.md does not name Smart App Control (GDK-245)"
+fi
+if ! grep -q 'GDK-211' docs/INSTALL.md; then
+  fail "docs/INSTALL.md does not name GDK-211 (signing planned, no date)"
+fi
+sac_off="$(
+  grep -nEi 'turn(ing)?[[:space:]]+((smart[[:space:]]+app[[:space:]]+control)|SAC)[[:space:]]+off|disable[[:space:]]+((smart[[:space:]]+app[[:space:]]+control)|SAC)|스마트[[:space:]]*앱[[:space:]]*제어를[[:space:]]*끄' \
+    README.md README.ko.md docs/INSTALL.md docs/DESKTOP.md \
+    || true
+)"
+# The docs must mention the prohibition. A line that says "Do not turn …
+# off" is the contract; a line that tells the user to turn it off is not.
+# Fail only when an imperative/how-to (turn/disable) is not a prohibition.
+if [[ -n "$sac_off" ]]; then
+  bad_off=""
+  while IFS= read -r line; do
+    echo "$line" | grep -Eiq 'do[[:space:]]*(\*\*)?not|don'\''t|never|끄지 마' && continue
+    bad_off+="  $line"$'\n'
+  done <<< "$sac_off"
+  if [[ -n "$bad_off" ]]; then
+    fail "install docs tell the user to turn Smart App Control off:"$'\n'"$bad_off"
+  fi
+fi
+ok "Windows desktop zip is documented; SAC-off is not offered"
+
 echo "doc-checks: all passed"

--- a/tools/winsmoke.ps1
+++ b/tools/winsmoke.ps1
@@ -1,0 +1,451 @@
+﻿# gadak Windows startup smoke (GDK-244) — manual / real-machine gate.
+#
+# Launch gadak-desktop.exe in an *interactive* desktop session, measure the
+# window, capture the screen, assert eleven conditions, write JSON.
+#
+# THIS IS NOT A CI GATE. GitHub's windows-latest runner has no interactive
+# desktop session; CopyFromScreen there is a black frame and the harness
+# would fail for the wrong reason. An earlier round had to bridge a real
+# host with `schtasks /create /it` + `/run` because an ssh session is
+# session 0 and cannot show this window (SAC also blocked the binary
+# there — see the run's smoke.json ci_events). Do not add this script to
+# .github/workflows as a required job.
+#
+# What it asserts (eleven; a false value is exit 1):
+#   chrome_probe_native, app_started, window_appeared,
+#   style_ws_caption, style_ws_thickframe, style_ws_sysmenu,
+#   capture_fullscreen_png, capture_window_png, capture_not_black,
+#   closed_clean, dotgadak_untouched
+# It records msedgewebview2 child count and TCP listeners; it does not
+# fail the run on either. A missing WebView2 runtime is being fixed in a
+# parallel round — do not assert the old silent-exit behaviour here.
+#
+# Two facts that are easy to lose:
+#   1. The app has no TCP listener by design (desktop/main.go: the Wails
+#      asset server calls server.Handler in-process). "No port open" is a
+#      pass, not a failure. Fetches against anything found are kept so a
+#      future listener would be exercised.
+#   2. GADAK_HOME is a temporary directory. This script refuses to point
+#      it at the user's real ~/.gadak (never %USERPROFILE%\.gadak).
+#
+# Encoding: this file MUST keep a UTF-8 BOM. Windows PowerShell 5.1 reads
+# a BOM-less file as the system ANSI code page (949 on a Korean host) and
+# then the script is garbage.
+#
+# Designed to be scheduled via: schtasks /create /it + /run.
+#
+# Exit codes: 0 all assertions passed
+#             1 assertion failure (incl. "app never started / never showed a window")
+#             64 usage (bad parameter values, or GadakHome is ~/.gadak)
+#             69 required tool or input missing (exe, System.Drawing)
+#
+
+param(
+    [string]$BundleDir  = (Join-Path $env:TEMP 'gadak-winsmoke\bundle'),
+    [string]$OutDir     = (Join-Path $env:TEMP 'gadak-winsmoke\out'),
+    [string]$GadakHome  = (Join-Path $env:TEMP 'gadak-winsmoke\home'),
+    [int]$WindowWaitSeconds = 60
+)
+
+$ErrorActionPreference = 'Continue'
+$script:Assertions = [ordered]@{}
+$script:Smoke = [ordered]@{}
+$script:LogPath = $null
+
+function Write-Log([string]$line) {
+    if ($script:LogPath) {
+        Add-Content -Path $script:LogPath -Value ("{0} {1}" -f (Get-Date).ToString('u'), $line) -Encoding UTF8
+    }
+    Write-Output $line
+}
+
+function Save-SmokeJson() {
+    $script:Smoke['assertions'] = $script:Assertions
+    $script:Smoke['finished_at'] = (Get-Date).ToString('u')
+    $tmp = Join-Path $OutDir 'smoke.json.tmp'
+    $script:Smoke | ConvertTo-Json -Depth 7 | Out-File -FilePath $tmp -Encoding utf8
+    Move-Item -Path $tmp -Destination (Join-Path $OutDir 'smoke.json') -Force
+}
+
+# --- usage / tool checks -----------------------------------------------------
+if ([string]::IsNullOrWhiteSpace($BundleDir) -or [string]::IsNullOrWhiteSpace($OutDir) -or
+    [string]::IsNullOrWhiteSpace($GadakHome) -or $WindowWaitSeconds -le 0) {
+    Write-Output 'usage: winsmoke.ps1 [-BundleDir <dir>] [-OutDir <dir>] [-GadakHome <dir>] [-WindowWaitSeconds <n>]'
+    exit 64
+}
+# Isolation: never the user's real profile. GADAK_HOME must be a temp dir.
+$realGadak = [System.IO.Path]::GetFullPath((Join-Path $env:USERPROFILE '.gadak'))
+try {
+    $homeFull = [System.IO.Path]::GetFullPath($GadakHome)
+} catch {
+    Write-Output ("usage: GadakHome is not a usable path: {0}" -f $GadakHome)
+    exit 64
+}
+$sep = [IO.Path]::DirectorySeparatorChar
+if ($homeFull -eq $realGadak -or $homeFull.StartsWith($realGadak + $sep, [System.StringComparison]::OrdinalIgnoreCase)) {
+    Write-Output ("REFUSING: GadakHome must not be the real ~/.gadak ({0})" -f $realGadak)
+    exit 64
+}
+
+$DesktopExe = Join-Path $BundleDir 'gadak-desktop.exe'
+$CliExe     = Join-Path $BundleDir 'gadak.exe'
+foreach ($f in @($DesktopExe, $CliExe)) {
+    if (-not (Test-Path $f)) { Write-Output "MISSING INPUT: $f"; exit 69 }
+}
+try {
+    Add-Type -AssemblyName System.Drawing
+    Add-Type -AssemblyName System.Windows.Forms
+} catch {
+    Write-Output ("MISSING TOOL: System.Drawing/Forms: {0}" -f $_.Exception.Message)
+    exit 69
+}
+
+if (-not (Test-Path $OutDir))  { New-Item -ItemType Directory -Path $OutDir  -Force | Out-Null }
+if (-not (Test-Path $GadakHome)) { New-Item -ItemType Directory -Path $GadakHome -Force | Out-Null }
+$script:LogPath = Join-Path $OutDir 'smoke.log'
+if (Test-Path $script:LogPath) { Remove-Item $script:LogPath -Force }
+if (Test-Path (Join-Path $OutDir 'done.flag')) { Remove-Item (Join-Path $OutDir 'done.flag') -Force }
+
+try { Start-Transcript -Path (Join-Path $OutDir 'transcript.log') -Force | Out-Null } catch {}
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public struct RECT { public int Left, Top, Right, Bottom; }
+public struct PT   { public int X, Y; }
+public class Win32Smoke {
+    [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr h, out RECT r);
+    [DllImport("user32.dll")] public static extern bool ClientToScreen(IntPtr h, ref PT p);
+    [DllImport("user32.dll")] public static extern int  GetWindowLong(IntPtr h, int i);
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+}
+"@
+
+$exitCode = 0
+$proc = $null
+$hwnd = [IntPtr]::Zero
+
+try {
+    Write-Log ("winsmoke start pid={0} user={1} session={2}" -f $PID, $env:USERNAME, (Get-Process -Id $PID).SessionId)
+    $script:Smoke['started_at']   = (Get-Date).ToString('u')
+    $script:Smoke['computer']     = $env:COMPUTERNAME
+    $script:Smoke['os']           = [Environment]::OSVersion.VersionString
+    $script:Smoke['psversion']    = $PSVersionTable.PSVersion.ToString()
+    $script:Smoke['bundle_dir']   = $BundleDir
+    $script:Smoke['gadak_home']   = $GadakHome
+    $script:Smoke['desktop_exe']  = $DesktopExe
+    $script:Smoke['desktop_exe_bytes'] = (Get-Item $DesktopExe).Length
+    $wv2 = Get-ItemProperty -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' -ErrorAction SilentlyContinue
+    $script:Smoke['webview2_pv']  = $wv2.pv
+    $sac = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy' -ErrorAction SilentlyContinue
+    $script:Smoke['sac_state']    = $sac.VerifiedAndReputablePolicyState   # 0=off 1=enforce 2=eval
+    $script:Smoke['dotgadak_before'] = Test-Path $realGadak
+    if ($script:Smoke['dotgadak_before']) {
+        $script:Smoke['dotgadak_before_snap'] = @(Get-ChildItem $realGadak -Recurse -File -ErrorAction SilentlyContinue |
+            ForEach-Object { "{0}|{1}" -f $_.FullName.Substring($realGadak.Length), $_.Length } |
+            Sort-Object)
+    } else {
+        $script:Smoke['dotgadak_before_snap'] = @()
+    }
+
+    # existing instances must not confuse the run
+    $pre = Get-Process -Name 'gadak-desktop' -ErrorAction SilentlyContinue
+    $script:Smoke['preexisting_gadak_desktop'] = @($pre).Count
+
+    # --- chrome probe (same process start path as the app itself) ------------
+    Write-Log 'stage: chrome-probe'
+    $env:GADAK_HOME = $GadakHome
+    $env:GADAK_PROFILE = $null
+    $probeOut = ''
+    $probeRc = $null
+    try {
+        $probeOut = (& $DesktopExe '--print-window-chrome' 2>&1) -join "`n"
+        $probeRc = $LASTEXITCODE
+    } catch {
+        $probeOut = ("EXCEPTION: {0}" -f $_.Exception.Message)
+        if ($_.Exception.InnerException) { $probeOut += (" | inner: {0}" -f $_.Exception.InnerException.Message) }
+    }
+    $script:Smoke['chrome_probe'] = @{ stdout = $probeOut; exitcode = $probeRc }
+    $script:Assertions['chrome_probe_native'] = ($probeOut -match 'window_chrome=native')
+    Write-Log ("chrome probe: rc={0} out=<{1}>" -f $probeRc, $probeOut)
+
+    # --- CLI version probe ----------------------------------------------------
+    $cliOut = (& $CliExe version 2>&1) -join "`n"
+    $script:Smoke['cli_version'] = @{ stdout = $cliOut; exitcode = $LASTEXITCODE }
+
+    # --- launch the app -------------------------------------------------------
+    Write-Log 'stage: launch'
+    $si = New-Object System.Diagnostics.ProcessStartInfo
+    $si.FileName = $DesktopExe
+    $si.WorkingDirectory = $BundleDir
+    $si.UseShellExecute = $false
+    $si.CreateNoWindow = $true
+    $si.EnvironmentVariables['GADAK_HOME'] = $GadakHome
+    if ($si.EnvironmentVariables.ContainsKey('GADAK_PROFILE')) { $si.EnvironmentVariables.Remove('GADAK_PROFILE') | Out-Null }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $proc = [System.Diagnostics.Process]::Start($si)
+        Write-Log ("app started pid={0}" -f $proc.Id)
+        $script:Assertions['app_started'] = $true
+    } catch {
+        $msg = $_.Exception.Message
+        $inner = ''
+        $native = $null
+        if ($_.Exception.InnerException) {
+            $inner = $_.Exception.InnerException.Message
+            if ($_.Exception.InnerException.NativeErrorCode) { $native = $_.Exception.InnerException.NativeErrorCode }
+        }
+        Write-Log ("app START FAILED: {0} | inner: {1} | native: {2}" -f $msg, $inner, $native)
+        $script:Smoke['launch_failure'] = @{ message = $msg; inner = $inner; native_error = $native }
+        $script:Assertions['app_started'] = $false
+        $exitCode = 1
+    }
+
+    # --- wait for the window --------------------------------------------------
+    if ($proc) {
+        Write-Log 'stage: wait-window'
+        $windowMs = $null
+        while ($sw.ElapsedMilliseconds -lt ($WindowWaitSeconds * 1000)) {
+            Start-Sleep -Milliseconds 500
+            $proc.Refresh()
+            if ($proc.HasExited) { break }
+            if ($proc.MainWindowHandle -ne [IntPtr]::Zero) { $windowMs = $sw.ElapsedMilliseconds; break }
+        }
+        $proc.Refresh()
+        if ($proc.HasExited) {
+            Write-Log ("app EXITED early code={0} after {1}ms" -f $proc.ExitCode, $sw.ElapsedMilliseconds)
+            $script:Smoke['early_exit'] = @{ exitcode = $proc.ExitCode; after_ms = $sw.ElapsedMilliseconds }
+            $script:Assertions['window_appeared'] = $false
+            $exitCode = 1
+        } elseif ($null -ne $windowMs) {
+            $hwnd = $proc.MainWindowHandle
+            Write-Log ("window appeared after {0}ms hwnd=0x{1:X}" -f $windowMs, [int64]$hwnd)
+            $script:Smoke['window_appear_ms'] = $windowMs
+            $script:Assertions['window_appeared'] = $true
+        } else {
+            Write-Log ("window DID NOT appear within {0}s (process alive)" -f $WindowWaitSeconds)
+            $script:Assertions['window_appeared'] = $false
+            $exitCode = 1
+        }
+        $script:Smoke['process_alive_at_measure'] = -not $proc.HasExited
+    }
+
+    # --- window metrics -------------------------------------------------------
+    if ($hwnd -ne [IntPtr]::Zero) {
+        Write-Log 'stage: window-metrics'
+        $r = New-Object RECT
+        [void][Win32Smoke]::GetWindowRect($hwnd, [ref]$r)
+        $c = New-Object RECT
+        [void][Win32Smoke]::GetClientRect($hwnd, [ref]$c)
+        $pt = New-Object PT
+        $pt.X = 0; $pt.Y = 0
+        [void][Win32Smoke]::ClientToScreen($hwnd, [ref]$pt)
+        $style   = [Win32Smoke]::GetWindowLong($hwnd, -16)
+        $exstyle = [Win32Smoke]::GetWindowLong($hwnd, -20)
+        $script:Smoke['window'] = [ordered]@{
+            title          = $proc.MainWindowTitle
+            hwnd           = ('0x{0:X}' -f [int64]$hwnd)
+            rect           = "L=$($r.Left) T=$($r.Top) R=$($r.Right) B=$($r.Bottom) W=$($r.Right-$r.Left) H=$($r.Bottom-$r.Top)"
+            client         = "origin=$($pt.X),$($pt.Y) W=$($c.Right) H=$($c.Bottom)"
+            style_hex      = ('0x{0:X8}' -f $style)
+            exstyle_hex    = ('0x{0:X8}' -f $exstyle)
+            ws_caption     = [bool]($style -band 0x00C00000)
+            ws_thickframe  = [bool]($style -band 0x00040000)
+            ws_sysmenu     = [bool]($style -band 0x00080000)
+        }
+        Write-Log ("window: {0}" -f ($script:Smoke['window'] | ConvertTo-Json -Compress))
+        # contract: Windows chrome is 'native' -> standard caption bits present
+        $script:Assertions['style_ws_caption']    = [bool]($style -band 0x00C00000)
+        $script:Assertions['style_ws_thickframe'] = [bool]($style -band 0x00040000)
+        $script:Assertions['style_ws_sysmenu']    = [bool]($style -band 0x00080000)
+        if (-not ($script:Assertions['style_ws_caption'] -and $script:Assertions['style_ws_thickframe'] -and $script:Assertions['style_ws_sysmenu'])) { $exitCode = 1 }
+    }
+
+    # --- webview children + port census + (any) loopback fetch ----------------
+    $appPid = 0
+    if ($proc) { $appPid = $proc.Id }
+    $desc = @()
+    # OrderedDictionary in Windows PowerShell 5.1 has Contains, not ContainsKey.
+    if ($appPid -gt 0 -and -not $script:Smoke.Contains('early_exit')) {
+        Write-Log 'stage: descendants'
+        $all = Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name
+        $children = @{}
+        foreach ($p in $all) {
+            if (-not $children.ContainsKey([uint32]$p.ParentProcessId)) { $children[[uint32]$p.ParentProcessId] = @() }
+            $children[[uint32]$p.ParentProcessId] += $p
+        }
+        $frontier = @($appPid)
+        while ($frontier.Count -gt 0) {
+            $next = @()
+            foreach ($f in $frontier) {
+                if ($children.ContainsKey([uint32]$f)) {
+                    foreach ($ch in $children[[uint32]$f]) {
+                        if ($desc -notcontains $ch.ProcessId) { $desc += $ch.ProcessId; $next += $ch.ProcessId }
+                    }
+                }
+            }
+            $frontier = $next
+        }
+        $wvKids = @($all | Where-Object { $desc -contains $_.ProcessId -and $_.Name -eq 'msedgewebview2.exe' })
+        $script:Smoke['msedgewebview2_children'] = $wvKids.Count
+        Write-Log ("descendants: {0} total, {1} msedgewebview2" -f $desc.Count, $wvKids.Count)
+    }
+
+    Write-Log 'stage: port-census'
+    $listeners = @()
+    if ($desc.Count -gt 0 -or $appPid -gt 0) {
+        $watch = @($appPid) + @($desc)
+        $listeners = @(Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | Where-Object { $watch -contains $_.OwningProcess })
+    }
+    $script:Smoke['tcp_listeners'] = @($listeners | ForEach-Object {
+        "port=$($_.LocalPort) addr=$($_.LocalAddress) pid=$($_.OwningProcess)"
+    })
+    Write-Log ("listeners: {0}" -f ($script:Smoke['tcp_listeners'] -join '; '))
+    $fetches = @()
+    foreach ($l in ($listeners | Where-Object { $_.LocalAddress -in @('127.0.0.1','0.0.0.0','::1','::') } | Select-Object -First 5)) {
+        foreach ($path in @('/config.json', '/')) {
+            $rec = $null
+            try {
+                $resp = Invoke-WebRequest -Uri ("http://127.0.0.1:{0}{1}" -f $l.LocalPort, $path) -UseBasicParsing -TimeoutSec 3
+                $body = $resp.Content
+                $rec = @{ url = "/:{0}{1}" -f $l.LocalPort, $path; status = [int]$resp.StatusCode; has_windowChrome = ($body -match 'windowChrome') }
+            } catch {
+                $rec = @{ url = "/:{0}{1}" -f $l.LocalPort, $path; error = $_.Exception.Message }
+            }
+            $fetches += $rec
+        }
+    }
+    $script:Smoke['loopback_fetch'] = @($fetches)
+    $script:Smoke['loopback_note'] = 'desktop/main.go: no TCP listener by design (wails v3 serves the webview in-process). No port open is a pass. Census records the measured absence.'
+
+    # --- captures -------------------------------------------------------------
+    if ($hwnd -ne [IntPtr]::Zero) {
+        Write-Log 'stage: capture'
+        [void][Win32Smoke]::SetProcessDPIAware()
+        [void][Win32Smoke]::SetForegroundWindow($hwnd)
+        Start-Sleep -Milliseconds 1200
+        $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+        $script:Smoke['screen_bounds'] = "$($bounds.Width)x$($bounds.Height)"
+
+        function Get-BmpStats($bmp) {
+            $min = 255; $max = 0; [long]$sum = 0; [long]$n = 0
+            $sx = [Math]::Max(1, [int]($bmp.Width / 64)); $sy = [Math]::Max(1, [int]($bmp.Height / 64))
+            for ($x = 0; $x -lt $bmp.Width; $x += $sx) {
+                for ($y = 0; $y -lt $bmp.Height; $y += $sy) {
+                    $px = $bmp.GetPixel($x, $y)
+                    $l = [int](($px.R + $px.G + $px.B) / 3)
+                    if ($l -lt $min) { $min = $l }; if ($l -gt $max) { $max = $l }
+                    $sum += $l; $n++
+                }
+            }
+            return @{ min = $min; max = $max; mean = [Math]::Round($sum / [double]$n, 2); samples = $n }
+        }
+
+        $bmpFull = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+        $g = [System.Drawing.Graphics]::FromImage($bmpFull)
+        $g.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+        $g.Dispose()
+        $bmpFull.Save((Join-Path $OutDir 'fullscreen.png'), [System.Drawing.Imaging.ImageFormat]::Png)
+        $script:Smoke['fullscreen_stats'] = Get-BmpStats $bmpFull
+        $bmpFull.Dispose()
+
+        $r2 = New-Object RECT
+        [void][Win32Smoke]::GetWindowRect($hwnd, [ref]$r2)
+        $wx = [Math]::Max(0, $r2.Left); $wy = [Math]::Max(0, $r2.Top)
+        $ww = [Math]::Min($r2.Right, $bounds.Width) - $wx
+        $wh = [Math]::Min($r2.Bottom, $bounds.Height) - $wy
+        if ($ww -gt 0 -and $wh -gt 0) {
+            $bmpWin = New-Object System.Drawing.Bitmap $ww, $wh
+            $g2 = [System.Drawing.Graphics]::FromImage($bmpWin)
+            $g2.CopyFromScreen($wx, $wy, 0, 0, (New-Object System.Drawing.Size $ww, $wh))
+            $g2.Dispose()
+            $bmpWin.Save((Join-Path $OutDir 'window.png'), [System.Drawing.Imaging.ImageFormat]::Png)
+            $script:Smoke['window_capture'] = "origin=$wx,$wy size=${ww}x${wh}"
+            $script:Smoke['window_stats'] = Get-BmpStats $bmpWin
+            $bmpWin.Dispose()
+        }
+        foreach ($f in @('fullscreen.png', 'window.png')) {
+            $p = Join-Path $OutDir $f
+            $script:Assertions[("capture_" + $f.Replace('.', '_'))] = ((Test-Path $p) -and ((Get-Item $p).Length -gt 0))
+        }
+        $notBlack = ($script:Smoke['fullscreen_stats'].max -gt 0)
+        $script:Assertions['capture_not_black'] = [bool]$notBlack
+        if (-not $notBlack) { $exitCode = 1 }
+        Write-Log ("captures: fullscreen stats={0} window stats={1}" -f ($script:Smoke['fullscreen_stats'] | ConvertTo-Json -Compress), ($script:Smoke['window_stats'] | ConvertTo-Json -Compress))
+    } else {
+        Write-Log 'stage: capture SKIPPED (no window handle; a desktop photo without the app has no evidentiary value)'
+        $script:Assertions['capture_fullscreen_png'] = $false
+        $script:Assertions['capture_window_png'] = $false
+    }
+
+    # --- shutdown -------------------------------------------------------------
+    if ($proc -and -not $proc.HasExited) {
+        Write-Log 'stage: shutdown'
+        $closed = $proc.CloseMainWindow()
+        $proc.WaitForExit(10000) | Out-Null
+        $proc.Refresh()
+        $neededKill = $false
+        if (-not $proc.HasExited) {
+            $neededKill = $true
+            $proc.Kill()
+            $proc.WaitForExit(5000) | Out-Null
+        }
+        $script:Smoke['shutdown'] = @{ close_main_window = $closed; kill_needed = $neededKill; exitcode = $proc.ExitCode }
+        Write-Log ("shutdown: close={0} kill={1} exit={2}" -f $closed, $neededKill, $proc.ExitCode)
+        $script:Assertions['closed_clean'] = (-not $neededKill)
+        Start-Sleep -Seconds 4
+        # orphaned descendants (ancestry-scoped, never by name)
+        foreach ($d in $desc) {
+            $dp = Get-Process -Id $d -ErrorAction SilentlyContinue
+            if ($dp) { Stop-Process -Id $d -Force -ErrorAction SilentlyContinue; Write-Log ("orphan cleanup: killed pid {0}" -f $d) }
+        }
+    }
+
+    # --- footprint ------------------------------------------------------------
+    Write-Log 'stage: footprint'
+    $script:Smoke['gadak_home_tree'] = @(Get-ChildItem $GadakHome -Recurse -File -ErrorAction SilentlyContinue | ForEach-Object { "{0} ({1} bytes)" -f $_.FullName.Replace($GadakHome, '<home>'), $_.Length })
+    $script:Smoke['dotgadak_after'] = Test-Path $realGadak
+    function Get-DotGadakSnapshot([string]$path) {
+        if (-not (Test-Path $path)) { return @() }
+        return @(Get-ChildItem $path -Recurse -File -ErrorAction SilentlyContinue |
+            ForEach-Object { "{0}|{1}" -f $_.FullName.Substring($path.Length), $_.Length } |
+            Sort-Object)
+    }
+    if (-not $script:Smoke['dotgadak_before']) {
+        $script:Assertions['dotgadak_untouched'] = (-not $script:Smoke['dotgadak_after'])
+    } else {
+        $afterSnap = Get-DotGadakSnapshot $realGadak
+        $beforeSnap = $script:Smoke['dotgadak_before_snap']
+        $script:Assertions['dotgadak_untouched'] = $null -eq (Compare-Object -ReferenceObject @($beforeSnap) -DifferenceObject @($afterSnap))
+    }
+    $wvdir = Join-Path $env:APPDATA 'gadak-desktop.exe'
+    if (Test-Path $wvdir) {
+        $files = Get-ChildItem $wvdir -Recurse -File -ErrorAction SilentlyContinue
+        $script:Smoke['webview2_userdata'] = @{ path = $wvdir; files = $files.Count; bytes = ($files | Measure-Object Length -Sum).Sum }
+    } else { $script:Smoke['webview2_userdata'] = 'absent' }
+
+    # --- code-integrity events of this run (SAC evidence) ---------------------
+    try {
+        $since = (Get-Date).AddMinutes(-5)
+        $ci = Get-WinEvent -LogName 'Microsoft-Windows-CodeIntegrity/Operational' -MaxEvents 60 -ErrorAction Stop |
+              Where-Object { $_.TimeCreated -ge $since -and $_.Message -match 'gadak' }
+        $script:Smoke['ci_events'] = @($ci | ForEach-Object { "id=$($_.Id) time=$($_.TimeCreated.ToString('u')) :: $($_.Message.Substring(0, [Math]::Min(300, $_.Message.Length)))" })
+        Write-Log ("codeintegrity gadak events in window: {0}" -f @($ci).Count)
+    } catch { $script:Smoke['ci_events'] = "unavailable: $($_.Exception.Message)" }
+
+    # --- verdict --------------------------------------------------------------
+    $failed = @($script:Assertions.GetEnumerator() | Where-Object { -not $_.Value })
+    if ($failed.Count -gt 0) { $exitCode = 1 }
+    Write-Log ("verdict: {0}" -f (($script:Assertions.GetEnumerator() | ForEach-Object { "{0}={1}" -f $_.Key, $_.Value }) -join ' '))
+} catch {
+    Write-Log ("UNEXPECTED ERROR: {0}" -f $_.Exception.ToString())
+    $exitCode = 1
+} finally {
+    Save-SmokeJson
+    try { Stop-Transcript | Out-Null } catch {}
+    Set-Content -Path (Join-Path $OutDir 'done.flag') -Value ("exit={0}" -f $exitCode)
+    Write-Output ("WINSMOKE EXIT {0}" -f $exitCode)
+}
+exit $exitCode

--- a/web/src/components/list/FilterBar.svelte
+++ b/web/src/components/list/FilterBar.svelte
@@ -167,7 +167,7 @@
       title={t('filter.remove')}
       class:order-last={chip.kind === 'range'}
     >
-      <span class="truncate max-w-[180px]">{chip.label}</span>
+      <span class="truncate {chip.kind === 'range' ? 'max-w-[220px]' : 'max-w-[180px]'}">{chip.label}</span>
       <Icon name="x" size={12} class="text-text-muted transition-colors group-hover:text-status-reopen" />
     </button>
   {/each}

--- a/web/src/components/write/NewIssueDialog.svelte
+++ b/web/src/components/write/NewIssueDialog.svelte
@@ -380,7 +380,7 @@
         </div>
 
         <label class="flex flex-col gap-1">
-          <span class="text-micro text-text-secondary">duedate</span>
+          <span class="text-micro text-text-secondary">{t('common.due')}</span>
           <input
             bind:value={duedate}
             type="date"

--- a/web/src/lib/calendar.test.ts
+++ b/web/src/lib/calendar.test.ts
@@ -39,9 +39,13 @@ describe('calendar owner (aligned with internal/calendar)', () => {
     expect(laDay).toBe('2026-08-19')
   })
 
-  test('empty raw: pass only when there is no lower bound', () => {
+  test('empty raw: pass only when no bound is set', () => {
     expect(inRange(null, 'instant', '2026-08-18', null, seoul)).toBe(false)
     expect(inRange(null, 'instant', null, null, seoul)).toBe(true)
+    expect(inRange(null, 'date', null, '2026-09-01', seoul)).toBe(false)
+    expect(inRange('', 'date', null, '2026-09-01', seoul)).toBe(false)
+    expect(inRange(null, 'date', null, null, seoul)).toBe(true)
+    expect(inRange(null, 'date', '2026-08-18', null, seoul)).toBe(false)
   })
 
   test('explain reports the decision', () => {

--- a/web/src/lib/calendar.ts
+++ b/web/src/lib/calendar.ts
@@ -78,7 +78,7 @@ export function calendarDay(
 
 /**
  * Inclusive YYYY-MM-DD compare after calendarDay.
- * Empty raw passes only when from is unset (same as the old inRange).
+ * Empty raw fails when any bound is set; with no bounds it still passes.
  */
 export function inRange(
   raw: string | null | undefined,
@@ -87,7 +87,7 @@ export function inRange(
   to: string | null | undefined,
   zone: CalendarZone = localZone(),
 ): boolean {
-  if (!raw) return !from
+  if (!raw) return !from && !to
   const day = calendarDay(raw, kind, zone)
   if (!day) return false
   if (from && day < from) return false

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -55,6 +55,7 @@ export const en = {
   'common.project': 'Project',
   'common.title': 'Title',
   'common.description': 'Description',
+  'common.due': 'Due date',
   'common.group': 'Group',
   'common.detail': 'Details',
   'common.feed': 'Feed',

--- a/web/src/lib/i18n/ko.ts
+++ b/web/src/lib/i18n/ko.ts
@@ -56,6 +56,7 @@ export const ko = {
   'common.project': '프로젝트',
   'common.title': '제목',
   'common.description': '설명',
+  'common.due': '기한',
   'common.group': '그룹',
   'common.detail': '상세',
   'common.feed': '피드',

--- a/web/src/lib/integrations.ts
+++ b/web/src/lib/integrations.ts
@@ -66,8 +66,9 @@ function normalizePrerequisite(v: unknown): IntegrationPrerequisite | null {
 /**
  * `GET /desktop/integrations` body → items, in the order the server sent them.
  *
- * The order is the server's (raycast, skill, mcp-claude): it is the reading
- * order of the setup, so the UI must not re-sort it. Anything unusable is
+ * The order is the server's (command-line-tool, then raycast when the host
+ * offers it, skill, mcp-claude): it is the reading order of the setup, so
+ * the UI must not re-sort it. Windows omits raycast. Anything unusable is
  * dropped rather than drawn as a nameless card.
  */
 export function normalizeIntegrations(body: unknown): IntegrationItem[] {


### PR DESCRIPTION
Three commits: the Windows app becomes downloadable and honest (GDK-244,
GDK-245), and the date round's follow-ups land (GDK-253).

Scope decision (user, 2026-08-18): **0.16 makes Windows usable; signing is
deferred.** GDK-211 stays open, and nothing here assumes a certificate.

## Why Windows was not usable

The app has been building green in CI for a while and **nothing ever shipped
it** — `desktop-release.yml` had one job, `macos-14`, which built the dmg and
attached it. Meanwhile the README told users the CLI was "macOS + Linux",
which has not been true for releases, and the reporter of #5 is on Windows 11.

And the app that did build answered as if it were on a Mac:

- **The integrations catalog offered Raycast**, which does not exist on
  Windows. Its only prerequisite check is "is npm on PATH" — which can be
  true there — so the install button looked *ready*.
- **`gadak views open` could not reach the running app**: `focusDesktopApp`
  returned false on anything but darwin, so the CLI→app handoff did not exist.
- **A missing WebView2 runtime killed the app silently** — `os.Exit(1)`, no
  dialog. To a user that is "I double-clicked and nothing happened".

## What changed

`raycastOffered(goos)` is the single owner of the Raycast question, used by
both `ListFor` and `InstallArgsFor` — the install endpoint refuses it too,
rather than the UI merely hiding the row. The other three rows were verified
by installing them on a real Windows 11 machine, not by reading the code.

The Windows handoff starts the sibling `gadak-desktop.exe` with the `gadak://`
link and raises the window through user32 `FindWindowW`/`SetForegroundWindow`
— no CGO, no PowerShell shell-out. `decideDesktopFocus` is untouched; the
platform difference is a seam (`desktopFocusGOOS`) so the Windows branch is
testable from macOS.

wails' `ErrorHandler` now writes the reason to stderr and shows a `MessageBoxW`
naming Microsoft's Evergreen installer.

A `windows-latest` release job packs a portable zip per arch. The name is
load-bearing: v0.14.0 apps match `gadak-desktop-<os>-<arch>.zip` exactly and
would treat such a file as an update, so the asset is
`Gadak-<ver>-windows-<x64|arm64>.zip`, and the job asserts nothing in the
updater namespace was produced — mirroring the guard the macOS job already
has. Not an installer: unsigned, an installer buys more friction than a zip
and there is no signature to make it trustworthy.

`tools/winsmoke.ps1` is promoted out of a scratch directory: it launches the
app, waits for the window, reads hwnd/rect/style flags, counts WebView2
children, captures the screen, checks the capture is not black and closes
cleanly — eleven assertions. Its header says it is a **manual** gate and why:
GitHub's `windows-latest` runner has no interactive desktop, so wiring it into
CI produces a black capture.

`--print-integrations` joins `--print-window-chrome` as a probe that prints
what this host actually computes and exits — which is how the catalog was
checked on a machine with no visible desktop.

## Smart App Control, documented as measured

SAC's verdict is **per binary hash** through Microsoft's reputation service,
not per signature: one unsigned build was blocked, the same bytes renamed
stayed blocked, the same source rebuilt ran. There is no per-file "Run anyway"
as there is for SmartScreen, so the honest Windows route for 0.16 is the CLI
plus `gadak serve`, which is unsigned-friendly.

`doc-checks.sh` gains a check that pins the Windows asset name in the install
docs and **fails if any of them ever tells a user to turn Smart App Control
off** — once disabled it cannot be re-enabled without reinstalling Windows.

## Also here: GDK-253

`calendar.InRange` treated an empty value as "passes unless a lower bound is
set", so "due on or before X" kept every undated issue. Empty now fails
whenever any bound is set, in both language owners. Two defects the capture
round measured come with it: the range chip truncated its end date (199px of
label in a `max-w-[180px]` span), and the new-issue dialog's due label was the
literal string `duedate` while its seven siblings all go through i18n.

## Verification

Windows behaviour was verified on a real Windows 11 Pro box, not inferred: app
up in session 2, window at 422ms, `"desktop":true` from the CLI handoff, and a
second `gadak-desktop.exe` launch forwarded by wails SingleInstance exiting 0.
The host was left clean — scheduled tasks deleted and queried, copied binaries
removed, `~/.gadak` never created.

Gates re-run by the lead on this branch, after rebasing onto current main:
`go build`/`vet`/`test` rc=0, svelte-check 0 errors, vitest 325 passed,
doc-checks all passed, Playwright 235 passed.

Filed from this review, not fixed here: **GDK-259** — FTS5's `unicode61`
tokenizer plus prefix-only wildcards means a Korean compound word cannot be
searched by its middle (`결제` misses `간편결제`; measured `idempot*` 14 hits vs
`ency*` 0 on the demo mirror). That undercuts a headline claim and the obvious
trigram fix has a measured 3-character floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)