### PR TITLE
fix(ci): a stalled apt mirror is not a verdict on the change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,25 @@ jobs:
 
       - run: npm ci
 
+      # --with-deps runs apt-get, and an Ubuntu mirror that stalls rather than
+      # fails takes the whole job with it: on 2026-08-18 this step sat on
+      # archive.ubuntu.com for 29 minutes, hit the job's 30-minute timeout, and
+      # reported "Playwright E2E fail" on a pull request that changed one
+      # markdown file. No browser had started. A stalled mirror must not be
+      # able to look like a verdict on the change, so each attempt is killed at
+      # four minutes and retried instead of being waited on.
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        timeout-minutes: 14
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 240 npx playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::playwright install attempt ${attempt} failed or stalled; retrying"
+            sleep 10
+          done
+          echo "::error::playwright install failed three times — this is the installer, not the tests"
+          exit 1
 
       - name: Run browser E2E
         run: npx playwright test --config e2e/playwright.config.ts


### PR DESCRIPTION
The Playwright job installs browsers with `playwright install --with-deps`, which shells out to `apt-get`. On 2026-08-18 an Ubuntu mirror stopped responding mid-fetch: the step sat on `archive.ubuntu.com` for **29 minutes**, the job hit its 30-minute timeout, and PR #15 — which changed **one markdown file** — was reported as `Playwright E2E fail`. No browser was installed and no test ran.

That is the same failure shape this repo has already been bitten by twice: a signal that reads as a red verdict when it is really the *absence* of a verdict. `a596667` taught `tools/ci-status.sh` that a cancelled run is no verdict; this is the step that gets cancelled.

Each attempt is now killed at four minutes and retried up to three times, with the step bounded at fourteen. A mirror stall costs a few minutes and usually recovers; three real failures still fail the job, but the error line says it was the installer, not the tests.

Verified: `yaml.safe_load` parses the workflow, `bash -n` parses the run block, `tools/doc-checks.sh` all passed. This PR's own Playwright job exercises the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)