### PR TITLE
The standalone workspace's wiki was built and never wired (GDK-267)

### DIFF
--- a/cmd/gadak/api.go
+++ b/cmd/gadak/api.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/midagedev/gadak/internal/config"
-	"github.com/midagedev/gadak/internal/confluence"
 	"github.com/midagedev/gadak/internal/origin"
 	syncer "github.com/midagedev/gadak/internal/sync"
 )
@@ -107,7 +106,10 @@ func cmdAPI(args []string) error {
 			return errors.New("Confluence is not enabled for this profile — set confluence in config (or enable it in the web UI) before calling /wiki/ paths; gadak will not use the wiki API against a source you left off")
 		}
 		// Client base is already …/wiki; strip the routing prefix.
-		cc := confluence.New(cfg.Site, cfg.Email, cfg.Token)
+		cc, werr := origin.Wiki(cfg)
+		if werr != nil {
+			return werr
+		}
 		status, out, err = cc.Raw(ctx, method, stripWikiPrefix(path), body, mutating)
 		if db, oerr := openStore(); oerr != nil {
 			log.Printf("api usage flush: %v", oerr)

--- a/cmd/gadak/init.go
+++ b/cmd/gadak/init.go
@@ -165,6 +165,12 @@ func cmdInit(args []string) error {
 		return initStandalone(cfg, *jsonOut, *projectsFlag)
 	}
 
+	// Whether this run is converting a standalone workspace, captured before
+	// cfg.Kind is cleared below. The seeded wiki space must be dropped on
+	// every such conversion, not only the --replace-standalone one: an empty
+	// standalone workspace is allowed through without that flag.
+	wasStandalone := cfg.IsStandalone()
+
 	// Close the class "a command silently changes which origin owns this
 	// workspace". An empty standalone workspace is not a hazard; one that
 	// holds locally originated issues is (GDK-238).
@@ -308,6 +314,15 @@ func cmdInit(args []string) error {
 	cfg.Projects = projects
 	// Reached only after RefuseReplace (or --replace-standalone).
 	originbind.ClearStandalone(cfg)
+	// A workspace is bound to one origin. initStandalone writes the seeded
+	// space (LOC) so the wiki pass is on; that key is not a Cloud space, so
+	// converting to a connected origin drops it. Keyed on wasStandalone, not
+	// on --replace-standalone: the empty-workspace path reaches here without
+	// that flag and would otherwise ask a real site for a space named LOC.
+	// --spaces still owns the connected wiki scope below (untouched).
+	if wasStandalone && *spacesFlag == "" {
+		cfg.Confluence = nil
+	}
 
 	// Confluence: flag absent leaves the section untouched.
 	if *spacesFlag != "" {
@@ -388,6 +403,8 @@ func cmdInit(args []string) error {
 // initStandalone writes a workspace that is not bound to a Jira site.
 // No /myself call: there is no credential. The origin snapshot is created
 // on first origin.Client (PersistPath under the profile directory).
+// DefaultConfluenceConfig turns the wiki sync pass on and scopes it to the
+// space the standalone origin seeds.
 func initStandalone(cfg *config.Config, jsonOut bool, projectsFlag string) error {
 	cfg.Kind = config.KindStandalone
 	cfg.Site = ""
@@ -398,7 +415,7 @@ func initStandalone(cfg *config.Config, jsonOut bool, projectsFlag string) error
 	cfg.TokenExpiresAt = ""
 	cfg.TokenExpirySource = ""
 	cfg.AccountID = ""
-	cfg.Confluence = nil
+	cfg.Confluence = origin.DefaultConfluenceConfig()
 	if projectsFlag != "" {
 		cfg.Projects = parseProjectKeys(projectsFlag)
 	}

--- a/cmd/gadak/init_test.go
+++ b/cmd/gadak/init_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
 )
 
 // clearCredentialEnv treats every GADAK_* / SCRY_* init source as unset.
@@ -942,5 +943,65 @@ func TestSQLUnknownProfileDoesNotCreate(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(home, "profiles", "nosuch")); !os.IsNotExist(statErr) {
 		t.Fatalf("must not create profile dir; stat=%v", statErr)
+	}
+}
+
+// TestInitConvertingEmptyStandaloneDropsSeededSpace guards the half of "a
+// workspace is bound to one origin" that the --replace-standalone flag does not
+// cover. An *empty* standalone workspace is deliberately allowed to convert
+// without that flag (refuseStandaloneReplace returns nil at n==0), so a guard
+// keyed on the flag leaves the seeded issuetap space (LOC) in the config of a
+// now-connected workspace — and the wiki pass then asks a real Atlassian site
+// for a space that only ever existed in the in-process origin.
+func TestInitConvertingEmptyStandaloneDropsSeededSpace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	clearCredentialEnv(t)
+	config.SetProfile("")
+	// origin keeps live in-process sessions in a process-global map, and a
+	// standalone init opens one. Left behind, its debounced snapshot flush
+	// targets a TempDir that has already been removed, and the *next* test in
+	// this package to call origin.Close() is the one that fails.
+	t.Cleanup(func() { _ = origin.Close() })
+
+	withClosedStdin(t, func() {
+		if _, err := capture(t, func() error {
+			return cmdInit([]string{"--standalone", "--json"})
+		}); err != nil {
+			t.Fatalf("standalone init: %v", err)
+		}
+	})
+	seeded, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seeded.Confluence == nil || len(seeded.Confluence.Spaces) == 0 {
+		t.Fatalf("standalone init should seed a wiki space, got %+v", seeded.Confluence)
+	}
+
+	// No --replace-standalone: the workspace holds no locally originated
+	// issues, so this conversion is allowed through.
+	srv := myselfServer(t)
+	withClosedStdin(t, func() {
+		if _, err := capture(t, func() error {
+			return cmdInit([]string{
+				"--site", srv.URL,
+				"--email", "convert@example.com",
+				"--token-file", writeTokenFile(t, home, "test-token"),
+				"--json",
+			})
+		}); err != nil {
+			t.Fatalf("convert: %v", err)
+		}
+	})
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IsStandalone() {
+		t.Fatalf("converted workspace still reports standalone: kind=%q", cfg.Kind)
+	}
+	if cfg.Confluence != nil {
+		t.Fatalf("seeded standalone space survived the conversion: %+v", cfg.Confluence)
 	}
 }

--- a/cmd/gadak/status.go
+++ b/cmd/gadak/status.go
@@ -50,6 +50,9 @@ func cmdStatus(args []string) error {
 	if n, err := db.TableCount(context.Background(), "comments"); err == nil {
 		st["comments"] = n
 	}
+	if n, err := db.TableCount(context.Background(), "pages"); err == nil {
+		st["pages"] = n
+	}
 	usage, err := db.APIUsageSummary(context.Background())
 	if err != nil {
 		usage = store.APIUsageSummary{Today: store.APIUsageDay{Day: time.Now().UTC().Format("2006-01-02")}}
@@ -69,6 +72,13 @@ func cmdStatus(args []string) error {
 		tokenExpiry = cfg.TokenExpiryAt(time.Now().UTC())
 		st["token_expiry"] = tokenExpiry
 	}
+	wiki := wikiPathStatus(cfg)
+	if css, err := db.SyncState(context.Background(), "confluence"); err == nil {
+		if css.LastError != nil && *css.LastError != "" {
+			wiki["last_error"] = *css.LastError
+		}
+	}
+	st["wiki"] = wiki
 	var updateInfo selfupdate.Info
 	var updateOK bool
 	if cfg != nil && cfg.UpdateCheckEnabled() {
@@ -86,10 +96,13 @@ func cmdStatus(args []string) error {
 	if *asJSON {
 		return json.NewEncoder(os.Stdout).Encode(st)
 	}
-	for _, k := range []string{"profile", "issues", "comments", "watermark", "version", "last_full_sync_at", "last_error"} {
+	for _, k := range []string{"profile", "issues", "comments", "pages", "watermark", "version", "last_full_sync_at", "last_error"} {
 		if v, ok := st[k]; ok && v != "" {
 			fmt.Printf("%-18s %v\n", k, v)
 		}
+	}
+	if line := formatWikiStatusLine(wiki); line != "" {
+		fmt.Printf("%-18s %s\n", "wiki", line)
 	}
 	if line := formatAPIUsageLine(usage); line != "" {
 		fmt.Printf("%-18s %s\n", "api (today)", line)
@@ -105,6 +118,46 @@ func cmdStatus(args []string) error {
 		}
 	}
 	return nil
+}
+
+// wikiPathStatus reports whether the wiki sync pass will run for this
+// workspace. Reasons reuse the refusal strings the pass itself returns:
+// "sync: confluence is not configured" (internal/sync/confluence.go) and
+// "origin: site, email and token are required" (internal/origin.errNeedCredential).
+// No site, email, or token is copied into the map.
+func wikiPathStatus(cfg *config.Config) map[string]any {
+	out := map[string]any{}
+	if cfg == nil || cfg.Confluence == nil {
+		out["path"] = "skipped"
+		out["reason"] = "sync: confluence is not configured"
+		return out
+	}
+	if !cfg.IsStandalone() && (cfg.Site == "" || cfg.Email == "" || cfg.Token == "") {
+		out["path"] = "skipped"
+		out["reason"] = "origin: site, email and token are required"
+		return out
+	}
+	out["path"] = "on"
+	return out
+}
+
+// formatWikiStatusLine is the text-mode wiki row. Empty only if wiki is missing.
+func formatWikiStatusLine(wiki map[string]any) string {
+	if wiki == nil {
+		return ""
+	}
+	path, _ := wiki["path"].(string)
+	if path == "" {
+		return ""
+	}
+	line := path
+	if r, ok := wiki["reason"].(string); ok && r != "" {
+		line += " (" + r + ")"
+	}
+	if le, ok := wiki["last_error"].(string); ok && le != "" {
+		line += "; last_error " + le
+	}
+	return line
 }
 
 // formatAPIUsageLine returns "" when nothing has been counted in the last week,

--- a/cmd/gadak/status_test.go
+++ b/cmd/gadak/status_test.go
@@ -104,3 +104,113 @@ func TestStatusSurfacesConfigLoadError(t *testing.T) {
 		t.Fatalf("config_error must name the path, got %q", ce)
 	}
 }
+
+func TestStatusJSONWikiPathStandaloneOn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+
+	cfg := &config.Config{
+		Kind:       config.KindStandalone,
+		Confluence: &config.ConfluenceConfig{Spaces: []string{"LOC"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := capture(t, func() error { return cmdStatus([]string{"--json"}) })
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	var doc struct {
+		Pages int `json:"pages"`
+		Wiki  struct {
+			Path   string `json:"path"`
+			Reason string `json:"reason"`
+		} `json:"wiki"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if doc.Wiki.Path != "on" {
+		t.Fatalf("wiki.path = %q, want on; body %s", doc.Wiki.Path, out)
+	}
+	if doc.Wiki.Reason != "" {
+		t.Fatalf("wiki.reason = %q, want empty when on", doc.Wiki.Reason)
+	}
+	if strings.Contains(out, "token") && strings.Contains(strings.ToLower(out), "secret") {
+		t.Fatalf("status leaked a credential-shaped field: %s", out)
+	}
+}
+
+func TestStatusJSONWikiPathSkippedWhenNotConfigured(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+
+	cfg := &config.Config{
+		Kind: config.KindStandalone,
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := capture(t, func() error { return cmdStatus([]string{"--json"}) })
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	var doc struct {
+		Wiki struct {
+			Path   string `json:"path"`
+			Reason string `json:"reason"`
+		} `json:"wiki"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if doc.Wiki.Path != "skipped" {
+		t.Fatalf("wiki.path = %q, want skipped; body %s", doc.Wiki.Path, out)
+	}
+	if doc.Wiki.Reason != "sync: confluence is not configured" {
+		t.Fatalf("wiki.reason = %q", doc.Wiki.Reason)
+	}
+}
+
+func TestStatusJSONWikiPathConnectedOn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+
+	cfg := &config.Config{
+		Site:       "https://example.invalid",
+		Email:      "user@example.invalid",
+		Token:      "status-test-token",
+		Confluence: &config.ConfluenceConfig{Spaces: []string{"ENG"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := capture(t, func() error { return cmdStatus([]string{"--json"}) })
+	if err != nil {
+		t.Fatalf("status --json: %v", err)
+	}
+	if strings.Contains(out, "status-test-token") {
+		t.Fatalf("token leaked in status --json: %s", out)
+	}
+	var doc struct {
+		Wiki struct {
+			Path   string `json:"path"`
+			Reason string `json:"reason"`
+		} `json:"wiki"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("decode %q: %v", out, err)
+	}
+	if doc.Wiki.Path != "on" {
+		t.Fatalf("wiki.path = %q, want on; body %s", doc.Wiki.Path, out)
+	}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,11 @@ flowchart TB
 ```
 
 Confluence is a peer source (`internal/confluence`, `decisions/0006-confluence-connector.md`):
-the wiki mirror is read-only, so writes in this picture still go only to Jira.
+on a connected workspace the wiki mirror is read-only, so writes in this
+picture still go only to Jira. A standalone workspace builds the wiki client
+through `origin.Wiki` (the in-process issuetap handler, same session as
+`origin.Client`); page writes go to issuetap's Confluence API, not the
+SQLite mirror.
 
 The single-origin property is not incidental. Because the UI and the API are
 served from the same localhost origin, the server never emits a CORS header —

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -137,7 +137,7 @@ and `hasCredential` on the body are ignored.
 | `notify` | bool | **true** when absent | `gadak config set notify` / `config.json` (not on Settings UI or Settings PUT) | Next watch-loop tick; OS desktop alerts for new personal-feed events |
 | `updateCheck` | bool | **true** when absent | `gadak config set updateCheck` / `config.json` (not on Settings UI or Settings PUT) | Next `sync` / `status` / `serve` / desktop start; once-per-day GitHub release lookup (cached under the profile directory on disk). Set `false` to opt out — no outbound traffic beyond Jira |
 | `attachmentCacheMB` | int | `0` → package **512** | `gadak config set attachmentCacheMB` / `config.json` (not on Settings UI or Settings PUT) | Cap (MB) for the on-disk cache opened when a workspace mounts; `0` becomes the package default |
-| `confluence` | object or absent | absent = wiki mirror off | Settings → Sources / `gadak config set confluence` | Next Confluence pass |
+| `confluence` | object or absent | absent = wiki mirror off. `gadak init --standalone` writes the block scoped to `LOC` | Settings → Sources / `gadak config set confluence` | Next Confluence pass |
 | `confluence.spaces` | string[] | `[]` = every *global* space; personal spaces only if named (`internal/config/config.go`) | Settings → Sources / `gadak config set confluence.spaces` | Next Confluence pass |
 
 The space list *is* the scope: drop a space and the next Confluence pass

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -206,6 +206,9 @@ Empty `spaces` means every *global* space; personal spaces only if named.
 pages (current version, comments, labels) alongside issues —
 `--source jira|confluence|all` narrows a run. Pages land in the same FTS index,
 the sidebar grows a DOCS tree, and search answers across both.
+`gadak init --standalone` writes `confluence.spaces` as `["LOC"]` (the space
+the in-process origin seeds) so the wiki pass is on for a new standalone
+workspace.
 
 ## Two sites at once
 

--- a/internal/origin/direct_confluence_new_gate_test.go
+++ b/internal/origin/direct_confluence_new_gate_test.go
@@ -1,0 +1,119 @@
+package origin
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectConfluenceNewOutsideOrigin is the structural lock: "this
+// workspace's Confluence client" is built in this package only. A new
+// confluence.New( in production code (outside internal/confluence and this
+// package) fails this test.
+//
+// 2026-08-18 GDK-267: FAIL-first ran against the four production callers
+// (cmd/gadak/api.go, internal/server/settings.go, internal/sync/confluence.go,
+// internal/sync/one.go) before they were rewritten to origin.Wiki. Tests
+// (*_test.go) may still call confluence.New to stand up httptest servers.
+func TestNoDirectConfluenceNewOutsideOrigin(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			switch name {
+			case ".git", "vendor", "node_modules", "dist", "testdata", "scratch":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if allowedConfluenceNewFile(rel) {
+			return nil
+		}
+		hits = append(hits, findConfluenceNewCalls(t, path, rel)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) > 0 {
+		t.Fatalf("confluence.New must not be called from production code outside internal/origin (and its definition in internal/confluence):\n  %s",
+			strings.Join(hits, "\n  "))
+	}
+}
+
+func allowedConfluenceNewFile(rel string) bool {
+	if strings.HasPrefix(rel, "internal/origin/") {
+		return true
+	}
+	// The constructor itself (and any other file in that package).
+	if strings.HasPrefix(rel, "internal/confluence/") {
+		return true
+	}
+	return false
+}
+
+func findConfluenceNewCalls(t *testing.T, path, rel string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", rel, err)
+		return nil
+	}
+	var confName string
+	for _, imp := range f.Imports {
+		p := strings.Trim(imp.Path.Value, `"`)
+		if p != "github.com/midagedev/gadak/internal/confluence" {
+			continue
+		}
+		if imp.Name != nil {
+			confName = imp.Name.Name
+		} else {
+			confName = "confluence"
+		}
+	}
+	if confName == "" || confName == "_" {
+		return nil
+	}
+	var hits []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "New" {
+			return true
+		}
+		id, ok := sel.X.(*ast.Ident)
+		if !ok || id.Name != confName {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		hits = append(hits, filepath.ToSlash(rel)+":"+itoa(pos.Line))
+		return true
+	})
+	return hits
+}

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -29,7 +29,7 @@ const DefaultProjectKey = "STD"
 // display name, and not a site-specific key.
 const DefaultSpaceKey = "LOC"
 
-// DefaultConfluenceConfig is what initStandalone should write so the wiki
+// DefaultConfluenceConfig is what initStandalone writes so the wiki
 // sync pass is on and scoped to the seeded space. Presence of the block is
 // the on switch (internal/sync/confluence.go).
 func DefaultConfluenceConfig() *config.ConfluenceConfig {

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -204,7 +204,11 @@ func (s *server) handleSettingsSpaces(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusConflict, "credential_required")
 		return
 	}
-	c := confluence.New(cfg.Site, cfg.Email, cfg.Token)
+	c, err := origin.Wiki(cfg)
+	if err != nil {
+		fail(w, http.StatusConflict, "credential_required")
+		return
+	}
 	listed, err := c.Spaces(r.Context())
 	if err != nil {
 		if errors.Is(err, confluence.ErrAuth) {

--- a/internal/sync/confluence.go
+++ b/internal/sync/confluence.go
@@ -12,6 +12,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/confluence"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/store"
 )
 
@@ -38,6 +39,18 @@ const pageBatchSize = 50
 // A failure leaves already-committed batches in place.
 func RunConfluence(ctx context.Context, cfg *config.Config, db *store.DB, opts Options) (Result, error) {
 	var c *confluence.Client
+	// Acquire the wiki client before runSource so a failure can skip this
+	// pass without becoming the caller's error. Issue sync is a different
+	// function (Run); returning err here used to look like "the sync failed"
+	// even when only the wiki side could not start.
+	if opts.ConfluenceClient == nil && cfg != nil && cfg.Confluence != nil {
+		w, err := origin.Wiki(cfg)
+		if err != nil {
+			opts.logf("confluence: skip wiki pass: %v", err)
+			return Result{}, nil
+		}
+		opts.ConfluenceClient = w
+	}
 	return runSource(ctx, cfg, db, opts,
 		sourceIdent{ID: ConfluenceSourceID, Kind: "confluence"},
 		// Space-scope prune is the Confluence reconcile. The flag only suffixes
@@ -50,7 +63,14 @@ func RunConfluence(ctx context.Context, cfg *config.Config, db *store.DB, opts O
 			}
 			c = opts.ConfluenceClient
 			if c == nil {
-				c = confluence.New(cfg.Site, cfg.Email, cfg.Token)
+				var err error
+				c, err = origin.Wiki(cfg)
+				if err != nil {
+					// Pre-acquire above already skipped this case. Keep the
+					// same skip if a caller reaches here without it.
+					opts.logf("confluence: skip wiki pass: %v", err)
+					return "", nil, err
+				}
 			}
 			return c.BaseURL(), c, nil
 		},

--- a/internal/sync/one.go
+++ b/internal/sync/one.go
@@ -99,7 +99,12 @@ func SyncPage(ctx context.Context, cfg *config.Config, db *store.DB, id string) 
 	if !cfg.HasCredential() {
 		return errors.New("sync: site, email and token are required")
 	}
-	c := confluence.New(cfg.Site, cfg.Email, cfg.Token)
+	c, err := origin.Wiki(cfg)
+	if err != nil {
+		// SyncPage is wiki-only (desktop page resync). Returning the error
+		// does not stop issue sync; Run never calls this.
+		return err
+	}
 	rec, _, _, err := fetchPageRecord(ctx, c, confluence.Page{ID: id})
 	if err != nil {
 		if errors.Is(err, confluence.ErrNotFound) {

--- a/internal/sync/wiki_standalone_test.go
+++ b/internal/sync/wiki_standalone_test.go
@@ -1,0 +1,179 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+)
+
+// standaloneWikiCfg is a standalone workspace under GADAK_HOME, isolated
+// from the user's profile. Pattern follows internal/origin/wiki_test.go
+// standaloneHome (that helper is not exported; this package has no prior
+// standalone origin helper).
+func standaloneWikiCfg(t *testing.T, withConfluence bool) *config.Config {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	t.Setenv("HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() {
+		_ = origin.Close()
+		config.SetProfile("")
+	})
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if withConfluence {
+		cfg.Confluence = origin.DefaultConfluenceConfig()
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func wikiADF(text string) string {
+	b, err := json.Marshal(map[string]any{
+		"type":    "doc",
+		"version": 1,
+		"content": []any{
+			map[string]any{
+				"type": "paragraph",
+				"content": []any{
+					map[string]any{"type": "text", "text": text},
+				},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// TestStandaloneWikiPagesLandInMirror is the GDK-267 evidence: a page created
+// on the in-process origin is visible in the SQLite mirror after RunConfluence.
+// No network — GADAK_HOME is a temp dir.
+func TestStandaloneWikiPagesLandInMirror(t *testing.T) {
+	cfg := standaloneWikiCfg(t, true)
+	w, err := origin.Wiki(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := w.CreatePage(context.Background(), origin.DefaultSpaceKey, "Standalone wiki note", wikiADF("hello from standalone wiki"), "")
+	if err != nil {
+		t.Fatalf("CreatePage: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("CreatePage returned empty id")
+	}
+
+	db := newMirror(t)
+	res, err := RunConfluence(context.Background(), cfg, db.DB, Options{Full: true})
+	if err != nil {
+		t.Fatalf("RunConfluence: %v", err)
+	}
+	if res.Fetched < 1 {
+		t.Fatalf("fetched = %d, want >= 1", res.Fetched)
+	}
+
+	d, err := db.PageDetail(context.Background(), created.ID)
+	if err != nil || d == nil {
+		t.Fatalf("PageDetail(%s): %v %#v", created.ID, err, d)
+	}
+	if d.Title != "Standalone wiki note" {
+		t.Errorf("title %q", d.Title)
+	}
+	if d.SpaceKey != origin.DefaultSpaceKey {
+		t.Errorf("space %q, want %s", d.SpaceKey, origin.DefaultSpaceKey)
+	}
+
+	n, err := db.TableCount(context.Background(), "pages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n < 1 {
+		t.Fatalf("pages count = %d", n)
+	}
+}
+
+// TestStandaloneWikiPassOffWhenConfluenceNil is the existing-workspace case:
+// cfg.Confluence == nil keeps RunConfluence from mirroring, even though
+// origin.Wiki still returns a client. No config migration this round.
+func TestStandaloneWikiPassOffWhenConfluenceNil(t *testing.T) {
+	cfg := standaloneWikiCfg(t, false)
+	if cfg.Confluence != nil {
+		t.Fatal("precondition: Confluence must be nil")
+	}
+	w, err := origin.Wiki(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.CreatePage(context.Background(), origin.DefaultSpaceKey, "Unmirrored", wikiADF("stays in origin"), ""); err != nil {
+		t.Fatalf("CreatePage: %v", err)
+	}
+
+	db := newMirror(t)
+	_, err = RunConfluence(context.Background(), cfg, db.DB, Options{Full: true})
+	if err == nil || !strings.Contains(err.Error(), "confluence is not configured") {
+		t.Fatalf("RunConfluence err = %v, want confluence is not configured", err)
+	}
+	n, err := db.TableCount(context.Background(), "pages")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("pages = %d, want 0 when the pass is off", n)
+	}
+}
+
+// TestWikiAcquisitionFailureSkipsPass: origin.Wiki failing must not become
+// a hard RunConfluence error (degrade-don't-break). Issue sync is a different
+// function; this asserts the wiki pass itself returns success-and-skip.
+func TestWikiAcquisitionFailureSkipsPass(t *testing.T) {
+	home := t.TempDir()
+	blocked := filepath.Join(home, "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GADAK_HOME", blocked)
+	t.Setenv("HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() {
+		_ = origin.Close()
+		config.SetProfile("")
+	})
+
+	cfg := &config.Config{
+		Kind:       config.KindStandalone,
+		Confluence: origin.DefaultConfluenceConfig(),
+	}
+	var logs []string
+	db := newMirror(t)
+	res, err := RunConfluence(context.Background(), cfg, db.DB, Options{
+		Full: true,
+		Log:  func(s string) { logs = append(logs, s) },
+	})
+	if err != nil {
+		t.Fatalf("Wiki failure must skip, not fail RunConfluence: %v", err)
+	}
+	if res.Fetched != 0 {
+		t.Fatalf("fetched = %d after skip", res.Fetched)
+	}
+	joined := strings.Join(logs, "\n")
+	if !strings.Contains(joined, "skip wiki pass") {
+		t.Fatalf("missing skip log, got %q", joined)
+	}
+}


### PR DESCRIPTION
Closes GDK-267.

`origin.Wiki` has carried "this workspace's Confluence client" since `717d91f` — standalone branch, in-process issuetap transport, test behind it — and **zero production callers**. Four sites kept building `confluence.New(cfg.Site, cfg.Email, cfg.Token)` by hand, and on a standalone workspace those three fields are empty strings.

So the wiki was quietly dead there. And because `initStandalone` also left `cfg.Confluence` nil, sync skipped the pass entirely, so **no error ever surfaced**. CLAUDE.md's promise that "standalone wiki writes go through issuetap's Confluence API" was false in code.

| Site | Was | Now |
|---|---|---|
| `cmd/gadak/api.go:109` | `confluence.New(...)` | `origin.Wiki(cfg)` |
| `internal/server/settings.go:207` | `confluence.New(...)` | `origin.Wiki(cfg)` |
| `internal/sync/confluence.go:47` | `confluence.New(...)` | `origin.Wiki(cfg)` |
| `internal/sync/one.go:102` | `confluence.New(...)` | `origin.Wiki(cfg)` |

Connected behaviour is unchanged — `origin.Wiki` returns exactly `confluence.New(site, email, token)` for it.

## Degrade-don't-break

`RunConfluence` acquires the client **before** `runSource` and, on failure, logs `confluence: skip wiki pass` and returns success. The wiki side failing to start must not read as "the sync failed". `SyncPage` still returns its error, because that path is wiki-only (desktop page resync) and `Run` never calls it.

## Recurrence

`TestNoDirectConfluenceNewOutsideOrigin` — the confluence twin of the existing `jira.New` gate. FAIL-first, it named all four sites:

```
direct_confluence_new_gate_test.go:61: confluence.New must not be called from production code outside internal/origin:
      cmd/gadak/api.go:110
      internal/server/settings.go:207
      internal/sync/confluence.go:53
      internal/sync/one.go:102
```

## What lead review added

The round's own conversion guard keyed dropping the seeded `LOC` space on `--replace-standalone`. But an **empty** standalone workspace is deliberately allowed to convert *without* that flag (`refuseStandaloneReplace` returns nil at `n == 0`), so `LOC` survived into a connected config and the wiki pass would ask a real Atlassian site for a space that only ever existed in-process.

Now keyed on `wasStandalone`, captured before `Kind` is cleared. FAIL-first:

```
init_test.go:999: seeded standalone space survived the conversion: &{Spaces:[LOC]}
```

That test also has to close the origin session it opens: `origin` keeps live sessions in a process-global map, and a leaked one flushes its debounced snapshot into an already-removed `TempDir`, failing whichever later test in the package calls `origin.Close()` next. (That is how it first showed up — as `TestStandaloneCreateSyncSQL` failing in the full run but passing alone.)

## Debugging

`gadak status --json` gains `pages` and a `wiki` block (`path`, `reason`, `last_error`), so "the wiki pass is off and here is why" is one command instead of an inference. No credential appears in it.

## Gates (lead-run, from cold, in this tree)

```
go build ./...            clean
go vet ./...              clean
go test ./... -count=1    26 packages ok
tools/doc-checks.sh       all passed
```

No `web/` or `e2e/` file changed, so Playwright is not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)