### PR TITLE
secretscan: a Linear key is a credential shape both scanners can now see

### DIFF
--- a/internal/secretscan/secretscan.go
+++ b/internal/secretscan/secretscan.go
@@ -6,8 +6,8 @@
 // those surfaces have nothing else in common. Whichever one had owned the
 // patterns would have become an accidental dependency of the others.
 //
-// The Atlassian token patterns must not disagree with scripts/scan-internal.sh,
-// which guards the repository itself.
+// The Atlassian and Linear token patterns must not disagree with
+// scripts/scan-internal.sh, which guards the repository itself.
 package secretscan
 
 import "regexp"
@@ -21,6 +21,11 @@ var patterns = []struct {
 	{"http_bearer_token", regexp.MustCompile(`(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._-]{20,}`)},
 	{"slack_token", regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`)},
 	{"github_token", regexp.MustCompile(`\b(?:ghp_|gho_|github_pat_)[A-Za-z0-9_]{20,}`)},
+	// Linear personal API key (Settings > Security & access). Added when a real
+	// one first entered this machine for the GDK-263 connector work: a tracker
+	// gadak may one day mirror is exactly the kind of credential that ends up
+	// pasted into a fixture, and the scanners had no shape for it.
+	{"linear_api_key", regexp.MustCompile(`lin_api_[A-Za-z0-9]{20,}`)},
 	{"private_key_pem", regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`)},
 }
 

--- a/internal/secretscan/secretscan_test.go
+++ b/internal/secretscan/secretscan_test.go
@@ -32,6 +32,7 @@ func TestMatch(t *testing.T) {
 		{"github classic pat", "ghp_" + strings.Repeat("a", 20), "github_token"},
 		{"github oauth token", "gho_" + strings.Repeat("b", 20), "github_token"},
 		{"github fine-grained pat", "github_pat_" + strings.Repeat("c", 20), "github_token"},
+		{"linear personal api key", "lin_api_" + strings.Repeat("d", 32), "linear_api_key"},
 		{"pem private key", "-----BEGIN PRIVATE KEY-----", "private_key_pem"},
 		{"pem rsa private key", "-----BEGIN RSA PRIVATE KEY-----", "private_key_pem"},
 		{"pem ec private key", "-----BEGIN EC PRIVATE KEY-----", "private_key_pem"},
@@ -43,6 +44,7 @@ func TestMatch(t *testing.T) {
 		{"basic too short", "Authorization: Basic ABCDEFG", ""},
 		{"bearer too short", "Authorization: Bearer " + strings.Repeat("t", 19), ""},
 		{"github too short", "ghp_" + strings.Repeat("a", 19), ""},
+		{"linear too short", "lin_api_" + strings.Repeat("d", 19), ""},
 		{"slack too short", "xoxb-" + strings.Repeat("1", 9), ""},
 
 		// Negatives that must not block a legitimate export.
@@ -83,6 +85,7 @@ func TestMatchNamesAreOnlyDeclaredPatterns(t *testing.T) {
 		"http_bearer_token":   true,
 		"slack_token":         true,
 		"github_token":        true,
+		"linear_api_key":      true,
 		"private_key_pem":     true,
 	}
 	for _, p := range patterns {
@@ -97,26 +100,37 @@ func TestMatchNamesAreOnlyDeclaredPatterns(t *testing.T) {
 }
 
 func TestAtlassianPatternAgreesWithRepoScanner(t *testing.T) {
-	// Package comment: must not disagree with scripts/scan-internal.sh.
+	assertScriptVarMatchesPattern(t, "PAT_TOKEN", "atlassian_api_token")
+}
+
+func TestLinearPatternAgreesWithRepoScanner(t *testing.T) {
+	assertScriptVarMatchesPattern(t, "PAT_LINEAR", "linear_api_key")
+}
+
+// assertScriptVarMatchesPattern is the shared body of the two agreement tests:
+// the package comment promises these regexes do not disagree with
+// scripts/scan-internal.sh, and a promise with no assertion is a comment.
+func assertScriptVarMatchesPattern(t *testing.T, scriptVar, patternName string) {
+	t.Helper()
 	body, err := os.ReadFile(filepath.Join("..", "..", "scripts", "scan-internal.sh"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	m := regexp.MustCompile(`(?m)^PAT_TOKEN='([^']+)'`).FindSubmatch(body)
+	m := regexp.MustCompile(`(?m)^` + scriptVar + `='([^']+)'`).FindSubmatch(body)
 	if m == nil {
-		t.Fatal("PAT_TOKEN assignment not found in scripts/scan-internal.sh")
+		t.Fatalf("%s assignment not found in scripts/scan-internal.sh", scriptVar)
 	}
 	script := string(m[1])
 	var goPat string
 	for _, p := range patterns {
-		if p.name == "atlassian_api_token" {
+		if p.name == patternName {
 			goPat = p.re.String()
 		}
 	}
 	if goPat == "" {
-		t.Fatal("atlassian_api_token missing")
+		t.Fatalf("%s missing from the package table", patternName)
 	}
 	if script != goPat {
-		t.Errorf("scan-internal.sh PAT_TOKEN=%q\nsecretscan regex=%q", script, goPat)
+		t.Errorf("scan-internal.sh %s=%q\nsecretscan regex=%q", scriptVar, script, goPat)
 	}
 }

--- a/scripts/scan-internal.sh
+++ b/scripts/scan-internal.sh
@@ -36,6 +36,10 @@ trap 'rm -f "$hits_file" "$text_list"' EXIT
 
 # User API tokens / org API keys from Atlassian.
 PAT_TOKEN='ATATT[A-Za-z0-9+/=_-]{20,}|ATCTT[A-Za-z0-9+/=_-]{20,}'
+# Linear personal API key. Kept as its own variable, not folded into
+# PAT_TOKEN, because internal/secretscan asserts PAT_TOKEN equals its
+# atlassian_api_token regex exactly.
+PAT_LINEAR='lin_api_[A-Za-z0-9]{20,}'
 PAT_HOST='atlassian\.net'
 
 # Deployment-specific words, resolved from outside this file (see header).
@@ -114,7 +118,7 @@ fi
 
 if [[ -s "$text_list" ]]; then
   # shellcheck disable=SC2046
-  grep -nHE "$PAT_TOKEN" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true
+  grep -nHE "$PAT_TOKEN|$PAT_LINEAR" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true
   if [[ -n "$PAT_COMPANY" ]]; then
     # shellcheck disable=SC2046
     grep -niHE "$PAT_COMPANY" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true
@@ -128,7 +132,7 @@ if [[ -f examples/demo.db ]]; then
   echo "==> scanning strings in examples/demo.db"
   tmp_strings="$(mktemp)"
   strings examples/demo.db >"$tmp_strings"
-  grep -nE "$PAT_TOKEN" "$tmp_strings" 2>/dev/null \
+  grep -nE "$PAT_TOKEN|$PAT_LINEAR" "$tmp_strings" 2>/dev/null \
       | sed 's|^|examples/demo.db:strings:|' >>"$hits_file" || true
   if [[ -n "$PAT_COMPANY" ]]; then
     grep -niE "$PAT_COMPANY" "$tmp_strings" 2>/dev/null \


### PR DESCRIPTION
A real Linear personal API key entered this machine for the GDK-263 connector work, and neither scanner had a shape for it:

- `internal/secretscan` guards what **leaves the app** — snapshot databases, team config files.
- `scripts/scan-internal.sh` guards **the repository itself**.

A `lin_api_` string could have ridden into a fixture through either one.

## The one non-obvious decision

The pattern is a separate script variable (`PAT_LINEAR`), not folded into `PAT_TOKEN`, because `TestAtlassianPatternAgreesWithRepoScanner` asserts `PAT_TOKEN` equals the `atlassian_api_token` regex **exactly**. Extending `PAT_TOKEN` would have broken that agreement test.

That same agreement is now asserted for Linear, through a shared helper — a promise in a package comment with no assertion behind it is just a comment.

## FAIL-first

With the table row and the name entry added but no pattern:

```
--- FAIL: TestMatch/linear_personal_api_key
    secretscan_test.go:72: Match(...) = "", want "linear_api_key"
--- FAIL: TestMatchNamesAreOnlyDeclaredPatterns
    secretscan_test.go:98: declared pattern "linear_api_key" missing from package table
```

## Gates (lead-run, from cold)

```
go build ./...                    clean
go vet ./internal/secretscan/     clean
go test ./... -count=1            26 packages ok
bash scripts/scan-internal.sh     OK: 731 files, no token-shaped secrets
bash tools/doc-checks.sh          all passed
```

The key itself lives outside the repository (mode 0600, under `~/.config`) and is **named, never quoted**, in GDK-263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)