### PR TITLE
feat(web): the UI now says which workspace it is looking at (GDK-237)

### DIFF
--- a/e2e/standalone.spec.ts
+++ b/e2e/standalone.spec.ts
@@ -5,15 +5,25 @@ import { gotoApp, openServerSettings } from './helpers'
  * Track D: a standalone workspace must show its kind indicator; a connected
  * one must not. Key off data-testid + the served kind — not a locale string
  * or a platform command.
+ *
+ * The create path is the CLI (this round does not add a write endpoint).
+ * Copy is asserted against the real clipboard, not the "Copied" label
+ * (GDK-178: a toast that lies is worse than a button that fails aloud).
  */
 
-async function serveWorkspaceKind(page: Page, kind: 'standalone' | 'connected'): Promise<void> {
+const STANDALONE_INIT_COMMAND = 'gadak --profile <name> init --standalone'
+
+async function serveWorkspaceKind(
+  page: Page,
+  kind: 'standalone' | 'connected',
+  extra: Record<string, unknown> = {},
+): Promise<void> {
   await page.route('**/config.json', async (route) => {
     const res = await route.fetch()
     const doc = (await res.json()) as Record<string, unknown>
     await route.fulfill({
       response: res,
-      json: { ...doc, workspaceKind: kind },
+      json: { ...doc, ...extra, workspaceKind: kind },
     })
   })
 }
@@ -27,7 +37,8 @@ test.describe('standalone workspace indicator', () => {
     const indicator = page.getByTestId('workspace-kind')
     await expect(indicator).toBeVisible()
     await expect(indicator).toHaveAttribute('data-kind', 'standalone')
-    await expect(page.getByTestId('standalone-init-command')).toBeVisible()
+    await expect(indicator).toHaveAttribute('aria-label', /issuetap persist/)
+    await expect(page.getByTestId('standalone-init-command')).toHaveText(STANDALONE_INIT_COMMAND)
 
     // The served document is the source of truth — the chip must match it,
     // not a client-side guess from an empty site URL.
@@ -37,6 +48,18 @@ test.describe('standalone workspace indicator', () => {
     })
     expect(served).toBe('standalone')
     await expect(indicator).toHaveAttribute('data-kind', served)
+  })
+
+  test('copy writes the init command to the clipboard', async ({ page }) => {
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await serveWorkspaceKind(page, 'standalone')
+    await gotoApp(page)
+    await openServerSettings(page)
+
+    await page.getByTestId('standalone-init-copy').click()
+    await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(
+      STANDALONE_INIT_COMMAND,
+    )
   })
 
   test('connected workspace does not show the standalone indicator', async ({ page }) => {
@@ -52,5 +75,24 @@ test.describe('standalone workspace indicator', () => {
     })
     expect(served).toBe('connected')
     await expect(page.getByTestId('workspace-kind')).toHaveCount(0)
+  })
+
+  test('empty site + connected (hosted-demo shape) does not show the badge', async ({ page }) => {
+    await serveWorkspaceKind(page, 'connected', { jiraBaseUrl: '' })
+    await gotoApp(page)
+    await openServerSettings(page)
+
+    await expect(page.getByTestId('workspace-kind')).toHaveCount(0)
+    await expect(page.getByTestId('standalone-init-command')).toHaveText(STANDALONE_INIT_COMMAND)
+  })
+
+  test('sidebar create control reveals the init command', async ({ page }) => {
+    await serveWorkspaceKind(page, 'connected')
+    await gotoApp(page)
+
+    const create = page.getByTestId('standalone-create')
+    await expect(create).toBeVisible()
+    await create.click()
+    await expect(page.getByText(STANDALONE_INIT_COMMAND, { exact: true })).toBeVisible()
   })
 })

--- a/web/src/components/settings/RuntimeMirror.svelte
+++ b/web/src/components/settings/RuntimeMirror.svelte
@@ -10,16 +10,13 @@
    */
   import { t } from '../../lib/i18n'
   import { copyText } from '../../lib/copy-text'
-  import {
-    isStandaloneWorkspace,
-    STANDALONE_INIT_COMMAND,
-    surface,
-  } from '../../lib/config'
+  import { config, surface } from '../../lib/config'
+  import { isStandalone, STANDALONE_INIT_COMMAND } from '../../lib/workspace'
   import type { SettingsRuntime } from '../../lib/api'
   import { COPY_BTN } from './controls'
 
   const onDesktop = surface() === 'desktop'
-  const standalone = isStandaloneWorkspace()
+  const standalone = isStandalone(config())
 
   let { runtime }: { runtime: SettingsRuntime } = $props()
 
@@ -57,11 +54,14 @@
     <dd class="flex min-w-0 flex-wrap items-center gap-1.5">
       <span class="font-mono text-text-primary">{runtime.profile}</span>
       {#if standalone}
-        <!-- Same status-pill classes as IntegrationsTab's install-state chip. -->
+        <!-- Same status-pill classes as IntegrationsTab's install-state chip.
+             data-kind=standalone is a new case, not a borrowed enum. -->
         <span
           class="inline-flex items-center gap-1.5 rounded-full border border-border-subtle px-1.5 py-0.5 text-micro text-text-secondary"
           data-testid="workspace-kind"
           data-kind="standalone"
+          title={t('settings.workspaceStandaloneHint')}
+          aria-label={t('settings.workspaceStandaloneHint')}
         >
           {t('settings.workspaceStandalone')}
         </span>
@@ -155,21 +155,21 @@
     <dt class="text-text-muted">{t('settings.standaloneHow')}</dt>
     <dd class="min-w-0">
       <div class="flex flex-wrap items-center gap-1.5">
-        <span
+        <code
           class="break-all font-mono text-text-primary"
           data-testid="standalone-init-command"
-        >{STANDALONE_INIT_COMMAND}</span>
+        >{STANDALONE_INIT_COMMAND}</code>
         <button
           type="button"
           class={COPY_BTN}
+          data-testid="standalone-init-copy"
           onclick={() => copyValue('standalone-init', STANDALONE_INIT_COMMAND)}
         >
           {copiedKey === 'standalone-init' ? t('settings.copied') : t('settings.copy')}
         </button>
       </div>
-      {#if standalone}
-        <div class="mt-0.5 text-text-muted">{t('settings.workspaceStandaloneHint')}</div>
-      {/if}
+      <div class="mt-0.5 text-text-muted">{t('settings.workspaceStandaloneHint')}</div>
+      <div class="mt-0.5 text-text-muted">{t('settings.standaloneCommandHint')}</div>
     </dd>
   </dl>
 </section>

--- a/web/src/components/sidebar/SidebarNav.svelte
+++ b/web/src/components/sidebar/SidebarNav.svelte
@@ -26,6 +26,7 @@
     jiraFilterUrl,
     workspaceName,
   } from '../../lib/config'
+  import { isStandalone, STANDALONE_INIT_COMMAND } from '../../lib/workspace'
   import { busyLabel, fetchingDocuments, mirrorLabel } from '../../lib/mirror-status'
   import { builtinViews } from '../../lib/builtin-views'
   import { configToParams, type ViewConfig } from '../../lib/view-config'
@@ -203,6 +204,8 @@
       return w.site
     }
   }
+  const standalone = isStandalone(config())
+  let standaloneHowOpen = $state(false)
 
   /* ── Docs (mirrored wiki pages) ── */
   //  The nav carries two entries only — the document view, and a collapsed
@@ -754,6 +757,17 @@
               aria-hidden="true"
             ></span>
             <span class="min-w-0 flex-1 truncate">{w.name}</span>
+            {#if currentWorkspace === w.name && standalone}
+              <span
+                class="inline-flex flex-none items-center rounded-full border border-border-subtle px-1.5 py-0.5 text-micro text-text-secondary"
+                data-testid="workspace-kind"
+                data-kind="standalone"
+                title={t('settings.workspaceStandaloneHint')}
+                aria-label={t('settings.workspaceStandaloneHint')}
+              >
+                {t('settings.workspaceStandalone')}
+              </span>
+            {/if}
             {#if workspaceHost(w)}
               <span class="max-w-[45%] flex-none truncate text-micro text-text-muted">
                 {workspaceHost(w)}
@@ -771,6 +785,22 @@
        error screen, so the errand it offers does not exist. -->
   <div class="flex-none border-t border-border-subtle px-3 py-2">
     {#if hasServerVerb('settings')}
+      <button
+        type="button"
+        class="mb-1 flex h-control-sm w-full items-center gap-1.5 rounded-md px-1 text-[12px] text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary"
+        data-testid="standalone-create"
+        aria-expanded={standaloneHowOpen}
+        onclick={() => (standaloneHowOpen = !standaloneHowOpen)}
+      >
+        {t('settings.standaloneHow')}
+      </button>
+      {#if standaloneHowOpen}
+        <div class="mb-1 px-1">
+          <code class="break-all font-mono text-micro text-text-primary">{STANDALONE_INIT_COMMAND}</code>
+          <div class="mt-0.5 text-micro text-text-muted">{t('settings.workspaceStandaloneHint')}</div>
+          <div class="mt-0.5 text-micro text-text-muted">{t('settings.standaloneCommandHint')}</div>
+        </div>
+      {/if}
       <button
         type="button"
         class="mb-1 flex h-control-sm w-full items-center gap-1.5 rounded-md px-1 text-[12px] text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary"

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -10,6 +10,21 @@
  * (with optional surfaces switched off) when served as plain static files.
  */
 
+import {
+  isStandalone,
+  parseWorkspaceKind,
+  type WorkspaceKind,
+} from './workspace'
+
+export {
+  isStandalone,
+  parseWorkspaceKind,
+  STANDALONE_INIT_COMMAND,
+  WORKSPACE_KIND_CONNECTED,
+  WORKSPACE_KIND_STANDALONE,
+  type WorkspaceKind,
+} from './workspace'
+
 export const WINDOW_CHROME_NATIVE = 'native'
 export const WINDOW_CHROME_TRAFFIC_LIGHTS_INSET = 'traffic-lights-inset'
 export type WindowChrome =
@@ -100,26 +115,9 @@ export interface GadakConfig {
   features: GadakFeatures
 }
 
-export const WORKSPACE_KIND_CONNECTED = 'connected'
-export const WORKSPACE_KIND_STANDALONE = 'standalone'
-export type WorkspaceKind =
-  | typeof WORKSPACE_KIND_CONNECTED
-  | typeof WORKSPACE_KIND_STANDALONE
-  | ''
-
-/** CLI that creates a standalone workspace. Flag lives in cmd/gadak/init.go. */
-export const STANDALONE_INIT_COMMAND = 'gadak init --standalone'
-
-export function parseWorkspaceKind(raw: unknown): WorkspaceKind {
-  if (raw === WORKSPACE_KIND_STANDALONE || raw === WORKSPACE_KIND_CONNECTED) {
-    return raw
-  }
-  return ''
-}
-
 /** True only when the server said standalone. Unknown and connected are false. */
 export function isStandaloneWorkspace(): boolean {
-  return current.workspaceKind === WORKSPACE_KIND_STANDALONE
+  return isStandalone(current)
 }
 
 const DEFAULTS: GadakConfig = {

--- a/web/src/lib/i18n/en.ts
+++ b/web/src/lib/i18n/en.ts
@@ -797,7 +797,7 @@ export const en = {
   'settings.thisMirror': 'This mirror',
   'settings.workspaceStandalone': 'Standalone',
   'settings.workspaceStandaloneHint':
-    'No Jira site or credential. Issues exist only in this workspace.',
+    "A workspace without a Jira account. The origin is this computer's issuetap persist file, not gadak.db — back that file up.",
   'settings.standaloneHow': 'Create a standalone workspace',
   'settings.runtimeProfile': 'Profile',
   'settings.runtimeDb': 'Mirror database',
@@ -929,6 +929,7 @@ export const en = {
   'settings.locale': 'Language',
   'settings.localeEn': 'English',
   'settings.localeKo': '한국어',
+  'settings.standaloneCommandHint': '<name> is the profile name you choose.',
 
   /* ── Theme (per-browser; settings + palette) ── */
   'theme.label': 'Theme',

--- a/web/src/lib/i18n/ko.ts
+++ b/web/src/lib/i18n/ko.ts
@@ -792,7 +792,7 @@ export const ko = {
   'settings.thisMirror': '이 미러',
   'settings.workspaceStandalone': '독립',
   'settings.workspaceStandaloneHint':
-    'Jira 사이트와 자격증명이 없습니다. 이슈는 이 워크스페이스에만 있습니다.',
+    'Jira 계정 없이 쓰는 워크스페이스입니다. 원본은 이 컴퓨터의 issuetap persist 파일이며, 백업 대상은 gadak.db가 아니라 그 파일입니다.',
   'settings.standaloneHow': '독립 워크스페이스 만들기',
   'settings.runtimeProfile': '프로필',
   'settings.runtimeDb': '미러 DB',
@@ -922,6 +922,7 @@ export const ko = {
   'settings.locale': '언어',
   'settings.localeEn': 'English',
   'settings.localeKo': '한국어',
+  'settings.standaloneCommandHint': '<name>은 직접 정하는 프로필 이름입니다.',
 
   /* ── Theme (per-browser; settings + palette) ── */
   'theme.label': '테마',

--- a/web/src/lib/workspace.test.ts
+++ b/web/src/lib/workspace.test.ts
@@ -1,0 +1,96 @@
+/*
+ * GDK-237: workspaceKind is server-owned. The badge and the create-command
+ * copy key off isStandalone() in workspace.ts — never an empty site URL.
+ *
+ * Rendered visibility is Playwright's job (no component-mount harness).
+ * These tests pin the decision function, the command string, and the
+ * "no scattered === 'standalone'" wiring that is easy to lose again.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const OWNER = join(HERE, 'workspace.ts')
+const WEB_SRC = join(HERE, '..')
+const COMPONENTS = join(WEB_SRC, 'components')
+const STORES = join(WEB_SRC, 'stores')
+
+const COMPARE_STANDALONE =
+  /(?:===|==|!==|!=)\s*['"]standalone['"]|['"]standalone['"]\s*(?:===|==|!==|!=)|===\s*WORKSPACE_KIND_STANDALONE|WORKSPACE_KIND_STANDALONE\s*===/
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name)
+    if (ent.isDirectory()) walk(p, acc)
+    else if (/\.(ts|svelte)$/.test(ent.name) && !ent.name.endsWith('.test.ts')) acc.push(p)
+  }
+  return acc
+}
+
+describe('isStandalone (server-owned, never inferred from site)', () => {
+  test('the derived-value owner is workspace.ts', () => {
+    expect(existsSync(OWNER), 'web/src/lib/workspace.ts must own isStandalone').toBe(true)
+    const src = readFileSync(OWNER, 'utf8')
+    expect(src).toMatch(/export function isStandalone/)
+    expect(src).toMatch(COMPARE_STANDALONE)
+  })
+
+  test('standalone document → badge on; connected / empty-site-connected → off', async () => {
+    const { isStandalone } = await import('./workspace')
+    expect(isStandalone({ workspaceKind: 'standalone' })).toBe(true)
+    expect(isStandalone({ workspaceKind: 'connected' })).toBe(false)
+    // Hosted demo / older document: empty site is not evidence of standalone.
+    expect(isStandalone({ workspaceKind: 'connected', jiraBaseUrl: '' })).toBe(false)
+    expect(isStandalone({ jiraBaseUrl: '' })).toBe(false)
+    expect(isStandalone({ workspaceKind: 'local', jiraBaseUrl: '' })).toBe(false)
+    expect(isStandalone({})).toBe(false)
+    expect(isStandalone(null)).toBe(false)
+    expect(isStandalone(undefined)).toBe(false)
+  })
+})
+
+describe('standalone init command', () => {
+  test('names --profile <name> so the slot the user fills is visible', async () => {
+    const { STANDALONE_INIT_COMMAND } = await import('./workspace')
+    expect(STANDALONE_INIT_COMMAND).toBe('gadak --profile <name> init --standalone')
+  })
+})
+
+describe('no scattered standalone comparisons', () => {
+  test('web/src/{components,stores} never compare a standalone literal', () => {
+    const hits: string[] = []
+    for (const file of [...walk(COMPONENTS), ...walk(STORES)]) {
+      const src = readFileSync(file, 'utf8')
+      if (COMPARE_STANDALONE.test(src)) hits.push(file.slice(WEB_SRC.length + 1))
+    }
+    expect(hits, `comparisons must live in workspace.ts, found in: ${hits.join(', ')}`).toEqual(
+      [],
+    )
+  })
+
+  test('config.ts delegates; it does not own the comparison', () => {
+    const src = readFileSync(join(HERE, 'config.ts'), 'utf8')
+    expect(src).not.toMatch(COMPARE_STANDALONE)
+    expect(src).toMatch(/from ['"]\.\/workspace['"]/)
+  })
+})
+
+describe('badge surfaces wire through isStandalone', () => {
+  test('RuntimeMirror shows the badge only via isStandalone and labels it', () => {
+    const src = readFileSync(join(COMPONENTS, 'settings/RuntimeMirror.svelte'), 'utf8')
+    expect(src).toMatch(/isStandalone\(/)
+    expect(src).toContain('data-testid="workspace-kind"')
+    expect(src).toMatch(/aria-label/)
+    expect(src).toContain('standalone-init-command')
+    expect(src).toContain('standalone-init-copy')
+  })
+
+  test('SidebarNav badges the current workspace name via isStandalone', () => {
+    const src = readFileSync(join(COMPONENTS, 'sidebar/SidebarNav.svelte'), 'utf8')
+    expect(src).toMatch(/isStandalone\(/)
+    expect(src).toContain('data-testid="workspace-kind"')
+    expect(src).toContain('standalone-create')
+  })
+})

--- a/web/src/lib/workspace.ts
+++ b/web/src/lib/workspace.ts
@@ -1,0 +1,40 @@
+/*
+ * Workspace origin kind — single owner for "is this standalone?".
+ *
+ * The server sends workspaceKind on config.json (origin.Describe). Surfaces
+ * must ask here; they must not infer standalone from an empty jiraBaseUrl
+ * (hosted demo and older documents also have no site) and must not scatter
+ * `=== 'standalone'` comparisons.
+ *
+ * Creating a standalone workspace is still CLI-only this round
+ * (cmd/gadak/init.go --standalone). The command below is what the UI shows.
+ */
+
+export const WORKSPACE_KIND_CONNECTED = 'connected'
+export const WORKSPACE_KIND_STANDALONE = 'standalone'
+export type WorkspaceKind =
+  | typeof WORKSPACE_KIND_CONNECTED
+  | typeof WORKSPACE_KIND_STANDALONE
+  | ''
+
+/** CLI that creates a standalone workspace. Flag lives in cmd/gadak/init.go. */
+export const STANDALONE_INIT_COMMAND = 'gadak --profile <name> init --standalone'
+
+export function parseWorkspaceKind(raw: unknown): WorkspaceKind {
+  if (raw === WORKSPACE_KIND_STANDALONE || raw === WORKSPACE_KIND_CONNECTED) {
+    return raw
+  }
+  return ''
+}
+
+/**
+ * True only when the server said standalone. Unknown and connected are false.
+ * `jiraBaseUrl` is ignored on purpose — an empty site is not this kind.
+ */
+export function isStandalone(cfg: unknown): boolean {
+  if (!cfg || typeof cfg !== 'object') return false
+  return (
+    parseWorkspaceKind((cfg as { workspaceKind?: unknown }).workspaceKind) ===
+    WORKSPACE_KIND_STANDALONE
+  )
+}


### PR DESCRIPTION
A standalone workspace looked identical to a connected one. The server had already been sending `workspaceKind` on `config.json`; nothing showed it, and the one hint that existed sat in a settings row most people never open.

- `web/src/lib/workspace.ts` is the single owner of "is this standalone?". Surfaces ask it and must not infer the kind from an empty `jiraBaseUrl` — the hosted demo and older documents also have no site. `config.ts` keeps `isStandaloneWorkspace()` as the binding to the loaded document and re-exports the rest, so there is still one definition.
- The sidebar marks the current workspace with a **Standalone** chip, and its footer offers *Create a standalone workspace*, which reveals the CLI command — creating one is CLI-only this round. `data-kind=standalone` is a new case, not a borrowed enum.
- The command is `gadak --profile <name> init --standalone`. The global `--profile` is only accepted before the subcommand (`cmd/gadak/main.go`), and a second workspace needs a profile name, so the shorter form would be wrong in the place it is offered.
- The hint copy now names the real origin: a standalone workspace's **persist file** is what to back up, not `gadak.db`. The mirror is a cache you can rebuild; "issues exist only in this workspace" invited the opposite conclusion.

`e2e/standalone.spec.ts` adds the cases that would have let this ship wrong: copy asserted against the real clipboard rather than the "Copied" label (GDK-178), the hosted-demo shape (connected + empty site) proving the badge stays away, and the sidebar reveal.

Gates run by the lead from cold: `make typecheck` 0 errors · `npm run test:unit` 33 files / 332 tests · `npx playwright test --config e2e/playwright.config.ts` **238 passed** · `tools/doc-checks.sh` all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)