### PR TITLE
The create dialog sent a priority by name, and the gate that should have caught it was green (GDK-248)

### DIFF
--- a/cmd/gadak/create.go
+++ b/cmd/gadak/create.go
@@ -257,11 +257,11 @@ func createOne(ctx context.Context, cfg *config.Config, c *jira.Client, projectW
 		if err != nil {
 			return "", nil, err
 		}
-		id, err := resolvePriority(p, list)
+		id, err := create.Priority(p, list)
 		if err != nil {
 			return "", nil, err
 		}
-		fields["priority"] = map[string]string{"id": id}
+		fields["priority"] = create.PriorityField(id)
 	}
 	if parentKey != "" {
 		fields["parent"] = map[string]string{"key": parentKey}
@@ -372,10 +372,4 @@ func parseParentKey(raw, cmd string) (string, error) {
 		return "", fmt.Errorf("gadak %s --parent %q is not a Jira key (want ABC-123)", cmd, raw)
 	}
 	return normalizeKey(raw), nil
-}
-
-// formatCreateTypes is the Name (id N) list used by resolvePriority in edit.go
-// (same package). Type resolution itself lives in internal/create.
-func formatCreateTypes(types []jira.NamedID) string {
-	return create.FormatTypes(types)
 }

--- a/cmd/gadak/edit.go
+++ b/cmd/gadak/edit.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/midagedev/gadak/internal/create"
 	"github.com/midagedev/gadak/internal/jira"
 )
 
@@ -132,7 +133,7 @@ func cmdEdit(args []string) error {
 			if err != nil {
 				return nil, err
 			}
-			id, err := resolvePriority(*priority, list)
+			id, err := create.Priority(*priority, list)
 			if err != nil {
 				return nil, err
 			}
@@ -176,17 +177,4 @@ func labelUpdateOps(labels []string) ([]any, error) {
 		}
 	}
 	return ops, nil
-}
-
-func resolvePriority(want string, list []jira.NamedID) (string, error) {
-	want = strings.TrimSpace(want)
-	if want == "" {
-		return "", fmt.Errorf("pass --priority, available: %s", formatCreateTypes(list))
-	}
-	for _, p := range list {
-		if p.ID == want || strings.EqualFold(p.Name, want) {
-			return p.ID, nil
-		}
-	}
-	return "", fmt.Errorf("no priority matching %q — available: %s", want, formatCreateTypes(list))
 }

--- a/e2e/duedate.spec.ts
+++ b/e2e/duedate.spec.ts
@@ -33,6 +33,12 @@ async function fulfillJSON(route: Route, json: unknown, status = 200): Promise<v
 }
 
 /** Fixture Jira is fake — create-meta never returns. Seed local write-meta. */
+const PRIORITY_CATALOG = [
+  { id: '1', name: '가장 높음' },
+  { id: '2', name: '높음' },
+  { id: '3', name: '보통' },
+]
+
 async function stubCreateMeta(page: Page): Promise<void> {
   await page.route('**/api/v1/issues/meta/write/', async (route) => {
     if (route.request().method() !== 'GET') return route.continue()
@@ -45,6 +51,10 @@ async function stubCreateMeta(page: Page): Promise<void> {
   await page.route('**/api/v1/issues/create-meta/', async (route) => {
     if (route.request().method() !== 'GET') return route.continue()
     await fulfillJSON(route, { projects: CREATE_PROJECTS })
+  })
+  await page.route('**/api/v1/issues/priorities/', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    await fulfillJSON(route, { priorities: PRIORITY_CATALOG })
   })
 }
 
@@ -103,6 +113,47 @@ test.describe('duedate write + jira_errors', () => {
     expect(posted!.duedate).toBe('2026-09-01')
     expect(posted!.summary).toBe('gdk-223 due set')
     expect(JSON.stringify(posted)).not.toMatch(/ATATT|Bearer |api_token/i)
+
+    expect(
+      errors.filter((e) => !e.includes('400')),
+      `console errors:\n${errors.join('\n')}`,
+    ).toEqual([])
+  })
+
+  test('new-issue dialog POSTs catalog priority_id, not the display name', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    const template = await bootWithCreateMeta(page)
+
+    let posted: CreateBody | null = null
+    await page.route('**/api/v1/issues/create/', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue()
+      posted = route.request().postDataJSON() as CreateBody
+      await fulfillJSON(route, {
+        issue: {
+          ...template,
+          issue_key: 'GDK-248',
+          summary: posted.summary,
+          issue_type: 'Task',
+          source_project: 'NMB',
+        },
+      })
+    })
+
+    const dialog = await openNewIssue(page)
+    const select = dialog.getByTestId('new-issue-priority')
+    const named = select.locator('option[value="2"]')
+    await expect(named).toHaveText('높음')
+    await expect(select.locator('option[value="1"]')).toHaveText('가장 높음')
+    await expect(select.locator('option', { hasText: /^Highest$/ })).toHaveCount(0)
+
+    await dialog.getByPlaceholder(en['write.issueTitle']).fill('gdk-248 priority id')
+    await select.selectOption('2')
+    await dialog.getByRole('button', { name: en['common.create'] }).click()
+
+    await expect.poll(() => posted).not.toBeNull()
+    expect(posted!.priority_id).toBe('2')
+    expect(posted).not.toHaveProperty('priority')
+    expect(posted!.summary).toBe('gdk-248 priority id')
 
     expect(
       errors.filter((e) => !e.includes('400')),

--- a/e2e/url-state.spec.ts
+++ b/e2e/url-state.spec.ts
@@ -207,6 +207,10 @@ test.describe('place params', () => {
      * link could prefill a form someone is about to submit.
      */
     const errors = attachConsoleErrors(page)
+    await page.route('**/api/v1/issues/priorities/', (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      return route.fulfill({ json: { priorities: [] } })
+    })
     await gotoApp(page)
     const before = page.url()
 

--- a/internal/create/resolve.go
+++ b/internal/create/resolve.go
@@ -1,6 +1,6 @@
-// Package create is the single owner of project and issue-type resolution
-// for gadak create (CLI and REST). Both surfaces must call these functions
-// so a default cannot exist on one path and not the other.
+// Package create is the single owner of project, issue-type, and priority
+// resolution for gadak create (CLI and REST). Both surfaces must call these
+// functions so a default cannot exist on one path and not the other.
 package create
 
 import (
@@ -116,4 +116,25 @@ func FormatTypes(types []jira.NamedID) string {
 		parts = append(parts, fmt.Sprintf("%s (id %s)", t.Name, t.ID))
 	}
 	return strings.Join(parts, "; ")
+}
+
+// Priority resolves a user-supplied name or id against the site catalog.
+// Names follow the account language; the return is always the catalog id.
+func Priority(want string, list []jira.NamedID) (id string, err error) {
+	want = strings.TrimSpace(want)
+	if want == "" {
+		return "", fmt.Errorf("pass --priority, available: %s", FormatTypes(list))
+	}
+	for _, p := range list {
+		if p.ID == want || strings.EqualFold(p.Name, want) {
+			return p.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no priority matching %q — available: %s", want, FormatTypes(list))
+}
+
+// PriorityField is the Jira fields.priority value: always an id, never a
+// localized name. Create and edit both send this shape.
+func PriorityField(id string) map[string]string {
+	return map[string]string{"id": id}
 }

--- a/internal/create/resolve_test.go
+++ b/internal/create/resolve_test.go
@@ -1,0 +1,77 @@
+package create
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/jira"
+)
+
+func priList() []jira.NamedID {
+	return []jira.NamedID{
+		{ID: "1", Name: "Highest"},
+		{ID: "2", Name: "High"},
+		{ID: "3", Name: "Medium"},
+	}
+}
+
+func TestPriorityMatchesNameAndID(t *testing.T) {
+	list := priList()
+	cases := []struct {
+		want, id string
+	}{
+		{"High", "2"},
+		{"high", "2"},
+		{"1", "1"},
+		{"  Medium ", "3"},
+	}
+	for _, tc := range cases {
+		id, err := Priority(tc.want, list)
+		if err != nil || id != tc.id {
+			t.Fatalf("Priority(%q) = %q, %v; want %q", tc.want, id, err, tc.id)
+		}
+	}
+}
+
+func TestPriorityMatchesLocalizedName(t *testing.T) {
+	list := []jira.NamedID{
+		{ID: "1", Name: "가장 높음"},
+		{ID: "2", Name: "높음"},
+	}
+	id, err := Priority("높음", list)
+	if err != nil || id != "2" {
+		t.Fatalf("got %q %v", id, err)
+	}
+	if _, err := Priority("High", list); err == nil {
+		t.Fatal("English name must not match a Korean catalog")
+	}
+}
+
+func TestPriorityEmptyListsCatalog(t *testing.T) {
+	_, err := Priority("", priList())
+	if err == nil || !strings.Contains(err.Error(), "pass --priority") || !strings.Contains(err.Error(), "Highest (id 1)") {
+		t.Fatalf("empty: %v", err)
+	}
+}
+
+func TestPriorityUnmatchedListsCatalog(t *testing.T) {
+	_, err := Priority("Urgent", priList())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, want := range []string{`no priority matching "Urgent"`, "Highest (id 1)", "High (id 2)", "Medium (id 3)"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing %q in %v", want, err)
+		}
+	}
+}
+
+func TestPriorityFieldIsID(t *testing.T) {
+	got := PriorityField("2")
+	if got["id"] != "2" || len(got) != 1 {
+		t.Fatalf("%v", got)
+	}
+	if _, ok := got["name"]; ok {
+		t.Fatalf("name leaked: %v", got)
+	}
+}

--- a/internal/server/write.go
+++ b/internal/server/write.go
@@ -431,7 +431,7 @@ func (s *server) handlePriority(w http.ResponseWriter, r *http.Request) {
 		if id == "" {
 			return nil, c.UpdateFields(ctx, key, map[string]any{"priority": nil})
 		}
-		return nil, c.UpdateFields(ctx, key, map[string]any{"priority": map[string]string{"id": id}})
+		return nil, c.UpdateFields(ctx, key, map[string]any{"priority": create.PriorityField(id)})
 	})
 }
 
@@ -652,7 +652,7 @@ func (s *server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Summary           string   `json:"summary"`
 		DescriptionText   string   `json:"description_text"`
 		AssigneeAccountID *string  `json:"assignee_account_id"`
-		Priority          string   `json:"priority"`
+		PriorityID        string   `json:"priority_id"`
 		Labels            []string `json:"labels"`
 		Duedate           string   `json:"duedate"`
 	}
@@ -712,8 +712,8 @@ func (s *server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	if id := deref(p.AssigneeAccountID); id != "" {
 		fields["assignee"] = map[string]string{"accountId": id}
 	}
-	if pri := strings.TrimSpace(p.Priority); pri != "" {
-		fields["priority"] = map[string]string{"name": pri}
+	if id := strings.TrimSpace(p.PriorityID); id != "" {
+		fields["priority"] = create.PriorityField(id)
 	}
 	if labels := normalizeLabels(p.Labels); len(labels) > 0 {
 		fields["labels"] = labels

--- a/internal/server/write_test.go
+++ b/internal/server/write_test.go
@@ -568,7 +568,7 @@ func TestCreateIssueEmptyOptionalFieldsOmittedFromPayload(t *testing.T) {
 	// Empty string is "no value", not "set empty". issue_type:"" must resolve
 	// via the default; description/priority must not appear on the Jira body.
 	rec := send(t, h, http.MethodPost, apiBase+"create/",
-		`{"project_key":"NMB","issue_type":"","summary":"omit empties","description_text":"","priority":"","labels":[]}`)
+		`{"project_key":"NMB","issue_type":"","summary":"omit empties","description_text":"","priority_id":"","labels":[]}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("create → %d: %s", rec.Code, rec.Body.String())
 	}
@@ -583,6 +583,35 @@ func TestCreateIssueEmptyOptionalFieldsOmittedFromPayload(t *testing.T) {
 		if strings.Contains(sent, forbidden) {
 			t.Errorf("optional field %s present in payload: %s", forbidden, sent)
 		}
+	}
+}
+
+func TestCreateIssueSendsPriorityByID(t *testing.T) {
+	f, h, _ := writable(t)
+	rec := send(t, h, http.MethodPost, apiBase+"create/",
+		`{"project_key":"NMB","issue_type":"10004","summary":"with pri","priority_id":"2"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create → %d: %s", rec.Code, rec.Body.String())
+	}
+	sent := string(f.bodies["POST /issue"])
+	if !strings.Contains(sent, `"priority":{"id":"2"}`) {
+		t.Fatalf("priority id missing: %s", sent)
+	}
+	if strings.Contains(sent, `"priority":{"name"`) {
+		t.Fatalf("priority sent by name: %s", sent)
+	}
+}
+
+func TestCreateIssueIgnoresPriorityNameField(t *testing.T) {
+	f, h, _ := writable(t)
+	rec := send(t, h, http.MethodPost, apiBase+"create/",
+		`{"project_key":"NMB","issue_type":"10004","summary":"old name","priority":"High"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create → %d: %s", rec.Code, rec.Body.String())
+	}
+	sent := string(f.bodies["POST /issue"])
+	if strings.Contains(sent, `"priority"`) {
+		t.Fatalf("legacy priority name must not reach Jira: %s", sent)
 	}
 }
 

--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -125,6 +125,10 @@ fi
 # (GDK-28) and the same shape for status / issue-type equality on a
 # Jira-default EN/KO display name.
 #
+# Also: a plain string literal of a Jira-default name (GDK-248). The
+# pipe-table grep cannot see `['Highest', 'High', ...]` because there is
+# no `\|`. High/Medium/Low are omitted — too many other meanings.
+#
 # Deliberately not matched (would fail the current tree; sibling issue):
 #   - view-config.ts RESOLVED_STATUS_NAMES (legacy fallback when
 #     status_category is absent)
@@ -142,14 +146,32 @@ name_hits="$(
     -e "issue_type[[:space:]]*===[[:space:]]*['\"]Bug['\"]" \
     -e "issue_type[[:space:]]*===[[:space:]]*['\"]버그['\"]" \
     -e "name[[:space:]]*\.[[:space:]]*toLowerCase\(\)[[:space:]]*===[[:space:]]*['\"](bug|story|task|epic|sub-task|버그|스토리|작업|에픽)['\"]" \
+    -e "['\"]Highest['\"]" \
+    -e "['\"]Lowest['\"]" \
+    -e "['\"]In Progress['\"]" \
+    -e "['\"]Sub-task['\"]" \
     web/src/lib web/src/components web/src/stores \
     | grep -v '/i18n/' \
     || true
 )"
 if [[ -n "$name_hits" ]]; then
-  fail "web logic keys status/priority/type on a display name:"$'\n'"$name_hits"
+  fail "web logic keys status/priority/type on a display name — send GET /priorities/ catalog id via create.PriorityField(id); names follow the account language:"$'\n'"$name_hits"
 fi
 ok "web logic does not key status/priority/type on a display name"
+
+# Go writes must send priority/status/issuetype by id, never by name.
+# This is the real closure: every surface (web, CLI, future) hits Jira here.
+go_name_hits="$(
+  grep -RInE \
+    --include='*.go' --exclude='*_test.go' \
+    -e '\["(priority|status|issuetype)"\][[:space:]]*=[[:space:]]*map\[string\]string\{[[:space:]]*"name"' \
+    internal cmd \
+    || true
+)"
+if [[ -n "$go_name_hits" ]]; then
+  fail "Go write sends priority/status/issuetype by name — send priority via create.PriorityField(id); names follow the account language:"$'\n'"$go_name_hits"
+fi
+ok "Go writes do not send priority/status/issuetype by display name"
 
 # ── 8. PROMISES.md outbound list agrees with SECURITY.md ────────────────
 # SECURITY.md enumerates outbound destinations as a numbered list under

--- a/web/src/components/write/NewIssueDialog.svelte
+++ b/web/src/components/write/NewIssueDialog.svelte
@@ -22,7 +22,7 @@
   import { issues } from '../../stores/issues.svelte'
   import { filters } from '../../stores/filters.svelte'
   import { recentOf, whenReady } from '../../lib/recency'
-  import type { CreateMetaProject, JiraUser } from '../../lib/types'
+  import type { CreateMetaProject, JiraUser, PriorityOption } from '../../lib/types'
   import Icon from '../ui/Icon.svelte'
 
   // A native <select> keeps its keyboard model and its OS popup; only the closed
@@ -32,8 +32,6 @@
     'h-control w-full appearance-none rounded-md border border-border-strong bg-bg-base pl-2.5 pr-7 text-body text-text-primary outline-none focus:border-accent'
   const SELECT_CHEVRON =
     'pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rotate-90 text-text-muted'
-
-  const PRIORITIES = ['Highest', 'High', 'Medium', 'Low', 'Lowest']
 
   let loading = $state(true)
   let loadError = $state<string | null>(null)
@@ -47,6 +45,9 @@
   let summary = $state('')
   let description = $state('')
   let priority = $state('')
+  let priorities = $state<PriorityOption[]>([])
+  let prioritiesError = $state<string | null>(null)
+  let prioritiesLoading = $state(true)
   let duedate = $state('')
 
   // Assignee (optional)
@@ -78,7 +79,22 @@
 
   onMount(() => {
     void initDefaults()
+    void loadPriorities()
   })
+
+  async function loadPriorities() {
+    prioritiesLoading = true
+    prioritiesError = null
+    try {
+      const res = await api.getPriorities()
+      priorities = res.priorities.filter((p) => p.id)
+    } catch {
+      priorities = []
+      prioritiesError = t('write.prioritiesFailed')
+    } finally {
+      prioritiesLoading = false
+    }
+  }
 
   async function initDefaults() {
     // Wait for local.db recency (and the one-shot localStorage absorb) so
@@ -223,7 +239,7 @@
       summary: s,
       description_text: description.trim() || undefined,
       assignee_account_id: assignee?.account_id ?? undefined,
-      priority: priority || undefined,
+      priority_id: priority || undefined,
       labels: labels.length ? labels : undefined,
       duedate: duedate || undefined,
     })
@@ -368,14 +384,22 @@
           <label class="flex w-32 flex-none flex-col gap-1">
             <span class="text-micro text-text-secondary">{t('common.priority')}</span>
             <span class="relative flex">
-              <select bind:value={priority} class={SELECT}>
+              <select
+                bind:value={priority}
+                class={SELECT}
+                disabled={!!prioritiesError || prioritiesLoading}
+                data-testid="new-issue-priority"
+              >
                 <option value="">{t('common.defaultParen')}</option>
-                {#each PRIORITIES as p (p)}
-                  <option value={p}>{p}</option>
+                {#each priorities as p (p.id)}
+                  <option value={p.id}>{p.name}</option>
                 {/each}
               </select>
               <Icon name="chevron-right" size={13} class={SELECT_CHEVRON} />
             </span>
+            {#if prioritiesError}
+              <span class="text-micro text-status-reopen">{prioritiesError}</span>
+            {/if}
           </label>
         </div>
 

--- a/web/src/components/write/NewIssueDialog.test.ts
+++ b/web/src/components/write/NewIssueDialog.test.ts
@@ -1,0 +1,37 @@
+/*
+ * GDK-248: the create dialog must send a catalog priority id, never a
+ * hardcoded English display name.
+ *
+ * There is no component-mount harness (vitest is node, no svelte plugin),
+ * so this reads the source the way SearchBox.test.ts / HistoryView.test.ts
+ * do. Rendered catalog → POST payload is Playwright's job
+ * (e2e/duedate.spec.ts).
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = readFileSync(join(HERE, 'NewIssueDialog.svelte'), 'utf8')
+
+describe('NewIssueDialog create payload (GDK-248)', () => {
+  test('does not hardcode Jira default priority display names', () => {
+    expect(SRC).not.toMatch(/const PRIORITIES/)
+    expect(SRC).not.toMatch(/['"]Highest['"]/)
+    expect(SRC).not.toMatch(/['"]Lowest['"]/)
+  })
+
+  test('reads GET priorities/ through the existing api wrapper', () => {
+    expect(SRC).toMatch(/api\.getPriorities\s*\(/)
+  })
+
+  test('select values are catalog ids and labels are catalog names', () => {
+    expect(SRC).toMatch(/<option value=\{p\.id\}>\{p\.name\}<\/option>/)
+  })
+
+  test('submit sends priority_id and does not send a priority name key', () => {
+    expect(SRC).toMatch(/priority_id:\s*priority\s*\|\|\s*undefined/)
+    expect(SRC).not.toMatch(/^\s*priority:\s*priority/m)
+  })
+})

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -765,7 +765,8 @@ export interface CreateIssuePayload {
   summary: string
   description_text?: string
   assignee_account_id?: string | null
-  priority?: string
+  /** Site priority id from GET priorities/. Omit when unset. */
+  priority_id?: string
   labels?: string[]
   /** Calendar date (YYYY-MM-DD). Omit when unset — do not send "". */
   duedate?: string

--- a/web/src/stores/write.svelte.ts
+++ b/web/src/stores/write.svelte.ts
@@ -712,15 +712,12 @@ class WriteStore {
   }
 }
 
-const DEMO_PRIORITIES = ['Highest', 'High', 'Medium', 'Low', 'Lowest']
-
 function demoPriorities(pool: IssueLite[]): PriorityOption[] {
   const seen = new Map<string, number>()
   for (const it of pool) {
     if (!it.priority || seen.has(it.priority)) continue
     seen.set(it.priority, it.priority_rank ?? 99)
   }
-  if (seen.size === 0) return DEMO_PRIORITIES.map((name) => ({ id: name, name }))
   return [...seen.entries()]
     .sort((a, b) => a[1] - b[1])
     .map(([name]) => ({ id: name, name }))
@@ -752,7 +749,7 @@ const CREATE_OPTIONAL = [
   'issue_type',
   'description_text',
   'assignee_account_id',
-  'priority',
+  'priority_id',
   'labels',
   'duedate',
 ] as const
@@ -778,8 +775,8 @@ function compactCreatePayload(input: CreateIssuePayload): CreateIssuePayload {
   if (desc) body.description_text = desc
   const assignee = input.assignee_account_id?.trim()
   if (assignee) body.assignee_account_id = assignee
-  const priority = input.priority?.trim()
-  if (priority) body.priority = priority
+  const priority = input.priority_id?.trim()
+  if (priority) body.priority_id = priority
   if (input.labels?.length) {
     const labels = normalizeLabels(input.labels)
     if (labels.length) body.labels = labels


### PR DESCRIPTION
Closes GDK-248.

CLAUDE.md forbids keying status, priority and issue type on a display name, because Jira translates them per account and ignores `Accept-Language`. The web create path did it anyway:

- `NewIssueDialog.svelte:36` held `const PRIORITIES = ['Highest', 'High', 'Medium', 'Low', 'Lowest']`
- `internal/server/write.go:716` passed the chosen string straight through as `fields["priority"] = map[string]string{"name": pri}`

On a non-English account that is a **rejected field**, not a mistranslation.

Both other write paths were already right — `handlePriority` sends `{"id": id}`, and the CLI resolves through the catalog — so this was one surface out of three. And the catalog it needed was already on the wire at `GET /priorities/` with no reader.

## The gate is the more interesting half

`doc-checks` check 7 is named *"web logic does not key status/priority/type on a display name"* but only grepped the regex-alternation tables deleted from `format.ts` (GDK-28). A plain string array has no `\|`, so the violation sat in the tree while the check printed `ok`.

**A gate narrower than its own name poisons every "that trap is closed" judgement built on top of it.**

So the real closure is in Go, where every surface converges:

```
["priority"|"status"|"issuetype"] = map[string]string{"name"     → fail, anywhere in internal/ or cmd/
```

FAIL-first, it caught `internal/server/write.go:716`. Both failure messages now name the fix rather than only the line.

The string-literal patterns added to check 7 are deliberately limited to `Highest` / `Lowest` / `In Progress` / `Sub-task`. High, Medium and Low have too many other meanings, and a false-positive gate is one the next person turns off.

## Single owner

`create.Priority` (moved out of `cmd/gadak`) and `create.PriorityField` — now the only place that builds the Jira priority value, used by create-web, create-CLI and edit alike.

## What lead review added

The round moved the call site but left the original `resolvePriority` in `cmd/gadak/edit.go`, still used by edit — **two implementations of the resolution the change was meant to unify**. `edit.go` now calls `create.Priority` too, and `formatCreateTypes`, whose only remaining purpose was serving that duplicate, is gone.

## Gates (lead-run, from cold, in this tree)

```
go build ./... / go vet ./...                clean
go test ./... -count=1                       27 packages ok
tools/doc-checks.sh                          all passed, incl. both new assertions
npm run test:unit                            33 files / 329 tests
npx playwright test --config e2e/...         236 passed
```

Playwright count: 228 baseline → 235 after PR #6 → 236 here (+1 new duedate-spec case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)