### PR TITLE
build(aur): gate the recipe against version drift, refresh it on release (GDK-115)

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -35,6 +35,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          # check-pkgver.sh reads `git describe --tags`. A shallow clone has
+          # no tags, so it would skip instead of check — a registered gate
+          # that always passes is worse than no gate.
+          fetch-depth: 0
+
+      # Path-scoped to contrib/aur/**, so this fires when the recipe is
+      # edited — which is when pkgver drift matters — and not on every tag.
+      - name: PKGBUILD pkgver matches the latest tag
+        run: ./contrib/aur/gadak-bin/check-pkgver.sh
 
       - name: Build and check gadak-bin in an Arch container
         run: ./contrib/aur/gadak-bin/verify.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,37 @@ jobs:
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+
+  # Refresh the in-repo AUR recipe from the tag we just published.
+  # Does not push to aur.archlinux.org (account + SSH key; lead-only).
+  # contrib/aur/gadak-bin/update.sh rewrites pkgver and the two linux
+  # sha256sums from this tag's checksums.txt — it does not invent hashes.
+  # .SRCINFO is not regenerated here: makepkg is an Arch tool. After
+  # downloading the artifact, run contrib/aur/gadak-bin/verify.sh and
+  # commit PKGBUILD + .SRCINFO together.
+  #
+  # Existing job name, asset names, and goreleaser args are untouched:
+  # v0.14.0 apps read the updater zip namespace.
+  aur-pkgbuild:
+    name: Refresh gadak-bin PKGBUILD
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # pkgver cannot contain a hyphen. A prerelease tag (v0.16.0-rc.1)
+    # is skipped rather than failing the release.
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rewrite PKGBUILD pkgver and sha256sums from this tag
+        run: ./contrib/aur/gadak-bin/update.sh "${{ github.ref_name }}"
+
+      - name: Show the commit-ready diff
+        run: git --no-pager diff -- contrib/aur/gadak-bin/PKGBUILD
+
+      - name: Upload updated PKGBUILD
+        uses: actions/upload-artifact@v4
+        with:
+          name: gadak-bin-pkgbuild
+          path: contrib/aur/gadak-bin/PKGBUILD
+          if-no-files-found: error

--- a/contrib/aur/gadak-bin/check-pkgver.sh
+++ b/contrib/aur/gadak-bin/check-pkgver.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Fail if the in-repo gadak-bin PKGBUILD pkgver is not the latest git tag.
+#
+# Usage: contrib/aur/gadak-bin/check-pkgver.sh [PKGBUILD]
+#
+# The recipe itself lives at contrib/aur/gadak-bin/ (existing convention;
+# this directory is only the offline gate). Version ownership matches
+# tools/doc-checks.sh check 6: `git describe --tags --abbrev=0`. That is
+# also what GoReleaser stamps into the binary
+# (`.goreleaser.yaml` ldflags `-X main.version={{.Version}}`).
+# `gadak version` is *not* the source here: an unstamped tree prints
+# `0.0.0-dev` (`cmd/gadak/main.go`).
+#
+# A tagless checkout (shallow CI clone) skips, same as doc-checks.sh,
+# because there is then no tag to disagree with.
+#
+# Exit 64 = usage
+#      1  = pkgver does not match the latest tag, or PKGBUILD is unreadable
+#      0  = match, or no tag reachable
+set -euo pipefail
+
+usage() {
+  echo "usage: contrib/aur/gadak-bin/check-pkgver.sh [PKGBUILD]" >&2
+  exit 64
+}
+
+if [[ $# -gt 1 ]]; then
+  usage
+fi
+case "${1:-}" in
+  -h|--help) usage ;;
+esac
+
+# Builtins only for ROOT so a missing dirname cannot run first.
+self="${BASH_SOURCE[0]}"
+if [[ "$self" != /* ]]; then
+  self="$(pwd)/$self"
+fi
+# contrib/aur/gadak-bin/check-pkgver.sh → repo root is ../../..
+root="${self%/*}/../../.."
+cd "$root"
+root="$(pwd)"
+
+pkgbuild="${1:-$root/contrib/aur/gadak-bin/PKGBUILD}"
+if [[ "$pkgbuild" != /* ]]; then
+  pkgbuild="$root/$pkgbuild"
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+ok() {
+  echo "ok: $*"
+}
+
+if [[ ! -f "$pkgbuild" ]]; then
+  fail "PKGBUILD not found at ${pkgbuild}"
+fi
+
+tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -z "$tag" ]]; then
+  ok "no tag reachable — pkgver guard skipped"
+  exit 0
+fi
+
+want="${tag#v}"
+# pkgver cannot contain a hyphen (https://wiki.archlinux.org/title/PKGBUILD#pkgver).
+# Same skip as the release-workflow refresh job: an rc tag is not the
+# AUR version, and failing the gate on it would block a registered CI
+# check for the whole prerelease window.
+if [[ "$want" == *"-"* ]]; then
+  ok "latest tag ${tag} is not a PKGBUILD pkgver (hyphen) — skipped"
+  exit 0
+fi
+
+pkgver="$(awk -F= '/^pkgver=/ { v=$2; gsub(/['\''"]/, "", v); print v; exit }' "$pkgbuild")"
+if [[ -z "$pkgver" ]]; then
+  fail "${pkgbuild} has no pkgver= line"
+fi
+
+if [[ "$pkgver" != "$want" ]]; then
+  fail "PKGBUILD pkgver=${pkgver} does not match latest tag ${tag} (want ${want})"
+fi
+
+ok "PKGBUILD pkgver=${pkgver} matches latest tag ${tag}"


### PR DESCRIPTION
`contrib/aur/gadak-bin/` already had a working PKGBUILD, `.SRCINFO`, `update.sh` and a container `verify.sh`. What it lacked was anything that notices `pkgver` drifting from the tag it claims, and anything that refreshes it when a release happens — both were steps a person had to remember.

- `contrib/aur/gadak-bin/check-pkgver.sh` — offline gate: `pkgver` == latest tag minus `v`. Same version owner as `tools/doc-checks.sh` check 6 (`git describe --tags --abbrev=0`), not `gadak version` (an unstamped tree prints `0.0.0-dev`). Skips a tagless checkout and a hyphenated prerelease tag, which cannot be a `pkgver`.
- `.github/workflows/aur.yml` runs it with `fetch-depth: 0`, because a shallow clone has no tags and the gate would pass by skipping. Path-scoped to `contrib/aur/**`, so it fires when the recipe is edited rather than on every tag.
- `.github/workflows/release.yml` gains `aur-pkgbuild`: after GoReleaser it runs `update.sh` for the published tag, prints the commit-ready diff, and uploads the PKGBUILD as an artifact. It does **not** push to aur.archlinux.org (account + SSH key, lead-only), and `.SRCINFO` is still regenerated by `verify.sh` because that needs `makepkg`.

FAIL-first: a copy of PKGBUILD with `pkgver=0.0.0` gives `FAIL: PKGBUILD pkgver=0.0.0 does not match latest tag v0.15.2 (want 0.15.2)`, exit 1. The real file was not mutated.

Publishing remains blocked upstream: AUR closed new-package registration after the 2026-08 supply-chain attack (already recorded in `docs/INSTALL.md`), and `rpc/v5/search/gadak` is still `resultcount 0`. A correct recipe and an installable recipe are two different states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)