### PR TITLE
build(scoop): a Windows install path that is checkable without Windows (GDK-246)

### DIFF
--- a/.github/workflows/scoop.yml
+++ b/.github/workflows/scoop.yml
@@ -1,0 +1,41 @@
+# The Scoop bucket is not published, so nothing on this machine or in CI can
+# run `scoop install`. What can be checked without Windows is whether the
+# manifest is internally honest: valid against Scoop's own schema, pointing at
+# a version that exists, and carrying the hashes that tag's checksums.txt
+# actually publishes. A manifest whose hash disagrees with the release is the
+# defect that only shows up on the user's machine, at install time.
+#
+# contrib/scoop/verify.sh asserts that list. Registered the same way
+# .github/workflows/aur.yml registers the AUR verify: path-scoped, because
+# nothing outside contrib/scoop/ can change its answer.
+name: Scoop
+
+on:
+  pull_request:
+    paths: ['contrib/scoop/**', '.github/workflows/scoop.yml']
+  push:
+    branches: [main]
+    paths: ['contrib/scoop/**', '.github/workflows/scoop.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scoop-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manifest:
+    name: Scoop manifest agrees with the release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # verify.sh compares `version` to `git describe --tags`. A shallow
+          # clone has no tags, and the check would pass by skipping.
+          fetch-depth: 0
+
+      - name: Offline manifest checks
+        run: ./contrib/scoop/verify.sh

--- a/README.ko.md
+++ b/README.ko.md
@@ -255,6 +255,10 @@ Homebrew 없이 Windows에 설치하려면
 `gadak init && gadak sync && gadak serve`. 서명되지 않은 데스크톱 exe가
 막히면 0.16에서 믿을 수 있는 Windows 경로입니다.
 
+Scoop 매니페스트는 [`contrib/scoop`](contrib/scoop)에 있습니다. 버킷은
+아직 게시되지 않았고, Windows 머신에서 `scoop install`을 돌린 적도 없습니다
+([`docs/INSTALL.md`](docs/INSTALL.md#scoop-windows-cli)).
+
 Homebrew 없이 리눅스에 설치하려면
 [최신 릴리스](https://github.com/midagedev/gadak/releases/latest)에서
 `gadak_<version>_linux_amd64.tar.gz`(또는 `linux_arm64`)와 `checksums.txt`를

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ Unzip, put `gadak.exe` on `PATH`, then `gadak init && gadak sync && gadak serve`
 This is the reliable Windows route in 0.16 if the unsigned desktop exe is
 blocked.
 
+A Scoop manifest lives in [`contrib/scoop`](contrib/scoop). The bucket
+is not published and `scoop install` has not been run on a Windows machine
+([`docs/INSTALL.md`](docs/INSTALL.md#scoop-windows-cli)).
+
 Linux without Homebrew: from the
 [latest release](https://github.com/midagedev/gadak/releases/latest),
 download `gadak_<version>_linux_amd64.tar.gz` (or `linux_arm64`) and

--- a/contrib/scoop/README.md
+++ b/contrib/scoop/README.md
@@ -1,0 +1,103 @@
+# Scoop `gadak`
+
+In-repo source of the Scoop manifest that installs the Windows CLI zip from
+GitHub Releases. This is not the macOS desktop app (Homebrew cask `gadak`),
+not the Homebrew CLI formula (`gadak-cli`), and not the unsigned Windows
+desktop zip (`Gadak-<version>-windows-x64.zip`). The Scoop app name is
+`gadak` because Scoop is Windows-only and that is the command the shim
+puts on `PATH`.
+
+**The bucket is not published.** `scoop install` has not been run on a
+Windows machine. What this directory checks is offline: JSON against
+Scoop's schema, `version` against the latest git tag, hashes against that
+tag's `checksums.txt`, and Scoop's `checkver` regex against GitHub
+`/releases/latest`. Do not tell anyone to `scoop install gadak` until the
+bucket exists and a Windows host has actually installed from it.
+
+Do **not** add this gadak repository as a Scoop bucket.
+`scoop bucket add <name> <git-url>` clones the whole repo, then
+`Find-BucketDirectory` uses a top-level `bucket/` subdirectory if it
+exists, otherwise the repo root
+([`lib/buckets.ps1`](https://github.com/ScoopInstaller/Scoop/blob/master/lib/buckets.ps1)).
+This repo has no top-level `bucket/`, and `apps_in_bucket` does
+`Get-ChildItem *.json -Recurse`, so the root would treat `package.json`
+and every other JSON file as a manifest. A `bucket/` directory here
+would work mechanically and would still clone the whole tree (demo
+snapshot, web, e2e) for one file.
+
+## Checking the manifest (any host with curl and python3)
+
+```bash
+./verify.sh
+```
+
+Asserts the list in the script header. It downloads Scoop's
+`schema.json` and the release `checksums.txt`; it does not download the
+zips (those were listed once with `unzip -l` when the manifest was
+written: `LICENSE`, `NOTICE`, `README.md`, `gadak.exe` at the archive
+root). Exit 69 means curl, python3, or git is missing.
+
+Registered in CI ([`.github/workflows/scoop.yml`](../../.github/workflows/scoop.yml)) the same way
+[`.github/workflows/aur.yml`](../../.github/workflows/aur.yml) registers
+`contrib/aur/gadak-bin/verify.sh`: path-scoped to `contrib/scoop/**`.
+Do not fold it into `tools/doc-checks.sh`.
+
+## First publish (lead)
+
+1. Create `https://github.com/midagedev/scoop-gadak` (this directory
+   cannot). Same org as `midagedev/homebrew-tap`. Suggested default
+   branch: `master` (Scoop extras uses `master`).
+2. Layout of that repo only:
+
+   ```
+   bucket/gadak.json    # copy of this directory's gadak.json
+   README.md            # the user commands below
+   ```
+
+3. User commands, once the empty repo has that commit:
+
+   ```powershell
+   scoop bucket add gadak https://github.com/midagedev/scoop-gadak
+   scoop install gadak
+   gadak version
+   ```
+
+4. On a Windows host that already has Scoop: run those three, then
+   `Get-Command gadak` and `gadak version` against the tag in
+   `gadak.json`. That is the live check this directory cannot do.
+5. After that live check passes, one line in
+   [`docs/INSTALL.md`](../../docs/INSTALL.md) (the `Status:` line under
+   Scoop) becomes the two `scoop` commands. Then add the windows row in
+   `web/src/lib/upgrade-cta.ts` — not before; a command the bucket
+   cannot serve is a lie (that file's own comment).
+
+## Each new release
+
+From this directory, on any machine with `curl`:
+
+```bash
+./update.sh v0.15.2
+./verify.sh
+```
+
+`update.sh` rewrites `version` and the two windows sha256 values from
+that tag's `checksums.txt`. It does not compute hashes itself. Copy the
+updated `gadak.json` into `scoop-gadak/bucket/gadak.json`, commit, and
+push. Do not automate that push from the gadak release workflow (deploy
+key / PAT is a lead secret, same as the AUR clone).
+
+`checkver` + `autoupdate` in the manifest let a Scoop maintainer run
+`bin/checkver.ps1 gadak -Update` against the published bucket. That is
+Scoop-side automation; it does not update this file and it does not
+push `scoop-gadak`.
+
+## Why not extras / why not a release-workflow rewrite
+
+A PR to `ScoopInstaller/Extras` is a later option — `gadak.json` is
+404 in extras, main, and versions as of 2026-08-18. extras still needs
+the same live Windows install this directory has not done.
+
+`.github/workflows/release.yml` is left alone. Updating this JSON on
+tag is `update.sh`; publishing it is a push to `scoop-gadak`. Neither
+belongs inside GoReleaser, and changing release asset names would break
+the v0.14+ macOS updater namespace.

--- a/contrib/scoop/gadak.json
+++ b/contrib/scoop/gadak.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json",
+    "version": "0.15.2",
+    "description": "Local SQLite mirror of your Jira issues — web UI and agent SQL",
+    "homepage": "https://github.com/midagedev/gadak",
+    "license": "Apache-2.0",
+    "##": "Windows CLI (gadak.exe). Same zip as gadak_<ver>_windows_amd64.zip / windows_arm64. Not the desktop zip Gadak-<ver>-windows-x64.zip. Hashes are the sha256 lines in that tag's checksums.txt. Scoop app name is gadak (the command on PATH). Homebrew: gadak is the macOS app cask; gadak-cli is this CLI.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/midagedev/gadak/releases/download/v0.15.2/gadak_0.15.2_windows_amd64.zip",
+            "hash": "2636ab9f9014a027c7c7e08fb2e68fb1271ec8c7c08d2c6a78cb5293ec7137d7"
+        },
+        "arm64": {
+            "url": "https://github.com/midagedev/gadak/releases/download/v0.15.2/gadak_0.15.2_windows_arm64.zip",
+            "hash": "b5bddfbd42d2266bb0d633fc573d756398b0237071202c096705579d2f4660a5"
+        }
+    },
+    "bin": "gadak.exe",
+    "checkver": {
+        "github": "https://github.com/midagedev/gadak"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/midagedev/gadak/releases/download/v$version/gadak_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/midagedev/gadak/releases/download/v$version/gadak_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt",
+            "regex": "(?im)^$sha256\\s+$basename$"
+        }
+    }
+}

--- a/contrib/scoop/update.sh
+++ b/contrib/scoop/update.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Refresh gadak.json version and per-arch hashes from a GitHub Release.
+#
+# Usage: contrib/scoop/update.sh <tag>
+#
+#   tag — GitHub release tag, with or without a leading v (example: v0.15.2)
+#
+# Rewrites version, the two windows zip URLs, and their sha256 values from
+# that tag's checksums.txt. Does not compute hashes locally — checksums.txt
+# is the owner (same contract as contrib/aur/gadak-bin/update.sh).
+#
+# Exit 64 = usage / bad arguments
+#      69 = a required tool is missing
+#       1 = download failed, checksums.txt missing an asset, or rewrite failed
+#       0 = gadak.json updated
+#
+# Requires: curl, python3, awk, mktemp, rm, grep, cat.
+set -euo pipefail
+
+usage() {
+  echo "usage: contrib/scoop/update.sh <tag>" >&2
+  exit 64
+}
+
+need() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "update.sh: missing ${name}" >&2
+    exit 69
+  fi
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+case "$1" in
+  -h|--help)
+    usage
+    ;;
+esac
+
+tag="$1"
+ver="${tag#v}"
+if [[ -z "$ver" || "$ver" == *"/"* || "$ver" == *"-"* || "$ver" == *" "* ]]; then
+  echo "update.sh: tag must look like v0.15.2 (no hyphen, slash, or space)" >&2
+  exit 64
+fi
+rel_tag="v${ver}"
+
+need curl
+need python3
+need awk
+need mktemp
+need rm
+need grep
+need cat
+
+self="${BASH_SOURCE[0]}"
+if [[ "$self" != /* ]]; then
+  self="$(pwd)/$self"
+fi
+here="${self%/*}"
+manifest="${here}/gadak.json"
+if [[ ! -f "$manifest" ]]; then
+  echo "update.sh: gadak.json not found at ${manifest}" >&2
+  exit 1
+fi
+
+checksums_url="https://github.com/midagedev/gadak/releases/download/${rel_tag}/checksums.txt"
+amd64_asset="gadak_${ver}_windows_amd64.zip"
+arm64_asset="gadak_${ver}_windows_arm64.zip"
+
+tmp="$(mktemp "${TMPDIR:-/tmp}/gadak-scoop-checksums.XXXXXX")"
+cleanup() { rm -f "$tmp"; }
+trap cleanup EXIT INT HUP TERM
+
+if ! curl -fsSL -o "$tmp" "$checksums_url"; then
+  echo "update.sh: download failed: ${checksums_url}" >&2
+  exit 1
+fi
+
+hash_for() {
+  local file="$1"
+  local hash
+  hash="$(awk -v f="$file" '$2 == f { print $1; exit }' "$tmp")"
+  if [[ -z "$hash" ]]; then
+    echo "update.sh: no checksum entry for ${file} in checksums.txt" >&2
+    exit 1
+  fi
+  printf '%s\n' "$hash"
+}
+
+sha_amd64="$(hash_for "$amd64_asset")"
+sha_arm64="$(hash_for "$arm64_asset")"
+
+GADAK_SCOOP_MANIFEST="$manifest" GADAK_SCOOP_VER="$ver" \
+GADAK_SCOOP_SHA_AMD64="$sha_amd64" GADAK_SCOOP_SHA_ARM64="$sha_arm64" \
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["GADAK_SCOOP_MANIFEST"])
+ver = os.environ["GADAK_SCOOP_VER"]
+sha_amd64 = os.environ["GADAK_SCOOP_SHA_AMD64"]
+sha_arm64 = os.environ["GADAK_SCOOP_SHA_ARM64"]
+
+data = json.loads(path.read_text())
+data["version"] = ver
+arch = data.setdefault("architecture", {})
+amd = arch.setdefault("64bit", {})
+arm = arch.setdefault("arm64", {})
+amd["url"] = f"https://github.com/midagedev/gadak/releases/download/v{ver}/gadak_{ver}_windows_amd64.zip"
+amd["hash"] = sha_amd64
+arm["url"] = f"https://github.com/midagedev/gadak/releases/download/v{ver}/gadak_{ver}_windows_arm64.zip"
+arm["hash"] = sha_arm64
+
+# Stable key order so a no-op update is a tiny (or empty) diff.
+ordered = {}
+for key in (
+    "$schema",
+    "version",
+    "description",
+    "homepage",
+    "license",
+    "##",
+    "architecture",
+    "bin",
+    "checkver",
+    "autoupdate",
+):
+    if key in data:
+        ordered[key] = data[key]
+for key, value in data.items():
+    if key not in ordered:
+        ordered[key] = value
+
+text = json.dumps(ordered, indent=4, ensure_ascii=False) + "\n"
+path.write_text(text)
+PY
+
+if ! grep -q '"version": "'"${ver}"'"' "$manifest"; then
+  echo "update.sh: gadak.json rewrite did not set version=${ver}" >&2
+  exit 1
+fi
+if ! grep -q '"hash": "'"${sha_amd64}"'"' "$manifest"; then
+  echo "update.sh: gadak.json rewrite did not set 64bit hash" >&2
+  exit 1
+fi
+if ! grep -q '"hash": "'"${sha_arm64}"'"' "$manifest"; then
+  echo "update.sh: gadak.json rewrite did not set arm64 hash" >&2
+  exit 1
+fi
+
+echo "update.sh: version=${ver}"
+echo "update.sh: 64bit  ${amd64_asset}  ${sha_amd64}"
+echo "update.sh: arm64  ${arm64_asset}  ${sha_arm64}"

--- a/contrib/scoop/verify.sh
+++ b/contrib/scoop/verify.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# Check the Scoop manifest against the latest tag and that tag's checksums.txt.
+#
+# Usage: contrib/scoop/verify.sh [gadak.json]
+#
+# What it asserts (offline-checkable; this is not `scoop install`):
+#   1. gadak.json is valid JSON and validates against Scoop's published schema
+#      (required fields, additionalProperties, hash/version patterns)
+#   2. version equals `git describe --tags --abbrev=0` with the leading v
+#      stripped — same tag source as tools/doc-checks.sh. Skipped (not
+#      failed) when no tag is reachable, same as that script.
+#   3. architecture.64bit / arm64 hashes match that tag's checksums.txt
+#      (checksums.txt is the owner; this script does not compute hashes)
+#   4. url filenames are gadak_<ver>_windows_{amd64,arm64}.zip
+#   5. bin is gadak.exe (v0.15.2 zip members, unzip -l: no directory prefix)
+#   6. checkver's GitHub regex matches the latest release
+#
+# Exit 64 = usage / bad arguments
+#      69 = a required tool is missing
+#       1 = a verification above failed
+#       0 = all of them passed
+#
+# Requires: curl, python3, git, awk, mktemp, rm.
+set -euo pipefail
+
+usage() {
+  echo "usage: contrib/scoop/verify.sh [gadak.json]" >&2
+  exit 64
+}
+
+need() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "verify.sh: missing ${name}" >&2
+    exit 69
+  fi
+}
+
+if [[ $# -gt 1 ]]; then
+  usage
+fi
+case "${1:-}" in
+  -h|--help) usage ;;
+esac
+
+need curl
+need python3
+need git
+need awk
+need mktemp
+need rm
+
+self="${BASH_SOURCE[0]}"
+if [[ "$self" != /* ]]; then
+  self="$(pwd)/$self"
+fi
+here="${self%/*}"
+repo="$(cd "${here}/../.." && pwd)"
+manifest="${1:-${here}/gadak.json}"
+if [[ "$manifest" != /* ]]; then
+  manifest="$(pwd)/$manifest"
+fi
+if [[ ! -f "$manifest" ]]; then
+  echo "verify.sh: gadak.json not found at ${manifest}" >&2
+  exit 1
+fi
+
+schema_url="https://raw.githubusercontent.com/ScoopInstaller/Scoop/master/schema.json"
+checkver_regex='/releases/tag/(?:v|V)?([\d.]+)'
+# Scoop bin/checkver.ps1 default for checkver.github (field-read 2026-08-18).
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/gadak-scoop-verify.XXXXXX")"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT INT HUP TERM
+
+if ! curl -fsSL -o "${work}/schema.json" "$schema_url"; then
+  echo "verify.sh: download failed: ${schema_url}" >&2
+  exit 1
+fi
+
+# Schema walk is stdlib-only. jsonschema is not a repo dependency.
+GADAK_SCOOP_MANIFEST="$manifest" GADAK_SCOOP_SCHEMA="${work}/schema.json" \
+python3 - <<'PY'
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+manifest_path = Path(os.environ["GADAK_SCOOP_MANIFEST"])
+schema_path = Path(os.environ["GADAK_SCOOP_SCHEMA"])
+root = json.loads(schema_path.read_text())
+instance = json.loads(manifest_path.read_text())
+errors = []
+
+
+def resolve(schema):
+    if not isinstance(schema, dict):
+        return schema
+    ref = schema.get("$ref")
+    if not ref:
+        return schema
+    if not ref.startswith("#/"):
+        errors.append(f"unsupported $ref {ref}")
+        return {}
+    node = root
+    for part in ref[2:].split("/"):
+        node = node[part]
+    return node
+
+
+def check(inst, schema, path="$"):
+    schema = resolve(schema)
+    if schema is True:
+        return
+    if schema is False:
+        errors.append(f"{path}: schema is false")
+        return
+    if not isinstance(schema, dict):
+        return
+
+    if "anyOf" in schema:
+        before = len(errors)
+        for i, sub in enumerate(schema["anyOf"]):
+            sub_errs = []
+            saved = errors
+            # isolate
+            globals_errors_holder = []
+            # use a nested collector
+            # (re-bind via a local list)
+            # Implemented below with a helper that returns errs.
+            sub_list = _validate(inst, sub)
+            if not sub_list:
+                errors[:] = saved
+                return
+            globals_errors_holder.append(sub_list)
+        errors[:] = saved
+        errors.append(f"{path}: matches no anyOf branch: {globals_errors_holder[0][:3]}")
+        return
+
+    expected = schema.get("type")
+    if expected:
+        types = expected if isinstance(expected, list) else [expected]
+        ok_type = False
+        for t in types:
+            if t == "object" and isinstance(inst, dict):
+                ok_type = True
+            elif t == "array" and isinstance(inst, list):
+                ok_type = True
+            elif t == "string" and isinstance(inst, str):
+                ok_type = True
+            elif t == "boolean" and isinstance(inst, bool):
+                ok_type = True
+            elif t == "number" and isinstance(inst, (int, float)) and not isinstance(inst, bool):
+                ok_type = True
+            elif t == "integer" and isinstance(inst, int) and not isinstance(inst, bool):
+                ok_type = True
+            elif t == "null" and inst is None:
+                ok_type = True
+        if not ok_type:
+            errors.append(f"{path}: want type {expected}, got {type(inst).__name__}")
+            return
+
+    if "pattern" in schema and isinstance(inst, str):
+        if not re.search(schema["pattern"], inst):
+            errors.append(f"{path}: does not match {schema['pattern']}")
+
+    if schema.get("format") == "uri" and isinstance(inst, str):
+        parsed = urlparse(inst)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            errors.append(f"{path}: not an http(s) URI")
+
+    if schema.get("format") == "regex" and isinstance(inst, str):
+        try:
+            re.compile(inst)
+        except re.error as exc:
+            errors.append(f"{path}: not a regex ({exc})")
+
+    if isinstance(inst, dict):
+        required = schema.get("required") or []
+        for key in required:
+            if key not in inst:
+                errors.append(f"{path}: missing required {key}")
+        props = schema.get("properties") or {}
+        additional = schema.get("additionalProperties", True)
+        for key, value in inst.items():
+            if key in props:
+                check(value, props[key], f"{path}.{key}")
+            elif additional is False:
+                errors.append(f"{path}: additional property {key}")
+            elif isinstance(additional, dict):
+                check(value, additional, f"{path}.{key}")
+
+    if isinstance(inst, list) and "items" in schema:
+        item_schema = schema["items"]
+        for i, value in enumerate(inst):
+            check(value, item_schema, f"{path}[{i}]")
+
+
+def _validate(inst, schema):
+    global errors
+    saved = errors
+    errors = []
+    check(inst, schema, "$")
+    got = errors
+    errors = saved
+    return got
+
+
+check(instance, root)
+if errors:
+    print("FAIL: schema:", file=sys.stderr)
+    for err in errors:
+        print(f"  {err}", file=sys.stderr)
+    raise SystemExit(1)
+print("ok: schema (Scoop schema.json required/additionalProperties/patterns)")
+PY
+
+tag="$(git -C "$repo" describe --tags --abbrev=0 2>/dev/null || true)"
+ver="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$manifest")"
+
+if [[ -z "$tag" ]]; then
+  echo "ok: no tag reachable — version-vs-tag guard skipped (same as tools/doc-checks.sh)"
+  rel_tag="v${ver}"
+else
+  want="${tag#v}"
+  if [[ "$ver" != "$want" ]]; then
+    echo "FAIL: version: manifest ${ver} != latest tag ${tag}" >&2
+    exit 1
+  fi
+  echo "ok: version ${ver} matches latest tag ${tag}"
+  rel_tag="$tag"
+fi
+
+checksums_url="https://github.com/midagedev/gadak/releases/download/${rel_tag}/checksums.txt"
+if ! curl -fsSL -o "${work}/checksums.txt" "$checksums_url"; then
+  echo "verify.sh: download failed: ${checksums_url}" >&2
+  exit 1
+fi
+
+GADAK_SCOOP_MANIFEST="$manifest" GADAK_SCOOP_CHECKSUMS="${work}/checksums.txt" \
+GADAK_SCOOP_VER="$ver" python3 - <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+manifest = json.loads(Path(os.environ["GADAK_SCOOP_MANIFEST"]).read_text())
+ver = os.environ["GADAK_SCOOP_VER"]
+sums = {}
+for line in Path(os.environ["GADAK_SCOOP_CHECKSUMS"]).read_text().splitlines():
+    parts = line.split()
+    if len(parts) >= 2:
+        sums[parts[1]] = parts[0]
+
+want = {
+    "64bit": f"gadak_{ver}_windows_amd64.zip",
+    "arm64": f"gadak_{ver}_windows_arm64.zip",
+}
+arch = manifest.get("architecture") or {}
+failed = False
+for key, filename in want.items():
+    block = arch.get(key) or {}
+    url = block.get("url") or ""
+    got_hash = (block.get("hash") or "").lower()
+    if not url.endswith("/" + filename):
+        print(f"FAIL: {key} url does not end with {filename}: {url}", file=sys.stderr)
+        failed = True
+    if filename not in sums:
+        print(f"FAIL: checksums.txt has no entry for {filename}", file=sys.stderr)
+        failed = True
+        continue
+    want_hash = sums[filename].lower()
+    if got_hash != want_hash:
+        print(
+            f"FAIL: hash {key}: manifest {got_hash} != checksums.txt {want_hash}",
+            file=sys.stderr,
+        )
+        failed = True
+    else:
+        print(f"ok: hash {key} {got_hash} == checksums.txt {filename}")
+
+bin_name = manifest.get("bin")
+if bin_name != "gadak.exe":
+    print(f"FAIL: bin is {bin_name!r}, want 'gadak.exe' (zip member, no prefix)", file=sys.stderr)
+    failed = True
+else:
+    print("ok: bin gadak.exe")
+
+hash_url = ((manifest.get("autoupdate") or {}).get("hash") or {}).get("url") or ""
+if "checksums.txt" not in hash_url:
+    print(f"FAIL: autoupdate.hash.url does not name checksums.txt: {hash_url!r}", file=sys.stderr)
+    failed = True
+else:
+    print("ok: autoupdate.hash.url reads checksums.txt")
+
+if failed:
+    raise SystemExit(1)
+PY
+
+# Scoop checkver.github default regex, against the live latest-release page.
+html="${work}/latest.html"
+if ! curl -fsSL -A "gadak-scoop-verify" -o "$html" \
+  "https://github.com/midagedev/gadak/releases/latest"; then
+  echo "verify.sh: download failed: https://github.com/midagedev/gadak/releases/latest" >&2
+  exit 1
+fi
+GADAK_SCOOP_HTML="$html" GADAK_SCOOP_VER="$ver" GADAK_SCOOP_RE="$checkver_regex" \
+python3 - <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+
+html = Path(os.environ["GADAK_SCOOP_HTML"]).read_text(errors="replace")
+regex = re.compile(os.environ["GADAK_SCOOP_RE"])
+match = regex.search(html)
+if not match:
+    print("FAIL: checkver regex matched nothing on /releases/latest", file=sys.stderr)
+    raise SystemExit(1)
+got = match.group(1)
+want = os.environ["GADAK_SCOOP_VER"]
+if got != want:
+    print(f"FAIL: checkver regex captured {got}, manifest version is {want}", file=sys.stderr)
+    raise SystemExit(1)
+print(f"ok: checkver regex {os.environ['GADAK_SCOOP_RE']!s} -> {got}")
+PY
+
+echo "ok: ${manifest}"
+echo "verify.sh: offline checks passed (not a Windows scoop install)"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -86,6 +86,26 @@ again. Gadak notices a new release on its own and shows the notes in Settings �
 it will not print an upgrade command there on Arch, because there is not an
 honest one to print yet.
 
+### Scoop (Windows CLI)
+
+Status: **not in a published bucket; `scoop install` has not been run on a Windows machine.**
+<!-- PUBLISH: replace the Status line with:
+scoop bucket add gadak https://github.com/midagedev/scoop-gadak
+scoop install gadak
+-->
+
+The in-repo manifest is [`contrib/scoop/gadak.json`](../contrib/scoop/gadak.json).
+It is checked offline (Scoop's schema, sha256 against that tag's
+`checksums.txt`, zip members). It is the Windows CLI (`gadak.exe`) — the
+same file as `gadak_<version>_windows_amd64.zip` / `windows_arm64` — not
+the desktop zip `Gadak-<version>-windows-x64.zip`. Scoop's app name is
+`gadak` (Windows-only, that is the command on `PATH`). Homebrew uses
+`gadak` for the macOS app cask and `gadak-cli` for this same CLI.
+
+Until the bucket exists, install from the zip under
+[Desktop app (Windows)](#desktop-app-windows) or
+[Release binary](#release-binary).
+
 ### Desktop app (macOS)
 
 Download `Gadak-<version>-arm64.dmg` from the


### PR DESCRIPTION
Homebrew covers macOS and Linux; Windows had a zip and a paragraph. Scoop is what Windows CLI users already have — but the bucket cannot be published from this repo, and `scoop install` has not been run on a Windows machine even once. Everything here is written so that gap stays visible.

- `contrib/scoop/gadak.json` — the Windows **CLI** zip (`gadak.exe`), amd64 + arm64, hashes from the v0.15.2 `checksums.txt`. Not the desktop zip, not the Homebrew cask. Scoop's app name is `gadak` because Scoop is Windows-only and that is the shim on `PATH`; Homebrew keeps `gadak` for the macOS cask and `gadak-cli` for this same CLI.
- `contrib/scoop/verify.sh` — offline gate: JSON against Scoop's own `schema.json`, `version` against the latest git tag, both hashes against that tag's `checksums.txt`, `bin`, and the `checkver` regex against `/releases/latest`.
- `contrib/scoop/update.sh` — rewrites `version` and the two hashes from a tag's `checksums.txt`; it never computes a hash itself.
- `.github/workflows/scoop.yml` — runs `verify.sh`, path-scoped to `contrib/scoop/**`, `fetch-depth: 0` so the tag comparison is real instead of skipped.
- `docs/INSTALL.md`, `README.md`, `README.ko.md` — a Scoop section whose first line says the bucket is unpublished and untested on Windows. The two `scoop` commands sit in an HTML comment until that is false.

`contrib/scoop/README.md` also records why this repo must not be added as a Scoop bucket directly: Scoop falls back to the repo root when there is no top-level `bucket/`, and `apps_in_bucket` globs `*.json` recursively — it would read `package.json` as a manifest.

Still open and lead-only: create `midagedev/scoop-gadak`, install once on a real Windows host, then swap the `Status:` line and add the windows row to `web/src/lib/upgrade-cta.ts` — not before, because a command the bucket cannot serve is a lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)