### PR TITLE
A workspace is bound to one origin on the HTTP path too (GDK-247)

### DIFF
--- a/cmd/gadak/doctor.go
+++ b/cmd/gadak/doctor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/midagedev/gadak/internal/clitool"
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/originbind"
 	"github.com/midagedev/gadak/internal/store"
 )
 
@@ -48,6 +49,19 @@ type doctorReport struct {
 	MCP           doctorMCP             `json:"mcp"`
 	Sync          map[string]doctorSync `json:"sync"`
 	APIUsage      doctorAPIUsage        `json:"api_usage"`
+	Workspace     doctorWorkspace       `json:"workspace"`
+}
+
+// doctorWorkspace is the one-line consistency view: kind, whether a site
+// token is stored (never the token itself), the origin persist path, and
+// how many locally originated issues LocalData counts. Inconsistent is
+// standalone-with-a-token — the state GDK-247 closes on the write path.
+type doctorWorkspace struct {
+	Kind          string `json:"kind"`
+	HasCredential bool   `json:"has_credential"`
+	Persist       string `json:"persist"`
+	LocalIssues   int    `json:"local_issues"`
+	Inconsistent  bool   `json:"inconsistent"`
 }
 
 // doctorSkill answers "is my Claude Code skill current?" without the user
@@ -139,6 +153,9 @@ func collectDoctor() doctorReport {
 			Day: time.Now().UTC().Format("2006-01-02"),
 		},
 		Migrations: "unknown",
+		Workspace: doctorWorkspace{
+			Kind: config.KindConnected,
+		},
 	}
 
 	if path, err := config.DBPath(); err == nil {
@@ -167,6 +184,15 @@ func collectDoctor() doctorReport {
 			rep.Origin = tildeHome(src)
 		} else {
 			rep.Origin = src
+		}
+		n, persist, _ := originbind.LocalData(cfg)
+		hasTok := cfg.Token != ""
+		rep.Workspace = doctorWorkspace{
+			Kind:          cfg.WorkspaceKind(),
+			HasCredential: hasTok,
+			Persist:       tildeHome(persist),
+			LocalIssues:   n,
+			Inconsistent:  cfg.IsStandalone() && hasTok,
 		}
 	}
 
@@ -408,6 +434,7 @@ func formatDoctorText(r doctorReport) string {
 	line("profile", r.Profile)
 	line("workspace_kind", r.WorkspaceKind)
 	line("origin", r.Origin)
+	line("workspace", formatDoctorWorkspace(r.Workspace))
 	line("mirror_path", r.MirrorPath)
 
 	switch r.Mirror.Status {
@@ -487,6 +514,23 @@ func formatDoctorText(r doctorReport) string {
 	line("api_usage.retries", strconv.FormatInt(r.APIUsage.Retries, 10))
 
 	return b.String()
+}
+
+func formatDoctorWorkspace(w doctorWorkspace) string {
+	cred := "no"
+	if w.HasCredential {
+		cred = "yes"
+	}
+	persist := w.Persist
+	if persist == "" {
+		persist = "none"
+	}
+	s := fmt.Sprintf("kind=%s credential=%s persist=%s issues=%d",
+		w.Kind, cred, persist, w.LocalIssues)
+	if w.Inconsistent {
+		s += " inconsistent"
+	}
+	return s
 }
 
 // tildeHome shortens an absolute path under the user's home to ~/… so doctor

--- a/cmd/gadak/doctor_test.go
+++ b/cmd/gadak/doctor_test.go
@@ -250,6 +250,7 @@ func TestDoctorJSONMatchesHumanFields(t *testing.T) {
 		"schema_version:",
 		"migrations:",
 		"credential:",
+		"workspace:",
 		"site:",
 		"email:",
 		"api_usage.day:",
@@ -380,6 +381,52 @@ func doctorValue(t *testing.T, out, key string) string {
 	}
 	t.Fatalf("no %q line in doctor output:\n%s", key, out)
 	return ""
+}
+
+func TestDoctorReportsStandaloneWithCredential(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	t.Setenv("HOME", home)
+	config.SetProfile("")
+
+	const planted = "NOT-A-REAL-TOKEN-doctor-inconsistent"
+	cfg := &config.Config{Kind: config.KindStandalone, Token: planted}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := capture(t, func() error { return cmdDoctor(nil) })
+	if err != nil {
+		t.Fatalf("doctor: %v\n%s", err, out)
+	}
+	if strings.Contains(out, planted) {
+		t.Fatalf("doctor leaked the token:\n%s", out)
+	}
+	got := doctorValue(t, out, "workspace")
+	if !strings.Contains(got, "kind=standalone") {
+		t.Errorf("workspace line missing kind=standalone: %q", got)
+	}
+	if !strings.Contains(got, "credential=yes") {
+		t.Errorf("workspace line missing credential=yes: %q", got)
+	}
+	if !strings.Contains(got, "inconsistent") {
+		t.Errorf("standalone-with-token must say inconsistent: %q", got)
+	}
+
+	raw, err := capture(t, func() error { return cmdDoctor([]string{"--json"}) })
+	if err != nil {
+		t.Fatalf("doctor --json: %v\n%s", err, raw)
+	}
+	if strings.Contains(raw, planted) {
+		t.Fatalf("json leaked the token:\n%s", raw)
+	}
+	var rep doctorReport
+	if err := json.Unmarshal([]byte(raw), &rep); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, raw)
+	}
+	if !rep.Workspace.Inconsistent || !rep.Workspace.HasCredential || rep.Workspace.Kind != config.KindStandalone {
+		t.Fatalf("json workspace = %+v", rep.Workspace)
+	}
 }
 
 func TestClassifyLastError(t *testing.T) {

--- a/cmd/gadak/init.go
+++ b/cmd/gadak/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/jira"
 	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/originbind"
 	"github.com/midagedev/gadak/internal/store"
 )
 
@@ -70,141 +71,30 @@ func parseCSVKeys(s string, upper bool) []string {
 // sync treats them as upstream deletions.
 const replaceStandaloneUsage = "replace this standalone workspace with a Jira site; locally originated issues exist only here and a later sync will delete them from the mirror"
 
-// standaloneReplaceErrCode is the --json "error" value when a connected
-// init refuses to take over a standalone workspace that holds data.
-const standaloneReplaceErrCode = "standalone_data_present"
-
-// refuseStandaloneReplace stops a connected init from silently changing
-// which origin owns a standalone workspace that holds locally originated
-// issues. An empty standalone workspace (tried it, nothing filed) is not
-// a hazard and is allowed through.
-func refuseStandaloneReplace(cfg *config.Config, replace, jsonOut bool) error {
-	if cfg == nil || !cfg.IsStandalone() || replace {
-		return nil
+// renderReplaceRefusedJSON writes the --json document for a refused
+// standalone replace. Shape and field values match the previous
+// refuseStandaloneReplace encoder (CLI --json contract).
+func renderReplaceRefusedJSON(err error) error {
+	var refused *originbind.ReplaceRefusedError
+	if !errors.As(err, &refused) {
+		return err
 	}
-	n, persist, err := standaloneLocalData(cfg)
-	if err != nil {
-		return fmt.Errorf("cannot replace standalone workspace: %w", err)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	if encErr := enc.Encode(struct {
+		Error   string `json:"error"`
+		Issues  int    `json:"issues"`
+		Persist string `json:"persist"`
+		Hint    string `json:"hint"`
+	}{
+		Error:   originbind.ErrCodeReplaceRefused,
+		Issues:  refused.Issues,
+		Persist: refused.Persist,
+		Hint:    "gadak --profile <name> init",
+	}); encErr != nil {
+		return fmt.Errorf("%s\n(also failed to encode JSON: %v)", refused.Error(), encErr)
 	}
-	if n == 0 {
-		return nil
-	}
-	msg := standaloneReplaceMessage(n, persist)
-	if jsonOut {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetEscapeHTML(false)
-		if encErr := enc.Encode(struct {
-			Error   string `json:"error"`
-			Issues  int    `json:"issues"`
-			Persist string `json:"persist"`
-			Hint    string `json:"hint"`
-		}{
-			Error:   standaloneReplaceErrCode,
-			Issues:  n,
-			Persist: persist,
-			Hint:    "gadak --profile <name> init",
-		}); encErr != nil {
-			return fmt.Errorf("%s\n(also failed to encode JSON: %v)", msg, encErr)
-		}
-	}
-	return errors.New(msg)
-}
-
-func standaloneReplaceMessage(n int, persist string) string {
-	noun, exist := "issues", "they exist only here"
-	if n == 1 {
-		noun, exist = "issue", "it exists only here"
-	}
-	return fmt.Sprintf("this workspace is standalone and holds %d locally originated %s; %s — no Jira site has a copy\norigin persist file: %s\nconnect the site in a separate workspace: gadak --profile <name> init\n(list workspaces with gadak profiles)\nto replace this workspace anyway (a later sync will delete these issues from the mirror): --replace-standalone",
-		n, noun, exist, persist)
-}
-
-// standaloneLocalData reports how many locally originated issues this
-// standalone workspace holds, and the origin persist path (via
-// origin.PersistPath — never rebuilt from string pieces).
-//
-// "Holds data" is max(mirror issues, origin issues):
-//   - mirror: SELECT COUNT(*) FROM issues, only if gadak.db already exists
-//     (store.Open would create it)
-//   - origin: Search on the in-process origin, only if the persist file
-//     already exists (origin.Client would create it)
-//
-// init --standalone creates a persist file with a project fixture and no
-// issues, so that empty-origin case is n==0 and the common "I tried it,
-// now I want to connect" path is not blocked.
-func standaloneLocalData(cfg *config.Config) (n int, persist string, err error) {
-	dir := ""
-	if cfg != nil {
-		dir = cfg.Directory()
-	}
-	if dir == "" {
-		dir, err = config.Dir()
-		if err != nil {
-			return 0, "", err
-		}
-	}
-	persist = origin.PersistPath(dir)
-
-	mirrorN, err := standaloneMirrorIssueCount()
-	if err != nil {
-		return 0, persist, err
-	}
-	originN, err := standaloneOriginIssueCount(cfg, persist)
-	if err != nil {
-		return 0, persist, err
-	}
-	n = mirrorN
-	if originN > n {
-		n = originN
-	}
-	return n, persist, nil
-}
-
-func standaloneMirrorIssueCount() (int, error) {
-	path, err := config.DBPath()
-	if err != nil {
-		return 0, err
-	}
-	st, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	if st.IsDir() {
-		return 0, nil
-	}
-	db, err := store.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer db.Close()
-	return db.TableCount(context.Background(), "issues")
-}
-
-func standaloneOriginIssueCount(cfg *config.Config, persist string) (int, error) {
-	if persist == "" {
-		return 0, nil
-	}
-	if _, err := os.Stat(persist); err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
-	}
-	c, err := origin.Client(cfg)
-	if err != nil {
-		return 0, err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	n := 0
-	err = c.Search(ctx, "ORDER BY created ASC", []string{"summary"}, false, func(issues []jira.Issue) error {
-		n += len(issues)
-		return nil
-	})
-	return n, err
+	return err
 }
 
 // initMissingError lists every value still empty and how to supply it without a
@@ -278,7 +168,10 @@ func cmdInit(args []string) error {
 	// Close the class "a command silently changes which origin owns this
 	// workspace". An empty standalone workspace is not a hazard; one that
 	// holds locally originated issues is (GDK-238).
-	if err := refuseStandaloneReplace(cfg, *replaceStandalone, *jsonOut); err != nil {
+	if err := originbind.RefuseReplace(cfg, *replaceStandalone); err != nil {
+		if *jsonOut {
+			return renderReplaceRefusedJSON(err)
+		}
 		return err
 	}
 
@@ -413,8 +306,8 @@ func cmdInit(args []string) error {
 	cfg.Email = email
 	cfg.Token = token
 	cfg.Projects = projects
-	// Reached only after refuseStandaloneReplace (or --replace-standalone).
-	cfg.Kind = ""
+	// Reached only after RefuseReplace (or --replace-standalone).
+	originbind.ClearStandalone(cfg)
 
 	// Confluence: flag absent leaves the section untouched.
 	if *spacesFlag != "" {

--- a/e2e/onboarding-standalone.spec.ts
+++ b/e2e/onboarding-standalone.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from '@playwright/test'
+import { attachConsoleErrors, forceLocale } from './helpers'
+
+/*
+ * GDK-247: connecting a Jira site onto a standalone workspace that holds
+ * locally originated issues must be refused until the user opts in.
+ * The demo server is a connected fixture, so the empty first-run state and
+ * the 409 are both route-mocked — no request reaches Jira or mutates config.
+ */
+
+const API = '**/api/v1/issues/'
+
+const EMPTY_BOOTSTRAP = {
+  server_time: '2026-08-04T00:00:00.000Z',
+  sync_version: 0,
+  members: [],
+  members_version: '',
+  issues: [],
+  sync_health: { overall: 'healthy', checked_at: '2026-08-04T00:00:00.000Z', sources: [] },
+}
+
+const CREDENTIAL = {
+  configured: true,
+  jira_email: 'dana@example.com',
+  display_name: 'Dana Scully',
+  verified_at: '2026-08-04T00:00:00.000Z',
+  token_hint: '…9876',
+}
+
+const PERSIST = '/tmp/gadak-e2e/origin/issuetap.yaml'
+
+async function mockFirstRun(page: Page): Promise<void> {
+  await page.route('**/config.json', (route) =>
+    route.fulfill({
+      json: {
+        apiBase: '/api/v1/issues/',
+        authBase: '/api/v1/auth/',
+        jiraBaseUrl: '',
+        projects: [],
+        features: {},
+      },
+    }),
+  )
+  await page.route('**/api/v1/auth/me/', (route) => route.fulfill({ json: { email: null } }))
+  await page.route(`${API}bootstrap/**`, (route) =>
+    route.fulfill({ json: { ...EMPTY_BOOTSTRAP, issues: [] } }),
+  )
+  await page.route(`${API}delta/**`, (route) =>
+    route.fulfill({
+      json: { ...EMPTY_BOOTSTRAP, issues: [], upserted: [], deleted_keys: [] },
+    }),
+  )
+}
+
+test.describe('standalone onboarding origin guard', () => {
+  test('409 standalone_data_present is shown; replace requires a second confirm', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await mockFirstRun(page)
+
+    const connectBodies: Record<string, unknown>[] = []
+    await page.route(`${API}onboarding/connect/`, async (route) => {
+      const body = route.request().postDataJSON() as Record<string, unknown>
+      connectBodies.push(body)
+      if (body.replace_standalone === true) {
+        await route.fulfill({ json: CREDENTIAL })
+        return
+      }
+      await route.fulfill({
+        status: 409,
+        json: { error: 'standalone_data_present', issues: 3, persist: PERSIST },
+      })
+    })
+    await page.route(`${API}projects/available/`, (route) =>
+      route.fulfill({
+        json: {
+          projects: [{ key: 'NMB', name: 'Nimbus', projectTypeKey: 'software' }],
+          truncated: false,
+        },
+      }),
+    )
+
+    await forceLocale(page, 'en')
+    await page.goto('/')
+
+    const wizard = page.getByTestId('onboarding')
+    await expect(wizard).toBeVisible({ timeout: 30_000 })
+    await wizard.locator('input[name="site"]').fill('https://example.atlassian.net')
+    await wizard.locator('input[name="email"]').fill('dana@example.com')
+    await wizard.locator('input[name="token"]').fill('super-secret-token')
+    await wizard.getByRole('button', { name: 'Connect', exact: true }).click()
+
+    const block = page.getByTestId('onboarding-standalone-block')
+    await expect(block).toBeVisible()
+    await expect(block).toContainText('3 locally originated issues')
+    await expect(page.getByTestId('onboarding-standalone-persist')).toContainText(PERSIST)
+    await expect(block).toContainText('separate workspace')
+    expect(connectBodies).toHaveLength(1)
+    expect(connectBodies[0].replace_standalone).toBeUndefined()
+
+    const replace = wizard.getByRole('button', { name: 'Replace and connect', exact: true })
+    await expect(replace).toBeDisabled()
+
+    await page.getByTestId('onboarding-replace-standalone').check()
+    await expect(replace).toBeEnabled()
+    await replace.click()
+
+    await expect(page.getByTestId('onboarding-projects')).toBeVisible()
+    expect(connectBodies).toHaveLength(2)
+    expect(connectBodies[1].replace_standalone).toBe(true)
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})

--- a/internal/originbind/originbind.go
+++ b/internal/originbind/originbind.go
@@ -1,0 +1,171 @@
+// Package originbind owns one invariant: a workspace is bound to one origin.
+//
+// Both surfaces that can change which origin owns a workspace live behind it —
+// `gadak init` and PUT onboarding/connect/ — so the decision cannot exist on
+// one path and not the other. That split is exactly how GDK-247 happened: the
+// CLI path was closed and the unauthenticated HTTP path was not.
+//
+// It is not part of internal/workspace, which mounts profiles under /w/ and
+// imports internal/server: the server calls this, so that would cycle.
+package originbind
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/store"
+)
+
+// ErrCodeReplaceRefused is the --json / HTTP "error" value when a connected
+// init or onboarding connect refuses to take over a standalone workspace
+// that holds data. The string is a CLI --json contract; do not change it.
+const ErrCodeReplaceRefused = "standalone_data_present"
+
+// ReplaceRefusedError is returned when RefuseReplace blocks a connect.
+// Error() is the human sentence previously printed by gadak init.
+type ReplaceRefusedError struct {
+	Issues  int
+	Persist string
+}
+
+func (e *ReplaceRefusedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return replaceMessage(e.Issues, e.Persist)
+}
+
+// replaceMessage is the former standaloneReplaceMessage. Wording is a
+// user-facing contract; do not invent a new sentence.
+func replaceMessage(n int, persist string) string {
+	noun, exist := "issues", "they exist only here"
+	if n == 1 {
+		noun, exist = "issue", "it exists only here"
+	}
+	return fmt.Sprintf("this workspace is standalone and holds %d locally originated %s; %s — no Jira site has a copy\norigin persist file: %s\nconnect the site in a separate workspace: gadak --profile <name> init\n(list workspaces with gadak profiles)\nto replace this workspace anyway (a later sync will delete these issues from the mirror): --replace-standalone",
+		n, noun, exist, persist)
+}
+
+// RefuseReplace stops a connected init / onboarding connect from silently
+// changing which origin owns a standalone workspace that holds locally
+// originated issues. An empty standalone workspace (tried it, nothing
+// filed) is not a hazard and is allowed through.
+//
+// JSON rendering stays at the CLI call site — this returns an error only.
+func RefuseReplace(cfg *config.Config, replace bool) error {
+	if cfg == nil || !cfg.IsStandalone() || replace {
+		return nil
+	}
+	n, persist, err := LocalData(cfg)
+	if err != nil {
+		return fmt.Errorf("cannot replace standalone workspace: %w", err)
+	}
+	if n == 0 {
+		return nil
+	}
+	return &ReplaceRefusedError{Issues: n, Persist: persist}
+}
+
+// ClearStandalone is the single owner of "origin is now a Jira site, so
+// this workspace is no longer standalone". Reached only after RefuseReplace
+// (or an explicit replace opt-in). Empty standalone workspaces take this
+// path too: once connected, Kind must be cleared.
+func ClearStandalone(next *config.Config) {
+	if next == nil {
+		return
+	}
+	next.Kind = ""
+}
+
+// LocalData reports how many locally originated issues this standalone
+// workspace holds, and the origin persist path (via origin.PersistPath —
+// never rebuilt from string pieces).
+//
+// "Holds data" is max(mirror issues, origin issues):
+//   - mirror: SELECT COUNT(*) FROM issues, only if gadak.db already exists
+//     (store.Open would create it)
+//   - origin: Search on the in-process origin, only if the persist file
+//     already exists (origin.Client would create it)
+//
+// init --standalone creates a persist file with a project fixture and no
+// issues, so that empty-origin case is n==0 and the common "I tried it,
+// now I want to connect" path is not blocked.
+func LocalData(cfg *config.Config) (n int, persist string, err error) {
+	dir := ""
+	if cfg != nil {
+		dir = cfg.Directory()
+	}
+	if dir == "" {
+		dir, err = config.Dir()
+		if err != nil {
+			return 0, "", err
+		}
+	}
+	persist = origin.PersistPath(dir)
+
+	mirrorN, err := mirrorIssueCount()
+	if err != nil {
+		return 0, persist, err
+	}
+	originN, err := originIssueCount(cfg, persist)
+	if err != nil {
+		return 0, persist, err
+	}
+	n = mirrorN
+	if originN > n {
+		n = originN
+	}
+	return n, persist, nil
+}
+
+func mirrorIssueCount() (int, error) {
+	path, err := config.DBPath()
+	if err != nil {
+		return 0, err
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if st.IsDir() {
+		return 0, nil
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+	return db.TableCount(context.Background(), "issues")
+}
+
+func originIssueCount(cfg *config.Config, persist string) (int, error) {
+	if persist == "" {
+		return 0, nil
+	}
+	if _, err := os.Stat(persist); err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	c, err := origin.Client(cfg)
+	if err != nil {
+		return 0, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	n := 0
+	err = c.Search(ctx, "ORDER BY created ASC", []string{"summary"}, false, func(issues []jira.Issue) error {
+		n += len(issues)
+		return nil
+	})
+	return n, err
+}

--- a/internal/originbind/owner_gate_test.go
+++ b/internal/originbind/owner_gate_test.go
@@ -1,0 +1,112 @@
+package originbind
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectKindClearOutsideOriginbind is the structural lock: clearing
+// Kind (leaving standalone) belongs to ClearStandalone in this package.
+// A `.Kind = ""` assignment in production code outside internal/originbind/
+// fails this test.
+//
+// Tests (*_test.go) may still write Kind in fixtures.
+// Pattern borrowed from internal/origin/direct_new_gate_test.go.
+func TestNoDirectKindClearOutsideOriginbind(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "dist", "testdata", "scratch":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasPrefix(rel, "internal/originbind/") {
+			return nil
+		}
+		hits = append(hits, findKindClearAssignments(t, path, rel)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) > 0 {
+		t.Fatalf("cfg.Kind = \"\" must not be assigned from production code outside internal/originbind (use workspace.ClearStandalone):\n  %s",
+			strings.Join(hits, "\n  "))
+	}
+}
+
+func findKindClearAssignments(t *testing.T, path, rel string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", rel, err)
+		return nil
+	}
+	var hits []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			sel, ok := lhs.(*ast.SelectorExpr)
+			if !ok || sel.Sel == nil || sel.Sel.Name != "Kind" {
+				continue
+			}
+			if i >= len(as.Rhs) {
+				continue
+			}
+			lit, ok := as.Rhs[i].(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			if lit.Value != `""` && lit.Value != "``" {
+				continue
+			}
+			pos := fset.Position(as.Pos())
+			hits = append(hits, rel+":"+itoa(pos.Line))
+		}
+		return true
+	})
+	return hits
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/server/onboarding.go
+++ b/internal/server/onboarding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/jira"
 	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/originbind"
 	"github.com/midagedev/gadak/internal/store"
 	"github.com/midagedev/gadak/internal/sync"
 )
@@ -33,10 +34,11 @@ const maxProjects = 500
 /* ── step 1: connect ── */
 
 type connectDoc struct {
-	Site           string `json:"site"`
-	JiraEmail      string `json:"jira_email"`
-	APIToken       string `json:"api_token"`
-	TokenExpiresAt string `json:"token_expires_at"`
+	Site              string `json:"site"`
+	JiraEmail         string `json:"jira_email"`
+	APIToken          string `json:"api_token"`
+	TokenExpiresAt    string `json:"token_expires_at"`
+	ReplaceStandalone bool   `json:"replace_standalone"`
 }
 
 // handleConnect verifies the credential against Jira /myself before storing it,
@@ -58,6 +60,21 @@ func (s *server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusBadRequest, "email_and_token_required")
 		return
 	}
+	// Refuse before /myself: a standalone workspace that holds local issues
+	// must not send the pasted token anywhere, and must not write it to disk.
+	if err := originbind.RefuseReplace(s.config(), in.ReplaceStandalone); err != nil {
+		var refused *originbind.ReplaceRefusedError
+		if errors.As(err, &refused) {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":   originbind.ErrCodeReplaceRefused,
+				"issues":  refused.Issues,
+				"persist": refused.Persist,
+			})
+			return
+		}
+		serverError(w, r, err)
+		return
+	}
 	// Snapshot before save: first credential may need to kick the serve Watch loop.
 	hadCredential := s.config().HasCredential()
 	me, err := origin.Connected(site, email, token).Myself(r.Context())
@@ -77,6 +94,7 @@ func (s *server) handleConnect(w http.ResponseWriter, r *http.Request) {
 		fail(w, http.StatusBadRequest, "invalid_token_expires")
 		return
 	}
+	originbind.ClearStandalone(&next)
 	if err := next.Save(); err != nil {
 		serverError(w, r, err)
 		return

--- a/internal/server/onboarding_test.go
+++ b/internal/server/onboarding_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/store"
 	gadakSync "github.com/midagedev/gadak/internal/sync"
 )
@@ -474,6 +476,156 @@ func kickSyncFastTransport(s *server, cfg *config.Config, full bool) bool {
 		s.syncJob.Phase, s.syncJob.Done = "done", true
 	}()
 	return true
+}
+
+// standaloneConnectEnv is a standalone workspace whose in-process server is
+// ready for PUT onboarding/connect/. issueCount seeds gadak.db under
+// GADAK_HOME (the path LocalData counts) — the fixture DB used by the
+// handler is a different file and is not what the replace guard reads.
+func standaloneConnectEnv(t *testing.T, issueCount int) (*onboardJira, http.Handler, string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	f := newOnboardJira(t)
+	db, cfg := fixture(t)
+	cfg.Site, cfg.Email, cfg.Token = "", "", ""
+	cfg.Projects = nil
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if issueCount > 0 {
+		seedLocalMirrorIssues(t, issueCount)
+	}
+	return f, New(db, cfg), home
+}
+
+func seedLocalMirrorIssues(t *testing.T, n int) {
+	t.Helper()
+	path, err := config.DBPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := db.UpsertSource(context.Background(), store.Source{ID: "jira", Kind: "jira", BaseURL: ""}); err != nil {
+		t.Fatal(err)
+	}
+	recs := make([]store.IssueRecord, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("STD-%d", i+1)
+		recs[i] = store.IssueRecord{
+			Item: store.Item{
+				ID: "jira:" + key, SourceID: "jira", ExternalID: key, Key: key,
+				Title: "local " + key, CreatedAt: "2026-07-01T00:00:00.000Z", UpdatedAt: "2026-07-01T00:00:00.000Z",
+			},
+			Issue: store.Issue{ProjectKey: "STD", Status: "To Do", StatusID: "1", StatusCategory: "new"},
+		}
+	}
+	if _, err := db.UpsertIssues(context.Background(), store.Batch{
+		Categories: map[string]string{"1": "new"},
+		Records:    recs,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConnectRefusesStandaloneWithLocalData(t *testing.T) {
+	const secret = "tok-must-not-land-on-disk"
+	f, h, home := standaloneConnectEnv(t, 2)
+
+	rec := send(t, h, http.MethodPut, apiBase+"onboarding/connect/",
+		`{"site":"`+f.URL+`","jira_email":"hc@example.com","api_token":"`+secret+`"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Error   string `json:"error"`
+		Issues  int    `json:"issues"`
+		Persist string `json:"persist"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v body %s", err, rec.Body.String())
+	}
+	if body.Error != "standalone_data_present" {
+		t.Fatalf("error %q, want standalone_data_present", body.Error)
+	}
+	if body.Issues < 1 {
+		t.Fatalf("issues = %d, want >= 1", body.Issues)
+	}
+	wantPersist := origin.PersistPath(home)
+	if body.Persist != wantPersist {
+		t.Fatalf("persist %q, want %q", body.Persist, wantPersist)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(home, "config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(raw), secret) {
+		t.Fatalf("refused connect wrote the token to disk:\n%s", raw)
+	}
+	saved := savedConfig(t, home)
+	if tok, ok := saved["token"]; ok && tok != "" && tok != nil {
+		t.Fatalf("token present on disk after 409: %v", tok)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.IsStandalone() {
+		t.Fatal("refused connect must leave the workspace standalone")
+	}
+	if cfg.Token != "" {
+		t.Fatal("refused connect must not store a token")
+	}
+}
+
+func TestConnectReplaceStandaloneClearsKind(t *testing.T) {
+	f, h, home := standaloneConnectEnv(t, 2)
+
+	rec := send(t, h, http.MethodPut, apiBase+"onboarding/connect/",
+		`{"site":"`+f.URL+`","jira_email":"hc@example.com","api_token":"tok","replace_standalone":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Kind != "" {
+		t.Fatalf("Kind = %q, want empty", cfg.Kind)
+	}
+	if cfg.IsStandalone() {
+		t.Fatal("replace_standalone must leave IsStandalone false")
+	}
+	saved := savedConfig(t, home)
+	if saved["token"] != "tok" {
+		t.Fatalf("token after replace: %v", saved["token"])
+	}
+}
+
+func TestConnectEmptyStandaloneClearsKind(t *testing.T) {
+	f, h, _ := standaloneConnectEnv(t, 0)
+
+	rec := send(t, h, http.MethodPut, apiBase+"onboarding/connect/",
+		`{"site":"`+f.URL+`","jira_email":"hc@example.com","api_token":"tok"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty standalone should connect: %d %s", rec.Code, rec.Body.String())
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Kind != "" {
+		t.Fatalf("Kind = %q, want empty", cfg.Kind)
+	}
+	if cfg.IsStandalone() {
+		t.Fatal("empty standalone connect must leave IsStandalone false")
+	}
 }
 
 func connect(t *testing.T, h http.Handler, f *onboardJira) {

--- a/web/src/components/shell/Onboarding.svelte
+++ b/web/src/components/shell/Onboarding.svelte
@@ -73,21 +73,35 @@
   let connecting = $state(false)
   let connectError = $state<string | null>(null)
   let owner = $state('')
+  let standaloneBlock = $state<{ issues: number; persist: string } | null>(null)
+  let replaceStandalone = $state(false)
 
   async function connect(event: SubmitEvent): Promise<void> {
     event.preventDefault()
+    // Second request only after an explicit confirm — never auto-retry the 409.
+    if (standaloneBlock && !replaceStandalone) return
     connecting = true
     connectError = null
     try {
-      const cred = await api.connectJira(site.trim(), email.trim(), token, tokenExpires)
+      const cred = await api.connectJira(site.trim(), email.trim(), token, tokenExpires, {
+        replaceStandalone,
+      })
       owner = cred.display_name || cred.jira_email
       // The credential is the identity, so the rest of the app has to re-read it.
       await me.refreshIdentity()
       token = '' // no reason to keep it in a live component
+      standaloneBlock = null
+      replaceStandalone = false
       step = 2
       void loadProjects()
     } catch (e) {
-      connectError = connectMessage(e)
+      if (e instanceof api.StandaloneDataPresentError) {
+        standaloneBlock = { issues: e.issues, persist: e.persist }
+        replaceStandalone = false
+        connectError = null
+      } else {
+        connectError = connectMessage(e)
+      }
     } finally {
       connecting = false
     }
@@ -111,6 +125,7 @@
     if (code === 'site_required') return t('onboarding.errSite')
     if (code === 'email_and_token_required') return t('onboarding.errFields')
     if (code === 'invalid_token_expires') return t('onboarding.errExpires')
+    if (code === 'standalone_data_present') return t('onboarding.standaloneBlocked', { n: 0 })
     return t('onboarding.errConnect', { message: reason(e) })
   }
 
@@ -333,6 +348,27 @@
           <span class="text-micro text-text-muted">{t('onboarding.tokenExpiresHint')}</span>
         </label>
 
+        {#if standaloneBlock}
+          <div class="flex flex-col gap-2" role="alert" data-testid="onboarding-standalone-block">
+            <p class="text-[12px] text-status-reopen">
+              {t('onboarding.standaloneBlocked', { n: standaloneBlock.issues })}
+            </p>
+            <p class="font-mono text-micro text-text-secondary" data-testid="onboarding-standalone-persist">
+              {t('onboarding.standalonePersist', { path: standaloneBlock.persist })}
+            </p>
+            <p class="text-micro text-text-secondary">{t('onboarding.standaloneOtherWorkspace')}</p>
+            <label class="flex items-start gap-2 text-[12px] text-text-secondary">
+              <input
+                type="checkbox"
+                class="mt-0.5 accent-accent"
+                data-testid="onboarding-replace-standalone"
+                bind:checked={replaceStandalone}
+              />
+              <span>{t('onboarding.standaloneReplaceConfirm')}</span>
+            </label>
+          </div>
+        {/if}
+
         {#if connectError}
           <div class="flex flex-col gap-1" role="alert" data-testid="onboarding-error">
             <p class="text-[12px] text-status-reopen">{connectError}</p>
@@ -348,8 +384,16 @@
         {/if}
 
         <div class="flex items-center gap-2">
-          <button class={PRIMARY} type="submit" disabled={connecting}>
-            {connecting ? t('onboarding.connecting') : t('onboarding.connect')}
+          <button
+            class={PRIMARY}
+            type="submit"
+            disabled={connecting || (!!standaloneBlock && !replaceStandalone)}
+          >
+            {connecting
+              ? t('onboarding.connecting')
+              : standaloneBlock
+                ? t('onboarding.standaloneReplace')
+                : t('onboarding.connect')}
           </button>
           <button class={GHOST} type="button" onclick={onOpenSettings}>{t('onboarding.openSettings')}</button>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -67,6 +67,18 @@ export class ApiError extends Error {
   }
 }
 
+/** 409 standalone_data_present from PUT onboarding/connect/. */
+export class StandaloneDataPresentError extends ApiError {
+  issues: number
+  persist: string
+  constructor(status: number, issues: number, persist: string) {
+    super(status, 'standalone_data_present', 'standalone_data_present')
+    this.name = 'StandaloneDataPresentError'
+    this.issues = issues
+    this.persist = persist
+  }
+}
+
 /** Shared fetch — path is relative to the API base. */
 async function raw(path: string, init?: RequestInit): Promise<Response> {
   return fetch(config().apiBase + path, {
@@ -494,20 +506,48 @@ export interface SyncProgress {
 }
 
 /** Verify site+email+token via /myself, then store. Failures distinguished by ApiError.code. */
-export function connectJira(
+export async function connectJira(
   site: string,
   jiraEmail: string,
   apiToken: string,
   tokenExpiresAt?: string,
+  opts?: { replaceStandalone?: boolean },
 ): Promise<JiraCredential> {
-  const body: Record<string, string> = { site, jira_email: jiraEmail, api_token: apiToken }
+  const body: Record<string, unknown> = { site, jira_email: jiraEmail, api_token: apiToken }
   const expires = tokenExpiresAt?.trim()
   if (expires) body.token_expires_at = expires
-  return jsonW<JiraCredential>('onboarding/connect/', {
+  if (opts?.replaceStandalone) body.replace_standalone = true
+  const res = await raw('onboarding/connect/', {
     method: 'PUT',
     headers: JSON_HEADERS,
     body: JSON.stringify(body),
   })
+  if (!res.ok) {
+    let code: string | null = null
+    let issues = 0
+    let persist = ''
+    let message = `PUT onboarding/connect/ → ${res.status}`
+    try {
+      const doc = (await res.json()) as {
+        error?: string
+        issues?: number
+        persist?: string
+      }
+      if (doc.error) {
+        code = doc.error
+        message = doc.error
+      }
+      if (typeof doc.issues === 'number') issues = doc.issues
+      if (typeof doc.persist === 'string') persist = doc.persist
+    } catch {
+      /* No body / non-JSON — keep default message */
+    }
+    if (res.status === 409 && code === 'standalone_data_present') {
+      throw new StandaloneDataPresentError(res.status, issues, persist)
+    }
+    throw new ApiError(res.status, message, code)
+  }
+  return (await res.json()) as JiraCredential
 }
 
 /** Real project list for the site. `truncated` means the list was capped at 500. */

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -1107,6 +1107,16 @@ export const en = {
   'onboarding.switchAccount': 'Use a different account',
   'onboarding.openSettings': 'Open settings',
   'onboarding.cliHint': 'The same setup is available as gadak init in a terminal.',
+  // GDK-247: PUT onboarding/connect/ 409 standalone_data_present. Facts match
+  // cmd/gadak/init.go's ReplaceRefusedError sentence (via workspace.RefuseReplace).
+  'onboarding.standaloneBlocked':
+    'This workspace is standalone and holds {n} locally originated issues. They exist only here — no Jira site has a copy. Connecting a site here will let a later sync delete them from the mirror.',
+  'onboarding.standalonePersist': 'Origin persist file: {path}',
+  'onboarding.standaloneOtherWorkspace':
+    'Connect the site in a separate workspace: gadak --profile <name> init (list workspaces with gadak profiles).',
+  'onboarding.standaloneReplaceConfirm':
+    'Replace this workspace anyway. A later sync will delete these issues from the mirror.',
+  'onboarding.standaloneReplace': 'Replace and connect',
 
   /* ── Keyboard shortcuts cheat sheet (?) ── */
   'shortcuts.title': 'Keyboard shortcuts',

--- a/web/src/lib/i18n/ko.ts
+++ b/web/src/lib/i18n/ko.ts
@@ -1078,6 +1078,14 @@ export const ko = {
   'onboarding.switchAccount': '다른 계정으로 연결',
   'onboarding.openSettings': '설정 열기',
   'onboarding.cliHint': '같은 설정을 터미널에서 gadak init 으로도 할 수 있습니다.',
+  'onboarding.standaloneBlocked':
+    '이 워크스페이스는 standalone 이고 여기서만 존재하는 로컬 원본 이슈가 {n}개 있습니다. 어떤 Jira 사이트에도 사본이 없습니다. 여기서 사이트를 연결하면 이후 동기화가 미러에서 그 이슈들을 삭제합니다.',
+  'onboarding.standalonePersist': 'origin persist 파일: {path}',
+  'onboarding.standaloneOtherWorkspace':
+    '사이트는 별도 워크스페이스에 연결하세요: gadak --profile <name> init (워크스페이스 목록은 gadak profiles).',
+  'onboarding.standaloneReplaceConfirm':
+    '그래도 이 워크스페이스를 교체합니다. 이후 동기화가 미러에서 이 이슈들을 삭제합니다.',
+  'onboarding.standaloneReplace': '교체하고 연결',
 
   /* ── 단축키 치트시트(?) ── */
   'shortcuts.title': '키보드 단축키',


### PR DESCRIPTION
Closes GDK-247.

`e18fd9c` closed *"a command silently changes which origin owns this workspace"* for `gadak init`, and its comment said so. **It closed one of two paths.**

`PUT onboarding/connect/` — the endpoint whose own comment calls itself *"the only endpoint that writes cfg.Site"*, unauthenticated by the loopback single-user model — never looked at `cfg.IsStandalone()` at all. And nothing in `internal/server` wrote `cfg.Kind` either.

So a standalone workspace came out of connect **still reporting standalone while holding a verified real Atlassian API token on disk**. `origin.Client` checks `IsStandalone` before site/email/token, so that token had no consumer: it just sat in `config.json` of a workspace the user believes has no credential.

Not data loss — the mirror keeps reflecting issuetap. But silently keeping an unused credential is against the spirit of a tool whose promise is loopback-only and no outbound.

## Single owner

The guard could not be shared because it lived in `package main`. It now lives in **`internal/originbind`**, which owns exactly one invariant — *a workspace is bound to one origin* — and both surfaces call it:

- `RefuseReplace` — the decision
- `ClearStandalone` — "connecting means this is no longer standalone"

The CLI keeps rendering its own `--json` and text; the package returns a typed error, and the wording is the sentence `init` already printed — **moved, not rewritten**.

## The server refuses before `/myself`

So a token for a blocked workspace is never sent anywhere and never written to disk. `409` with `standalone_data_present`, the issue count and the persist path.

The web onboarding form explains what is at stake and requires a **second explicit consent** before retrying with `replace_standalone`. It never auto-retries the 409.

## Recurrence

`TestNoDirectKindClearOutsideOriginbind` — an AST walk in the shape of `internal/origin/direct_new_gate_test.go`. Tests may still write `Kind` in fixtures; production code outside that package may not.

## Debugging

`gadak doctor` reports workspace kind, whether a credential exists (**boolean only — never the token**), the origin persist path and the local issue count. "Standalone but holds a credential" is now one command instead of an inference.

## What lead review changed

The round put the package at `internal/workspace/replace`, and every call site aliased the import as `workspace` — colliding with the existing `internal/workspace` (profile mounts under `/w/`) that a reader would grep first. The parent package imports `internal/server`, so it genuinely could not live there — but the answer to that is its own name, not a borrowed one.

## Gates (lead-run, from cold, in this tree)

```
go build ./... / go vet ./...                clean
go test ./... -count=1                       27 packages ok
make typecheck                               0 errors
npm run test:unit                            32 files / 325 tests
tools/doc-checks.sh                          all passed
npx playwright test --config e2e/...         236 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)