### PR TITLE
feat(linear): a read-only client whose contract was measured, not guessed (GDK-263)

### DIFF
--- a/internal/linear/MAPPING.md
+++ b/internal/linear/MAPPING.md
@@ -1,0 +1,220 @@
+# Linear → gadak field mapping decisions (GDK-263)
+
+Status: **proposal by the connector round, for the lead to promote into a
+decision document.** Every Linear-side fact below was measured against the
+live GraphQL API on 2026-08-18 (personal API key); every gadak-side fact is
+cited to the repository. Where a field cannot be mapped truthfully, the
+decision is "leave it empty" — a derived field that silently lies is worse
+than a column that is honestly null.
+
+Gadak contract fields are the `issues` / `items` columns in
+`internal/store/schema.go` (schemaV1) as documented in
+`specs/000-product/data-model.md`. The rules that constrain any mapping:
+
+- status/priority/type logic keys on **ids or categories, never display
+  names** (CLAUDE.md; the same hazard `internal/store/derive.go:9` records
+  for Jira status names).
+- `priority_rank` is the 1-based position in the source's most-urgent-first
+  priority list; 0 = unset (`internal/store/derive.go:134`).
+- `time-in-status` is computed from `status_changed_at`, never stored
+  (CLAUDE.md; data-model.md "deliberately absent").
+- The mirror holds no gadak-only original data; anything not present in the
+  source is left empty, not synthesized.
+
+---
+
+## The table
+
+### `status_category` ← `WorkflowState.type`
+
+Linear `WorkflowState.type` is the stable axis (verified live). The spec's
+premise "six types" is **wrong in one value**: this workspace has
+`backlog, unstarted, started, completed, canceled, duplicate` — `duplicate`
+exists and `triage` only appears on teams with triage enabled. The enum is
+open: Linear added `duplicate` after the original six, so any consumer must
+tolerate unknown values.
+
+| WorkflowState.type | status_category | what is lost |
+| --- | --- | --- |
+| `backlog` | `new` | backlog vs triage vs fresh — indistinguishable |
+| `unstarted` | `new` | (same) |
+| `triage` (if present) | `new` | (same) |
+| `started` | `inprogress` | — |
+| `completed` | `done` | — |
+| `canceled` | `done` | canceled ≠ completed |
+| `duplicate` | `done` | duplicate ≠ completed |
+| **unknown future type** | **see below — LEAD DECISION** | |
+
+- **Grounds:** collapse is forced by gadak's three-value contract column;
+  canceled and duplicate are terminal in Linear (workflow position after
+  completed), so `done` is the only defensible bucket. The original survives
+  verbatim in `status_id` (the WorkflowState UUID) plus `status` (display
+  name), so a query that needs "done but not canceled" re-joins `status_id`
+  against `WorkflowStates(teamID)` — that is exactly why this client exposes
+  the catalog method.
+- **Becomes a false mapping when:** someone filters `status_category='done'`
+  and reads it as "shipped" — for Linear it means "closed, including
+  canceled/duplicate". And when Linear ships a new type: silently bucketing
+  an unknown type would be the display-name trap in a new coat. Recommended
+  rule for the sync wiring: a type outside the known set maps to `new` **and
+  increments a loudly-reported counter** (never a silent default). The
+  alternative — refusing the row — would 0-row silently, which is the exact
+  failure mode the constitution bans.
+
+### `priority` / `priority_rank` ← `Issue.priority` (int) + `Issue.priorityLabel`
+
+Linear: `0 = No priority, 1 = Urgent, 2 = High, 3 = Normal/Medium, 4 = Low`
+(0/"No priority" verified live; 1–4 from Linear's documented scale).
+Gadak: rank 1 = most urgent first, 0 = unset, "unset rank 0 sorts after
+Highest when sorting by priority asc" (`e2e/identity-web.spec.ts:51`,
+`internal/store/derive.go:134`, `web/src/lib/format.ts:148`).
+
+- **Decision: identity mapping.** Linear's integer already *is* a
+  most-urgent-first 1-based rank with 0 = unset: 1→1, 2→2, 3→3, 4→4, 0→0.
+  Direction and unset-position match on both ends; nothing flips.
+- `priority` (the name column) ← `priorityLabel`, display-only.
+- **Becomes a false mapping when:** a mirror sorts Jira and Linear rows as
+  one list — rank 2 then means "High" (Linear) and "second in the Jira site's
+  list" (Jira), which agree only if that site uses the default five. That is
+  a cross-source display question for GDK-262, not a reason to distort this
+  connector's ranks. If Linear ever adds priority 5, identity still holds.
+
+### `issue_type` / `issue_type_id` ← (nothing)
+
+Linear has no issue-type concept (the 85-field `Issue` introspection carries
+none). **Leave both empty.** A synthetic constant (`"linear-issue"`) would be
+gadak-only original data and would make `issue_type_id = X` queries return
+phantom truth for a field the source does not have. Consequence, accepted:
+type filters and type facets return no Linear rows — that is correct.
+
+### `key` ← `Issue.identifier` (`MID-1`-shaped)
+
+Same shape as a Jira key (`TEAMKEY-number`), so a Jira `ENG-123` and a
+Linear `ENG-123` can meet in one mirror. Storage does not collide —
+`items_source_key` is UNIQUE on `(source_id, key)` (`schema.go`, schemaV1) —
+but every **key-only** surface does: `watches.key` and `favorites.key` are
+single-column PRIMARY KEYs, saved views and `gadak views open --keys -`
+address issues by bare key, and deep links key on it. This is the same trap
+GDK-241 records for id collisions (that issue could not be read this round —
+see the report; the schema reading above is the verification).
+
+- **Decision for this round: none to make** — the client returns
+  `identifier` verbatim, as the constitution demands ("identifiers from the
+  source are stored verbatim, never re-keyed"). Qualifying keys for display
+  (`linear:ENG-123`) or collision-detecting at sync time is GDK-262's
+  contract with the surfaces; both options need the surfaces' buy-in.
+
+### `status_changed_at` ← derived from `Issue.stateHistory` (not fetched by `Issues()` today)
+
+There is **no** status-changed timestamp on `Issue` itself (verified against
+the full field list). Two derivable sources, both verified live:
+
+- `Issue.stateHistory` → `IssueStateSpan { stateId, startedAt, endedAt }`:
+  the span list is the issue's state timeline; the span with
+  `endedAt == null` is the current state, so its `startedAt` is
+  `status_changed_at`. Cleanest source, one nested paginated connection.
+- `Issue.history` → `IssueHistory { createdAt, actor, fromState, toState,
+  fromPriority, toPriority, … }`: maps 1:1 onto gadak's `changelog` rows
+  (`field='status'`, `from_id`/`to_id` = state ids, `at` = createdAt), and
+  `store.Derive` (`internal/store/derive.go:64`) then computes
+  `status_changed_at`, `resolved_at`, `reopen_count` the same way it does for
+  Jira — no Linear-specific derivation code needed.
+
+Both connections are unbounded, which is why `Issues()` does not inline
+them (a bounded inline fetch would truncate silently; the comments inline
+page avoids this by exposing `HasNextPage`). **What Linear sync must do**
+(GDK-262+ design): fetch `history` per issue (or `stateHistory`) with cursor
+follow-up, feed the existing `Derive` path. Until then: leave
+`status_changed_at` NULL — **time-in-status will not exist for Linear
+issues**, and that is the honest state.
+
+- Related verified fields that could shortcut some of this later:
+  `Issue.startedAt` / `completedAt` / `canceledAt` (work-start / completion /
+  cancellation instants, set per state type). `completedAt`+`canceledAt` can
+  fill `resolved_at` without history — but not `status_changed_at`, and not
+  reopens.
+
+### `parent_key` / `epic_key` ← `Issue.parent`; Project/Cycle ← **unmapped**
+
+- `Issue.parent { id, identifier }` → `parent_key`, same semantic (direct
+  parent). True mapping, no caveat.
+- `epic_key` stays NULL: gadak defines it as the
+  hierarchy-level-1 ancestor, which is a Jira-ism. Treating a Linear parent
+  as an epic is a false mapping whenever a team nests sub-tasks.
+- `Project` and `Cycle` have **no Jira counterpart and no gadak column.**
+  Forcing them into epic would be the classic false mapping. They survive
+  only in `raw` if the sync stores it; exposing them is a product decision
+  with a schema change attached (lead's), not a connector decision.
+
+### Comments ← `Issue.comments` (nested connection, markdown bodies)
+
+Comments come **nested on the issue** (`comments(first: N) { pageInfo nodes
+}`) with their own cursor — verified live; a follow-up fetch pattern exists
+the day an issue exceeds the inline page (`CommentsPageSize`, truncation
+exposed via `HasNextPage`, never silent).
+
+- `Comment.body` is **markdown** (verified; Linear also exposes `bodyData`
+  structured payloads and `documentContent`, both out of scope). gadak's
+  Jira path stores `body_adf` (ADF JSON via `internal/adf`) — **stuffing
+  markdown into an ADF column would be a false mapping.** Linear comments
+  belong in `body_text` (+ raw), and `body_adf` stays NULL until a
+  `body_markdown`-style column or a renderer decision exists (GDK-262+).
+- `attachments`: `Issue.attachments { nodes { id title url subtitle } }`
+  exists (shape verified; `size`/`mimeType` are **not** fields there, unlike
+  Jira). The workspace had no attachments, so the auth-requirements of
+  attachment URLs could not be tested — unverified, flagged.
+
+### The straightforward rows
+
+| gadak | Linear | notes |
+| --- | --- | --- |
+| `items.title` | `Issue.title` | verbatim |
+| `items.body_text` | `Issue.description` (markdown) | flatten markdown to text for FTS; do not store it as ADF |
+| `items.url` | `Issue.url` | contains the org slug; deep link works in a browser session |
+| `items.created_at` / `updated_at` | `createdAt` / `updatedAt` | verbatim ISO-8601 UTC with ms — the format the mirror already stores unmodified |
+| `items.external_id` | `Issue.id` | UUID |
+| `items.author` / `author_id` | `creator.name` / `creator.id` | reporter ← creator |
+| `assignee` / `assignee_id` / `assignee_email` | `Issue.assignee` | NULL assignee is common |
+| `labels` | `labels.nodes[].name` | Jira labels are name-keyed too; a renamed Linear label re-keys, same as Jira |
+| `duedate` | `Issue.dueDate` | field exists; no value in the capture workspace, so the exact wire format (date-only vs datetime) is **unverified** — check before wiring |
+| `project_key` | `team.key` | **proposal**: team is Linear's scope unit (the connector's `Teams` are what a Jira project maps to); `identifier`'s prefix is the team key, matching how `build()` falls back to the key prefix (`internal/sync/sync.go:623`). False-mapping case: a workspace using Linear *Projects* as the project axis — then team-key-as-project lies. Revisit when Project mapping is decided. |
+| `resolution` | (nothing) | Linear has no resolution field; `completedAt`/`canceledAt` are instants, not resolutions. Leave empty. |
+| `changelog` | `Issue.history` | see status_changed_at above — the rows land in the existing table unchanged |
+
+## Deletion / archive semantics (reconcile input)
+
+- Archived: `Issue.archivedAt` set; **rows are visible again when
+  `includeArchived: true`** (the arg exists on `Query.issues`), so reconcile
+  can distinguish archived from deleted. The client passes the flag through
+  (`IssueOpts.IncludeArchived`).
+- Deleted: Linear moves issues to trash (`Issue.trashed` field exists) and
+  they disappear from the default listing. Trashing could not be exercised
+  live (no mutations allowed), so **whether trashed rows ever appear in any
+  listing mode is unverified**; the safe reconcile rule is the Jira one —
+  absence from a full listing is deletion (`internal/sync/sync.go:527`
+  documents the same proof-by-absence).
+
+## What GDK-262 must provide before any of this syncs
+
+1. **Credential storage**: one personal API key string per Linear source
+   (`Authorization: <key>` bare — a "Bearer" prefix fails with an explicit
+   400; this client's header shape is pinned by test). No site/email pair
+   like Atlassian.
+2. **A `sources` row**: `kind='linear'`, `base_url='https://api.linear.app'`
+   (or empty — the endpoint is a constant), `id` a stable slug (`linear`).
+   The workspace-is-bound-to-one-origin constitution article applies
+   unchanged.
+3. **Key-space policy**: decide how bare keys on key-only surfaces
+   (`watches`, `favorites`, `views open --keys -`, deep links) disambiguate
+   a Jira/Linear collision (GDK-241 class). Storage already tolerates it;
+   the surfaces do not.
+4. **Watermark format**: `sync_state.watermark` = Linear `updatedAt`
+   string (ISO-8601 UTC ms, verbatim); incremental pass = `Issues(
+   UpdatedAfter: watermark)` with the same minute-buffer the Jira path
+   applies (`internal/sync/sync.go:35` drops same-minute updates; Linear's
+   ms precision narrows but does not remove that hazard — `gte` re-reads the
+   boundary row, which is cheap and idempotent).
+5. **History fetch design** for `status_changed_at` / reopen fields (see
+   above), or an explicit decision to ship Linear without time-in-status.
+6. **A display story for markdown** bodies (comments, descriptions) —
+   `body_adf` must not become a markdown container.

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -1,0 +1,424 @@
+// Package linear is the read-only GraphQL client for a Linear workspace:
+// viewer, teams, workflow states, and cursor-paged issues with an updatedAt
+// watermark filter. It issues no mutations — this connector mirrors, and a
+// mirror never writes to the origin (gadak constitution, "writes pass through
+// the origin"; Linear writes, if ever, are a separate decision).
+//
+// The API key lives only in the Authorization header. It is never put in an
+// error, a log line, or a URL — the same article-8 discipline internal/jira
+// follows. This package contains no logging at all.
+//
+// Why not internal/atlhttp: that package is the shared transport for
+// *Atlassian Cloud* clients, and its headline guarantee is path safety —
+// joining a caller-supplied path onto a configured site so the Authorization
+// header cannot wander off-host. Linear has one fixed endpoint and no path
+// parameter, so that machinery has nothing to do; what is worth keeping
+// (retry/backoff policy, Retry-After handling, the 64 MiB response cap, the
+// usage counters) is mirrored here with the same semantics, and the
+// rate-limit visibility is Linear-specific: Linear states its budget in
+// response headers (x-ratelimit-*), which Atlassian never did.
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Endpoint is the single Linear GraphQL URL. Personal API keys are the only
+// credential shape this client supports.
+const Endpoint = "https://api.linear.app/graphql"
+
+// maxPageSize is the largest first: value the API accepted in testing
+// (2026-08-18: first: 250 returned 200). Values above it are clamped, not
+// rejected, so a caller guessing "1000" still gets a working page size.
+const maxPageSize = 250
+
+// defaultPageSize keeps request complexity well under the complexity budget
+// while making a page worth committing.
+const defaultPageSize = 50
+
+// ErrAuth is a rejected credential (HTTP 401 or 403). It deliberately does
+// not unwrap to atlhttp.ErrAuth: that sentinel's identity is "Atlassian
+// credential rejected", and importing the Atlassian transport package for a
+// Linear client would couple this package to a host family it never talks to.
+// A future sync wiring keys on errors.Is(err, linear.ErrAuth).
+var ErrAuth = errors.New("linear: credential rejected")
+
+// Client talks to one Linear workspace over GraphQL, read-only.
+type Client struct {
+	// APIKey is sent bare in the Authorization header — no "Bearer" prefix.
+	// Linear rejects the prefixed form with a 400 that says so outright
+	// (measured 2026-08-18), which is why the header shape is pinned by a
+	// test.
+	APIKey string
+
+	// Endpoint is overridable so tests can point at an httptest server.
+	// Production callers get the constant from New.
+	Endpoint string
+
+	HTTP *http.Client
+	// Retries is the total number of attempts per request; Backoff is the
+	// first wait, doubling per attempt and capped at 30 s.
+	Retries int
+	Backoff time.Duration
+
+	// usage and rate are process-local observability; see Usage and
+	// LastRateLimit. They never block a request.
+	usage meter
+	rate  atomic.Pointer[RateLimit]
+}
+
+// New builds a Client for a personal API key. The HTTP client times out at
+// 60 s; Retries is 5; the first Backoff is 1 s — the same defaults
+// internal/jira ships.
+func New(apiKey string) *Client {
+	c := &Client{
+		APIKey:   apiKey,
+		Endpoint: Endpoint,
+		HTTP:     &http.Client{Timeout: 60 * time.Second},
+		Retries:  5,
+		Backoff:  time.Second,
+	}
+	return c
+}
+
+// IssueOpts scopes an Issues call. All fields are optional; the zero value
+// pages every issue the credential can see, live ones only.
+type IssueOpts struct {
+	// TeamID restricts the page to one team (filter.team.id.eq). IDs come
+	// from Teams; keys are display-facing and never a filter key.
+	TeamID string
+	// UpdatedAfter is an ISO-8601 timestamp and becomes filter.updatedAt.gte
+	// — the incremental-sync watermark. Verified live: the gte and gt
+	// comparators both exist on IssueFilter.updatedAt.
+	UpdatedAfter string
+	// IncludeArchived asks for archived rows too (archivedAt set), which a
+	// reconcile pass needs so an archived issue is not misread as deleted.
+	IncludeArchived bool
+	// PageSize clamps to [1, maxPageSize]; 0 means defaultPageSize.
+	PageSize int
+}
+
+// Viewer returns the authenticated user. It is the minimal credential check
+// (Jira's /myself equivalent). The result carries personal data (name,
+// email): log neither.
+func (c *Client) Viewer(ctx context.Context) (User, error) {
+	var page struct {
+		Viewer User `json:"viewer"`
+	}
+	if err := c.gql(ctx, queryViewer, nil, &page); err != nil {
+		return User{}, err
+	}
+	return page.Viewer, nil
+}
+
+// Teams lists every team the credential can see.
+func (c *Client) Teams(ctx context.Context) ([]Team, error) {
+	out := []Team{}
+	after := ""
+	for {
+		vars := map[string]any{}
+		if after != "" {
+			vars["after"] = after
+		}
+		var page struct {
+			Teams TeamConnection `json:"teams"`
+		}
+		if err := c.gql(ctx, queryTeams, vars, &page); err != nil {
+			return nil, err
+		}
+		out = append(out, page.Teams.Nodes...)
+		if !page.Teams.PageInfo.HasNextPage || page.Teams.PageInfo.EndCursor == "" {
+			return out, nil
+		}
+		after = page.Teams.PageInfo.EndCursor
+	}
+}
+
+// WorkflowStates returns a team's status catalog. This is the id → type map
+// the status_category mapping needs (MAPPING.md): state names are display
+// text, types are the stable axis.
+func (c *Client) WorkflowStates(ctx context.Context, teamID string) ([]WorkflowState, error) {
+	out := []WorkflowState{}
+	after := ""
+	for {
+		vars := map[string]any{
+			"filter": map[string]any{
+				"team": map[string]any{"id": map[string]any{"eq": teamID}},
+			},
+		}
+		if after != "" {
+			vars["after"] = after
+		}
+		var page struct {
+			WorkflowStates WorkflowStateConnection `json:"workflowStates"`
+		}
+		if err := c.gql(ctx, queryWorkflowStates, vars, &page); err != nil {
+			return nil, err
+		}
+		out = append(out, page.WorkflowStates.Nodes...)
+		if !page.WorkflowStates.PageInfo.HasNextPage || page.WorkflowStates.PageInfo.EndCursor == "" {
+			return out, nil
+		}
+		after = page.WorkflowStates.PageInfo.EndCursor
+	}
+}
+
+// Issues pages issues oldest-updated-first and calls fn once per page, which
+// is what lets a sync commit page by page — the same contract as
+// jira.Client.Search. Pagination is cursor-based (pageInfo.endCursor);
+// verified live that following the cursor returns exactly the next rows.
+func (c *Client) Issues(ctx context.Context, opts IssueOpts, fn func([]Issue) error) error {
+	filter := map[string]any{}
+	if opts.UpdatedAfter != "" {
+		filter["updatedAt"] = map[string]any{"gte": opts.UpdatedAfter}
+	}
+	if opts.TeamID != "" {
+		filter["team"] = map[string]any{"id": map[string]any{"eq": opts.TeamID}}
+	}
+
+	size := opts.PageSize
+	if size <= 0 {
+		size = defaultPageSize
+	}
+	if size > maxPageSize {
+		size = maxPageSize
+	}
+
+	after := ""
+	for {
+		vars := map[string]any{
+			"first":           size,
+			"filter":          filter,
+			"includeArchived": opts.IncludeArchived,
+		}
+		if after != "" {
+			vars["after"] = after
+		}
+		var page struct {
+			Issues IssueConnection `json:"issues"`
+		}
+		if err := c.gql(ctx, queryIssues, vars, &page); err != nil {
+			return err
+		}
+		if len(page.Issues.Nodes) > 0 {
+			if err := fn(page.Issues.Nodes); err != nil {
+				return err
+			}
+		}
+		if !page.Issues.PageInfo.HasNextPage || page.Issues.PageInfo.EndCursor == "" {
+			return nil
+		}
+		after = page.Issues.PageInfo.EndCursor
+	}
+}
+
+// graphRequest is the GraphQL over HTTP envelope.
+type graphRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables,omitempty"`
+}
+
+// graphResponse is the reply envelope. GraphQL answers errors as HTTP 200
+// with an errors array; those are surfaced as errors here.
+type graphResponse struct {
+	Data   json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// gql sends one query and unmarshals data into out. Errors never contain the
+// API key: the key travels only in the Authorization header, and response
+// bodies (the only foreign text in an error) cannot echo a header they never
+// saw.
+func (c *Client) gql(ctx context.Context, query string, vars map[string]any, out any) error {
+	payload, err := json.Marshal(graphRequest{Query: query, Variables: vars})
+	if err != nil {
+		return err
+	}
+
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint, strings.NewReader(string(payload)))
+		if err != nil {
+			return err
+		}
+		// Bare key. "Authorization: Bearer <key>" is rejected by Linear with
+		// a 400 telling you to remove the prefix — pinned by test.
+		req.Header.Set("Authorization", c.APIKey)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		res, err := c.HTTP.Do(req)
+		c.usage.noteRequest()
+		if err != nil {
+			if attempt < c.Retries-1 {
+				if werr := c.wait(ctx, attempt, ""); werr != nil {
+					return werr
+				}
+				c.usage.noteRetry()
+				continue
+			}
+			return fmt.Errorf("POST /graphql: %w", err)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(res.Body, 64<<20))
+		res.Body.Close()
+		c.usage.noteStatus(res.StatusCode)
+		c.noteRateLimit(res.Header)
+
+		if res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusForbidden {
+			// A rejected credential is final: retrying would burn the rate
+			// budget for an answer that cannot change.
+			return fmt.Errorf("POST /graphql: %w (%d %s)", ErrAuth, res.StatusCode, http.StatusText(res.StatusCode))
+		}
+		if isRetryable(res.StatusCode) && attempt < c.Retries-1 {
+			if werr := c.wait(ctx, attempt, res.Header.Get("Retry-After")); werr != nil {
+				return werr
+			}
+			c.usage.noteRetry()
+			continue
+		}
+		if readErr != nil && res.StatusCode >= 200 && res.StatusCode < 300 {
+			return fmt.Errorf("POST /graphql: %w", readErr)
+		}
+		if res.StatusCode >= 300 {
+			return fmt.Errorf("POST /graphql: linear: %d %s: %s", res.StatusCode, http.StatusText(res.StatusCode), snippet(data))
+		}
+
+		var env graphResponse
+		if err := json.Unmarshal(data, &env); err != nil {
+			return fmt.Errorf("POST /graphql: bad JSON: %w", err)
+		}
+		if len(env.Errors) > 0 {
+			msgs := make([]string, 0, len(env.Errors))
+			for _, e := range env.Errors {
+				msgs = append(msgs, e.Message)
+			}
+			return fmt.Errorf("POST /graphql: linear: graphql error: %s", snippet([]byte(strings.Join(msgs, "; "))))
+		}
+		if out == nil || len(env.Data) == 0 {
+			return nil
+		}
+		return json.Unmarshal(env.Data, out)
+	}
+}
+
+// isRetryable mirrors the read policy of internal/atlhttp (writes do not
+// exist here): throttle and transient server errors are worth another
+// attempt, everything else is an answer.
+func isRetryable(code int) bool {
+	switch code {
+	case 429, 500, 502, 503, 504:
+		return true
+	}
+	return false
+}
+
+func (c *Client) wait(ctx context.Context, attempt int, retryAfter string) error {
+	d := c.Backoff << attempt
+	if d > 30*time.Second {
+		d = 30 * time.Second
+	}
+	if s, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && s > 0 {
+		d = time.Duration(s) * time.Second
+	}
+	if d <= 0 {
+		return ctx.Err()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// snippet trims and truncates a response body for error messages — the same
+// shape as atlhttp.Snippet, kept local because this package does not import
+// atlhttp.
+func snippet(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > 400 {
+		return s[:400] + "…"
+	}
+	return s
+}
+
+// Usage is a point-in-time snapshot of this process's outbound Linear HTTP
+// traffic. Counters are process-local until a caller persists them; Requests
+// counts every attempt including retries, which is the unit that draws from
+// the rate budget.
+type Usage struct {
+	Requests      int64
+	Retries       int64
+	Throttled     int64     // 429 responses
+	ServerErrors  int64     // 5xx responses, excluding 429
+	LastThrottled time.Time // UTC; zero if never throttled
+}
+
+// Usage returns the current counters without resetting them.
+func (c *Client) Usage() Usage { return c.usage.snapshot() }
+
+// TakeUsage returns the counters and zeroes them so a flusher can accumulate
+// without double-counting. LastThrottledAt is a timestamp, not a counter, and
+// is not cleared.
+func (c *Client) TakeUsage() Usage { return c.usage.take() }
+
+// meter holds the atomic counters behind Usage.
+type meter struct {
+	requests     atomic.Int64
+	retries      atomic.Int64
+	throttled    atomic.Int64
+	serverErrors atomic.Int64
+	lastUnixNs   atomic.Int64
+}
+
+func (m *meter) snapshot() Usage {
+	return Usage{
+		Requests:      m.requests.Load(),
+		Retries:       m.retries.Load(),
+		Throttled:     m.throttled.Load(),
+		ServerErrors:  m.serverErrors.Load(),
+		LastThrottled: unixToTime(m.lastUnixNs.Load()),
+	}
+}
+
+func (m *meter) take() Usage {
+	u := Usage{
+		Requests:      m.requests.Swap(0),
+		Retries:       m.retries.Swap(0),
+		Throttled:     m.throttled.Swap(0),
+		ServerErrors:  m.serverErrors.Swap(0),
+		LastThrottled: unixToTime(m.lastUnixNs.Load()), // not reset
+	}
+	return u
+}
+
+func (m *meter) noteRequest() { m.requests.Add(1) }
+
+func (m *meter) noteRetry() { m.retries.Add(1) }
+
+func (m *meter) noteStatus(code int) {
+	switch {
+	case code == 429:
+		m.throttled.Add(1)
+		m.lastUnixNs.Store(time.Now().UTC().UnixNano())
+	case code >= 500 && code <= 599:
+		m.serverErrors.Add(1)
+	}
+}
+
+func unixToTime(ns int64) time.Time {
+	if ns <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
+}

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -1,0 +1,427 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testKey stands where the real API key would. It is deliberately not
+// key-shaped (no lin_api_ prefix) so no scanner ever has an opinion about it.
+const testKey = "linear-test-key-not-a-real-secret"
+
+func testClient(t *testing.T, h http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	c := New(testKey)
+	c.Endpoint = srv.URL
+	c.Retries, c.Backoff = 4, 0
+	return c
+}
+
+func decode(t *testing.T, r *http.Request, out any) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(out); err != nil {
+		t.Fatalf("bad request body: %v", err)
+	}
+}
+
+func fixture(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("fixture %s: %v", name, err)
+	}
+	return b
+}
+
+func writeFixture(w http.ResponseWriter, t *testing.T, name string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(fixture(t, name))
+}
+
+// The Authorization header is the bare key. Linear answers "Bearer <key>"
+// with a 400 that tells you to remove the prefix (measured 2026-08-18), so a
+// regression to the prefixed form breaks every call — this pins the shape.
+func TestAuthHeaderIsBareKey(t *testing.T) {
+	var got, contentType string
+	var method, path string
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		contentType = r.Header.Get("Content-Type")
+		method, path = r.Method, r.URL.Path
+		writeFixture(w, t, "viewer.json")
+	}))
+	if _, err := c.Viewer(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got != testKey {
+		// Print the length, not the value: if this ever fails against a real
+		// credential, the failure message must not become the leak.
+		t.Errorf("Authorization header is not exactly the API key (got length %d)", len(got))
+	}
+	if strings.HasPrefix(got, "Bearer ") {
+		t.Error("Authorization must not carry a Bearer prefix — Linear rejects it with 400")
+	}
+	if method != http.MethodPost || path != "/" {
+		// The test server has no path; production posts to Endpoint. What
+		// matters here is the verb and that nothing else was contacted.
+		t.Errorf("request = %s %s, want POST to the configured endpoint", method, path)
+	}
+	if !strings.HasSuffix(Endpoint, "/graphql") || !strings.HasPrefix(Endpoint, "https://api.linear.app/") {
+		t.Errorf("Endpoint = %q, want the Linear GraphQL URL", Endpoint)
+	}
+	if !strings.Contains(contentType, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", contentType)
+	}
+}
+
+// Page 1 of the real capture ends hasNextPage with a cursor; page 2 was
+// captured with exactly that cursor. The client must join them in order.
+func TestIssuesFollowsCursorAcrossPages(t *testing.T) {
+	calls := 0
+	var seen []string
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body struct {
+			Variables struct {
+				After string `json:"after"`
+			} `json:"variables"`
+		}
+		decode(t, r, &body)
+		switch body.Variables.After {
+		case "":
+			writeFixture(w, t, "issues_page1.json")
+		case "00000000-0000-4000-8000-000000000000":
+			writeFixture(w, t, "issues_page2.json")
+		default:
+			t.Errorf("unexpected cursor %q", body.Variables.After)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	err := c.Issues(context.Background(), IssueOpts{}, func(pg []Issue) error {
+		for _, iss := range pg {
+			seen = append(seen, iss.Identifier)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	want := []string{"FIX-1", "FIX-4", "FIX-2", "FIX-3"}
+	if strings.Join(seen, ",") != strings.Join(want, ",") {
+		t.Errorf("identifiers = %v, want %v in page order", seen, want)
+	}
+	if u := c.Usage(); u.Requests != 2 {
+		t.Errorf("Usage.Requests = %d, want 2", u.Requests)
+	}
+}
+
+// The watermark and team scope must travel as filter variables — the
+// incremental-sync contract (updatedAt.gte) and the never-key-on-display-name
+// rule (team.id, not team key) both live here.
+func TestIssuesSendsWatermarkFilterAndTeamScope(t *testing.T) {
+	var vars struct {
+		First           int  `json:"first"`
+		IncludeArchived bool `json:"includeArchived"`
+		Filter          struct {
+			UpdatedAt struct {
+				Gte string `json:"gte"`
+			} `json:"updatedAt"`
+			Team struct {
+				ID struct {
+					Eq string `json:"eq"`
+				} `json:"id"`
+			} `json:"team"`
+		} `json:"filter"`
+	}
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Variables json.RawMessage `json:"variables"`
+		}
+		decode(t, r, &body)
+		if err := json.Unmarshal(body.Variables, &vars); err != nil {
+			t.Fatalf("variables: %v", err)
+		}
+		writeFixture(w, t, "issues_page2.json") // single final page
+	}))
+	err := c.Issues(context.Background(), IssueOpts{
+		TeamID:          "team-uuid-from-teams-call",
+		UpdatedAfter:    "2026-08-01T00:00:00.000Z",
+		IncludeArchived: true,
+	}, func([]Issue) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars.Filter.UpdatedAt.Gte != "2026-08-01T00:00:00.000Z" {
+		t.Errorf("filter.updatedAt.gte = %q, want the watermark", vars.Filter.UpdatedAt.Gte)
+	}
+	if vars.Filter.Team.ID.Eq != "team-uuid-from-teams-call" {
+		t.Errorf("filter.team.id.eq = %q, want the team id", vars.Filter.Team.ID.Eq)
+	}
+	if !vars.IncludeArchived {
+		t.Error("includeArchived must be passed through for reconcile passes")
+	}
+	if vars.First != defaultPageSize {
+		t.Errorf("first = %d, want default %d", vars.First, defaultPageSize)
+	}
+}
+
+func TestIssuesClampsPageSize(t *testing.T) {
+	var first int
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Variables struct {
+				First int `json:"first"`
+			} `json:"variables"`
+		}
+		decode(t, r, &body)
+		first = body.Variables.First
+		writeFixture(w, t, "issues_page2.json")
+	}))
+	err := c.Issues(context.Background(), IssueOpts{PageSize: 1000}, func([]Issue) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != maxPageSize {
+		t.Errorf("first = %d, want clamp to %d", first, maxPageSize)
+	}
+}
+
+func TestAuthFailureBecomesErrAuthWithoutRetry(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		calls := 0
+		c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(status)
+			w.Write([]byte(`{"errors":[{"message":"invalid api key"}]}`))
+		}))
+		_, err := c.Teams(context.Background())
+		if !errors.Is(err, ErrAuth) {
+			t.Fatalf("status %d: err = %v, want ErrAuth", status, err)
+		}
+		if calls != 1 {
+			t.Errorf("status %d: attempts = %d, want 1 — a bad credential must not burn the rate budget", status, calls)
+		}
+	}
+}
+
+// The credential-leak assertion. Article 8 (same as jira): the key travels
+// only in the Authorization header; no error string may echo it. Every error
+// path this package can produce is checked.
+func TestErrorsNeverContainCredential(t *testing.T) {
+	newErr := func(h http.Handler) error {
+		c := testClient(t, h)
+		_, err := c.Teams(context.Background())
+		return err
+	}
+	cases := map[string]http.Handler{
+		"auth rejected": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"errors":[{"message":"unauthorized"}]}`, http.StatusUnauthorized)
+		}),
+		"server error after retries": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}),
+		"graphql error envelope": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"errors":[{"message":"It looks like you're trying to use an API key as a Bearer token."}]}`))
+		}),
+		"bad json": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`not json`))
+		}),
+	}
+	for name, h := range cases {
+		err := newErr(h)
+		if err == nil {
+			t.Errorf("%s: expected an error", name)
+			continue
+		}
+		if strings.Contains(err.Error(), testKey) {
+			t.Errorf("%s: error message leaked the credential", name)
+		}
+	}
+	// Transport failure: the endpoint is unreachable. The wrapped error names
+	// the method and URL context; it must still not echo the key.
+	c := New(testKey)
+	c.Endpoint = "http://127.0.0.1:0/graphql" // port 0: nothing listens
+	c.Retries, c.Backoff = 2, 0
+	if _, err := c.Viewer(context.Background()); err == nil || !strings.Contains(err.Error(), "POST /graphql") {
+		t.Fatalf("transport error = %v, want a wrapped POST /graphql error", err)
+	} else if strings.Contains(err.Error(), testKey) {
+		t.Error("transport error leaked the credential")
+	}
+	// And the endpoint itself is not the key: the default is a constant.
+	if strings.Contains(Endpoint, testKey) {
+		t.Error("Endpoint embeds the test key")
+	}
+}
+
+func TestRetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("X-RateLimit-Requests-Remaining", "2497")
+		w.Header().Set("X-RateLimit-Requests-Limit", "2500")
+		writeFixture(w, t, "teams.json")
+	}))
+	teams, err := c.Teams(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 3 {
+		t.Errorf("attempts = %d, want 3", calls)
+	}
+	if len(teams) != 1 || teams[0].Key != "FIX" {
+		t.Errorf("teams = %+v, want the fixture team", teams)
+	}
+	u := c.Usage()
+	if u.Requests != 3 || u.Retries != 2 || u.Throttled != 2 {
+		t.Errorf("usage = %+v, want 3 requests / 2 retries / 2 throttled", u)
+	}
+	rl := c.LastRateLimit()
+	if rl.RequestsRemaining != 2497 || rl.RequestsLimit != 2500 {
+		t.Errorf("rate limit = %+v, want the parsed headers", rl)
+	}
+}
+
+func TestGraphQLErrorsSurfaceAsErrors(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"errors":[{"message":"Something went wrong."},{"message":"Second message."}]}`))
+	}))
+	_, err := c.Viewer(context.Background())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "Something went wrong.") || !strings.Contains(err.Error(), "Second message.") {
+		t.Errorf("err = %v, want both graphql messages", err)
+	}
+	if strings.Contains(err.Error(), testKey) {
+		t.Error("graphql error leaked the credential")
+	}
+}
+
+func TestFixtureParses(t *testing.T) {
+	t.Run("viewer", func(t *testing.T) {
+		c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writeFixture(w, t, "viewer.json")
+		}))
+		v, err := c.Viewer(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if v.ID == "" || v.Email == "" || v.Name == "" {
+			t.Errorf("viewer = %+v, want id/name/email populated", v)
+		}
+	})
+	t.Run("workflowstates carries the duplicate type", func(t *testing.T) {
+		var teamFilter string
+		c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body struct {
+				Variables struct {
+					Filter struct {
+						Team struct {
+							ID struct {
+								Eq string `json:"eq"`
+							} `json:"id"`
+						} `json:"team"`
+					} `json:"filter"`
+				} `json:"variables"`
+			}
+			decode(t, r, &body)
+			teamFilter = body.Variables.Filter.Team.ID.Eq
+			writeFixture(w, t, "workflowstates.json")
+		}))
+		states, err := c.WorkflowStates(context.Background(), "00000000-0000-4000-8000-000000000003")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if teamFilter != "00000000-0000-4000-8000-000000000003" {
+			t.Errorf("team filter = %q, want the requested team id", teamFilter)
+		}
+		types := map[string]bool{}
+		for _, s := range states {
+			types[s.Type] = true
+		}
+		for _, want := range []string{"backlog", "unstarted", "started", "completed", "canceled", "duplicate"} {
+			if !types[want] {
+				t.Errorf("state type %q missing from catalog %v", want, types)
+			}
+		}
+	})
+	t.Run("issue fields round-trip", func(t *testing.T) {
+		c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			writeFixture(w, t, "issues_page2.json") // final page, loop ends
+		}))
+		var got []Issue
+		if err := c.Issues(context.Background(), IssueOpts{}, func(pg []Issue) error {
+			got = append(got, pg...)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("issues = %d, want 2", len(got))
+		}
+		one := got[0]
+		if one.Identifier != "FIX-2" || one.State.Type != "unstarted" || one.State.Name != "Todo" {
+			t.Errorf("issue = %s state %+v, want FIX-2 on the Todo/unstarted state", one.Identifier, one.State)
+		}
+		if one.Team.Key != "FIX" || one.Team.ID != "00000000-0000-4000-8000-000000000003" {
+			t.Errorf("team = %+v, want the fixture team with the id shared across files", one.Team)
+		}
+		if one.Priority != 0 || one.PriorityLabel != "No priority" {
+			t.Errorf("priority = %d %q, want 0 No priority", one.Priority, one.PriorityLabel)
+		}
+		if one.CreatedAt != "2026-08-18T13:18:31.131Z" || one.UpdatedAt == "" {
+			t.Errorf("timestamps = %q / %q, want verbatim ISO-8601", one.CreatedAt, one.UpdatedAt)
+		}
+		if !strings.Contains(one.Description, "## Overview") || !strings.Contains(one.URL, "linear.app/example/issue/FIX-") {
+			t.Errorf("description/url lost the scrubbed fixture shape")
+		}
+	})
+}
+
+// The nested comments connection must expose its own pageInfo so an issue
+// with more comments than the inline page is observable, never silently
+// truncated. Synthetic vector: the capture workspace has no comment-heavy
+// issue, so the envelope is hand-built to the verified shape.
+func TestCommentsTruncationIsObservable(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":{"issues":{"pageInfo":{"hasNextPage":false},"nodes":[{` +
+			`"id":"c1","identifier":"FIX-9","comments":{` +
+			`"pageInfo":{"hasNextPage":true,"endCursor":"cmt-cursor"},` +
+			`"nodes":[{"id":"c0","body":"body markdown","createdAt":"2026-08-18T13:18:31.131Z","updatedAt":"2026-08-18T13:18:31.131Z","user":{"id":"u0","name":"Fixture User 9","displayName":"Fix User 9"}}]}}]}}}`))
+	}))
+	var got []Issue
+	if err := c.Issues(context.Background(), IssueOpts{}, func(pg []Issue) error {
+		got = pg
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("issues = %d, want 1", len(got))
+	}
+	cm := got[0].Comments
+	if len(cm.Nodes) != 1 || cm.Nodes[0].Body != "body markdown" {
+		t.Fatalf("comments = %+v, want the parsed node", cm.Nodes)
+	}
+	if !cm.PageInfo.HasNextPage || cm.PageInfo.EndCursor != "cmt-cursor" {
+		t.Errorf("comments pageInfo = %+v, want truncation visible", cm.PageInfo)
+	}
+}

--- a/internal/linear/queries.go
+++ b/internal/linear/queries.go
@@ -1,0 +1,156 @@
+package linear
+
+import "strconv"
+
+// Every GraphQL string this package sends lives in this file, so a Linear
+// schema change has exactly one place to fix. Each query was executed against
+// the live API (2026-08-18) before being pinned here; the tests replay
+// recorded responses against these exact strings.
+//
+// Filters are always passed as whole-object variables ($filter), never
+// interpolated into the string — the query text has no caller-controlled
+// bytes in it.
+//
+// Filters are always passed as whole-object variables ($filter), never
+// interpolated into the string — the query text has no caller-controlled
+// bytes in it.
+
+// queryViewer is the smallest question that proves the credential works: the
+// equivalent of Jira's /myself for `gadak init`. The response carries personal
+// data (name, email); see User.
+const queryViewer = `query Viewer {
+  viewer {
+    id
+    name
+    displayName
+    email
+  }
+}`
+
+// queryTeams lists the teams the credential can see. A workspace has few
+// teams, but teams is a connection like everything else, so the client still
+// follows the cursor.
+const queryTeams = `query Teams($after: String) {
+  teams(first: 50, after: $after) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      id
+      key
+      name
+      private
+    }
+  }
+}`
+
+// queryWorkflowStates lists one team's status catalog. Filter shape verified
+// live: workflowStates(filter: {team: {id: {eq: "<uuid>"}}}) returns exactly
+// that team's states.
+const queryWorkflowStates = `query WorkflowStates($filter: WorkflowStateFilter, $after: String) {
+  workflowStates(filter: $filter, first: 100, after: $after) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      id
+      name
+      type
+      position
+    }
+  }
+}`
+
+// CommentsPageSize is the inline comment page on every issue row. Issues with
+// more comments than this set Comments.PageInfo.HasNextPage, which is the
+// contract that makes the truncation visible (see Issue.Comments).
+const CommentsPageSize = 50
+
+// queryIssues pages issues oldest-updated-first. A var, not a const: the
+// inline comment page size is spliced from CommentsPageSize so "50" has one
+// owner. Filter carries the
+// incremental-sync watermark (updatedAt.gte) and the team scope; both were
+// verified live. orderBy: updatedAt has no descending direction argument on
+// Query.issues (orderDirection does not exist there — verified by rejection),
+// and ascending is what a watermark-driven sync wants anyway.
+//
+// includeArchived is passed as a variable so reconcile passes can see archived
+// rows (archivedAt set) instead of mistaking them for deleted.
+//
+// Not requested here, deliberately: stateHistory / history (unbounded nested
+// connections — the status_changed_at derivation is specified in MAPPING.md
+// and belongs to the sync-wiring round) and attachments.
+var queryIssues = `query Issues($first: Int, $after: String, $filter: IssueFilter, $includeArchived: Boolean) {
+  issues(first: $first, after: $after, filter: $filter, includeArchived: $includeArchived, orderBy: updatedAt) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      id
+      identifier
+      number
+      title
+      description
+      url
+      createdAt
+      updatedAt
+      archivedAt
+      priority
+      priorityLabel
+      dueDate
+      state {
+        id
+        name
+        type
+        position
+      }
+      team {
+        id
+        key
+        name
+      }
+      assignee {
+        id
+        name
+        displayName
+        email
+      }
+      creator {
+        id
+        name
+        displayName
+        email
+      }
+      labels {
+        nodes {
+          id
+          name
+        }
+      }
+      parent {
+        id
+        identifier
+      }
+      comments(first: ` + strconv.Itoa(CommentsPageSize) + `) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          body
+          createdAt
+          updatedAt
+          user {
+            id
+            name
+            displayName
+          }
+        }
+      }
+    }
+  }
+}`

--- a/internal/linear/ratelimit.go
+++ b/internal/linear/ratelimit.go
@@ -1,0 +1,76 @@
+package linear
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RateLimit is the budget Linear states in response headers after every call
+// (captured 2026-08-18 on a personal API key):
+//
+//	x-complexity: 1
+//	x-ratelimit-complexity-limit: 3000000
+//	x-ratelimit-complexity-remaining: 2999999
+//	x-ratelimit-complexity-reset: 1787064041508
+//	x-ratelimit-requests-limit: 2500
+//	x-ratelimit-requests-remaining: 2499
+//	x-ratelimit-requests-reset: 1787064041508
+//
+// Two axes: a request count (2500 per window) and a query-complexity sum
+// (3,000,000 per window), both resetting at the same epoch-millisecond stamp.
+// This is server-claimed state, unlike Usage, which counts what this process
+// sent — a connector that only watches one of them can be surprised by the
+// other.
+type RateLimit struct {
+	// Complexity of the most recent query (x-complexity).
+	Complexity int64 `json:"complexity"`
+	// ComplexityLimit / ComplexityRemaining are the window's budget and what
+	// is left of it; ComplexityResetMS is the epoch-ms reset instant.
+	ComplexityLimit     int64 `json:"complexity_limit"`
+	ComplexityRemaining int64 `json:"complexity_remaining"`
+	ComplexityResetMS   int64 `json:"complexity_reset_ms"`
+	// RequestsLimit / RequestsRemaining are the request-count window;
+	// RequestsResetMS is the epoch-ms reset instant.
+	RequestsLimit     int64 `json:"requests_limit"`
+	RequestsRemaining int64 `json:"requests_remaining"`
+	RequestsResetMS   int64 `json:"requests_reset_ms"`
+	// ObservedAt is when these values were read (UTC).
+	ObservedAt time.Time `json:"observed_at"`
+}
+
+// LastRateLimit returns the headers of the most recent response, or the zero
+// RateLimit before the first call. It is a snapshot for diagnostics — sync
+// status output, `gadak` health — never a gate: a missing header must not
+// fail a request that succeeded.
+func (c *Client) LastRateLimit() RateLimit {
+	if rl := c.rate.Load(); rl != nil {
+		return *rl
+	}
+	return RateLimit{}
+}
+
+// noteRateLimit parses the x-ratelimit-* headers of one response. Unparsable
+// or absent headers leave fields at zero; parsing never fails the request.
+func (c *Client) noteRateLimit(h http.Header) {
+	rl := RateLimit{
+		Complexity:          parseHeaderInt(h, "X-Complexity"),
+		ComplexityLimit:     parseHeaderInt(h, "X-RateLimit-Complexity-Limit"),
+		ComplexityRemaining: parseHeaderInt(h, "X-RateLimit-Complexity-Remaining"),
+		ComplexityResetMS:   parseHeaderInt(h, "X-RateLimit-Complexity-Reset"),
+		RequestsLimit:       parseHeaderInt(h, "X-RateLimit-Requests-Limit"),
+		RequestsRemaining:   parseHeaderInt(h, "X-RateLimit-Requests-Remaining"),
+		RequestsResetMS:     parseHeaderInt(h, "X-RateLimit-Requests-Reset"),
+		ObservedAt:          time.Now().UTC(),
+	}
+	c.rate.Store(&rl)
+}
+
+func parseHeaderInt(h http.Header, name string) int64 {
+	v, err := strconv.ParseInt(strings.TrimSpace(h.Get(name)), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/internal/linear/testdata/README.md
+++ b/internal/linear/testdata/README.md
@@ -1,0 +1,48 @@
+# testdata — scrubbed live captures
+
+Each file is a real GraphQL response from the Linear API (captured 2026-08-18,
+personal API key, with the exact query constants this package ships), scrubbed
+so it carries no person- or workspace-identifying value. Shape is real;
+identity is not.
+
+| File | Captured with | What it exercises |
+| --- | --- | --- |
+| `viewer.json` | `queryViewer` | user parse, credential-check reply shape |
+| `teams.json` | `queryTeams` | team list, connection envelope |
+| `workflowstates.json` | `queryWorkflowStates` (team filter) | the six state `type` values incl. `duplicate` |
+| `issues_page1.json` | `queryIssues` (`first: 2`) | issue parse; `hasNextPage: true` + real cursor |
+| `issues_page2.json` | `queryIssues` (`after:` page 1's cursor) | cursor continuation, final page |
+
+## Scrub rules
+
+The captures were piped through a one-shot scrubber that walks the JSON and
+rewrites, with a value-keyed map shared across all files (so the same original
+always becomes the same fake — the team uuid in `teams.json` and inside
+`issues_page*.json` agree):
+
+- every UUID-shaped string → `00000000-0000-4000-8000-<12-digit counter>`
+- user `name` / `displayName` / `email` → `Fixture User <n>` / `Fix User <n>`
+  / `user-<n>@example.invalid`
+- team `name` / `key` → `Fixture Team` / `FIX`
+- issue `identifier` `MID-<n>` → `FIX-<n>` (numbers kept)
+- issue `url` → `https://linear.app/example/issue/FIX-<n>/scrubbed`
+  (the real org slug and title slug are dropped)
+- issue `title` → `Fixture issue <n>`
+- issue `description` and comment `body` → a synthetic markdown block with the
+  same structural shape (heading, checklist, link, fenced code)
+- workflow-state `name` → Linear's default vocabulary for its `type`
+  (`backlog`→Backlog, `unstarted`→Todo, `started`→In Progress,
+  `completed`→Done, `canceled`→Canceled, `duplicate`→Duplicate) — this
+  workspace already used the defaults, so those specific strings round-trip
+
+Kept verbatim because they identify no one and the fixtures need them real:
+timestamps (ISO-8601 UTC with ms), `priority`/`priorityLabel` vocabulary,
+`position`, booleans, `number`, connection cursors-as-fakes.
+
+The scrubber refuses to write a file if any rewritten original survives in the
+output text (substring scan over the final bytes, exempting the known-safe
+Linear default vocabulary above); the run that produced these files ended with
+`40 originals replaced and verified absent`.
+
+No raw capture ever entered the repository — scrubbing happened outside the
+tree and only the output was written here.

--- a/internal/linear/testdata/issues_page1.json
+++ b/internal/linear/testdata/issues_page1.json
@@ -1,0 +1,88 @@
+{
+  "data": {
+    "issues": {
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "00000000-0000-4000-8000-000000000000"
+      },
+      "nodes": [
+        {
+          "id": "00000000-0000-4000-8000-000000000001",
+          "identifier": "FIX-1",
+          "number": 1,
+          "title": "Fixture issue 1",
+          "description": "## Overview\n\nA fixture description with the shape of real Linear markdown.\n\n- [ ] one open checklist item\n- [x] one done checklist item\n\nA [docs link](https://linear.app/docs) and `inline code`.\n\n```\na fenced code block\n```\n",
+          "url": "https://linear.app/example/issue/FIX-1/scrubbed",
+          "createdAt": "2026-08-18T13:18:31.131Z",
+          "updatedAt": "2026-08-18T13:18:31.131Z",
+          "archivedAt": null,
+          "priority": 0,
+          "priorityLabel": "No priority",
+          "dueDate": null,
+          "state": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "name": "Todo",
+            "type": "unstarted",
+            "position": 1
+          },
+          "team": {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "key": "FIX",
+            "name": "Fixture Team"
+          },
+          "assignee": null,
+          "creator": null,
+          "labels": {
+            "nodes": []
+          },
+          "parent": null,
+          "comments": {
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            },
+            "nodes": []
+          }
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000000",
+          "identifier": "FIX-4",
+          "number": 4,
+          "title": "Fixture issue 2",
+          "description": "## Overview\n\nA fixture description with the shape of real Linear markdown.\n\n- [ ] one open checklist item\n- [x] one done checklist item\n\nA [docs link](https://linear.app/docs) and `inline code`.\n\n```\na fenced code block\n```\n",
+          "url": "https://linear.app/example/issue/FIX-4/scrubbed",
+          "createdAt": "2026-08-18T13:18:31.131Z",
+          "updatedAt": "2026-08-18T13:18:31.131Z",
+          "archivedAt": null,
+          "priority": 0,
+          "priorityLabel": "No priority",
+          "dueDate": null,
+          "state": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "name": "Todo",
+            "type": "unstarted",
+            "position": 1
+          },
+          "team": {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "key": "FIX",
+            "name": "Fixture Team"
+          },
+          "assignee": null,
+          "creator": null,
+          "labels": {
+            "nodes": []
+          },
+          "parent": null,
+          "comments": {
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            },
+            "nodes": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/linear/testdata/issues_page2.json
+++ b/internal/linear/testdata/issues_page2.json
@@ -1,0 +1,88 @@
+{
+  "data": {
+    "issues": {
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": "00000000-0000-4000-8000-000000000004"
+      },
+      "nodes": [
+        {
+          "id": "00000000-0000-4000-8000-000000000005",
+          "identifier": "FIX-2",
+          "number": 2,
+          "title": "Fixture issue 1",
+          "description": "## Overview\n\nA fixture description with the shape of real Linear markdown.\n\n- [ ] one open checklist item\n- [x] one done checklist item\n\nA [docs link](https://linear.app/docs) and `inline code`.\n\n```\na fenced code block\n```\n",
+          "url": "https://linear.app/example/issue/FIX-2/scrubbed",
+          "createdAt": "2026-08-18T13:18:31.131Z",
+          "updatedAt": "2026-08-18T13:18:31.131Z",
+          "archivedAt": null,
+          "priority": 0,
+          "priorityLabel": "No priority",
+          "dueDate": null,
+          "state": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "name": "Todo",
+            "type": "unstarted",
+            "position": 1
+          },
+          "team": {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "key": "FIX",
+            "name": "Fixture Team"
+          },
+          "assignee": null,
+          "creator": null,
+          "labels": {
+            "nodes": []
+          },
+          "parent": null,
+          "comments": {
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            },
+            "nodes": []
+          }
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000004",
+          "identifier": "FIX-3",
+          "number": 3,
+          "title": "Fixture issue 2",
+          "description": "## Overview\n\nA fixture description with the shape of real Linear markdown.\n\n- [ ] one open checklist item\n- [x] one done checklist item\n\nA [docs link](https://linear.app/docs) and `inline code`.\n\n```\na fenced code block\n```\n",
+          "url": "https://linear.app/example/issue/FIX-3/scrubbed",
+          "createdAt": "2026-08-18T13:18:31.131Z",
+          "updatedAt": "2026-08-18T13:18:31.131Z",
+          "archivedAt": null,
+          "priority": 0,
+          "priorityLabel": "No priority",
+          "dueDate": null,
+          "state": {
+            "id": "00000000-0000-4000-8000-000000000002",
+            "name": "Todo",
+            "type": "unstarted",
+            "position": 1
+          },
+          "team": {
+            "id": "00000000-0000-4000-8000-000000000003",
+            "key": "FIX",
+            "name": "Fixture Team"
+          },
+          "assignee": null,
+          "creator": null,
+          "labels": {
+            "nodes": []
+          },
+          "parent": null,
+          "comments": {
+            "pageInfo": {
+              "hasNextPage": false,
+              "endCursor": null
+            },
+            "nodes": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/internal/linear/testdata/teams.json
+++ b/internal/linear/testdata/teams.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "teams": {
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": "00000000-0000-4000-8000-000000000003"
+      },
+      "nodes": [
+        {
+          "id": "00000000-0000-4000-8000-000000000003",
+          "key": "FIX",
+          "name": "Fixture Team",
+          "private": false
+        }
+      ]
+    }
+  }
+}

--- a/internal/linear/testdata/viewer.json
+++ b/internal/linear/testdata/viewer.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "viewer": {
+      "id": "00000000-0000-4000-8000-000000000011",
+      "name": "Fixture User 0",
+      "displayName": "Fix User 0",
+      "email": "user-0@example.invalid"
+    }
+  }
+}

--- a/internal/linear/testdata/workflowstates.json
+++ b/internal/linear/testdata/workflowstates.json
@@ -1,0 +1,48 @@
+{
+  "data": {
+    "workflowStates": {
+      "pageInfo": {
+        "hasNextPage": false,
+        "endCursor": "00000000-0000-4000-8000-000000000006"
+      },
+      "nodes": [
+        {
+          "id": "00000000-0000-4000-8000-000000000007",
+          "name": "Canceled",
+          "type": "canceled",
+          "position": 4
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000008",
+          "name": "In Progress",
+          "type": "started",
+          "position": 2
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000009",
+          "name": "Duplicate",
+          "type": "duplicate",
+          "position": 5
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000002",
+          "name": "Todo",
+          "type": "unstarted",
+          "position": 1
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000010",
+          "name": "Done",
+          "type": "completed",
+          "position": 3
+        },
+        {
+          "id": "00000000-0000-4000-8000-000000000006",
+          "name": "Backlog",
+          "type": "backlog",
+          "position": 0
+        }
+      ]
+    }
+  }
+}

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -1,0 +1,134 @@
+package linear
+
+// The payload shapes below are only the parts a mirror needs. Field names and
+// shapes were verified against the live GraphQL API (2026-08-18); anything not
+// listed here is simply not requested by the queries in queries.go.
+
+// User is a Linear account reference. Name/DisplayName/Email are personal
+// data: this package never logs them, and callers must not either.
+type User struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email"`
+}
+
+// Team is the scope unit a workspace divides issues by — the closest Linear
+// counterpart to a Jira project (see MAPPING.md, "project_key").
+type Team struct {
+	ID      string `json:"id"`
+	Key     string `json:"key"`
+	Name    string `json:"name"`
+	Private bool   `json:"private"`
+}
+
+// WorkflowState is one status in a team's workflow. Type is the stable axis:
+// name is display-only and can be anything ("In Progress", "진행 중", a custom
+// "In Review"); logic must key on Type or ID, never on Name — the same
+// localization hazard Jira's status names carry.
+//
+// Verified Type values: backlog, unstarted, started, completed, canceled,
+// duplicate (and triage on teams with triage enabled). The set is open:
+// Linear added duplicate after the original six, so code consuming Type must
+// tolerate values it does not know (see MAPPING.md, "status_category").
+type WorkflowState struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Position int    `json:"position"`
+}
+
+// Label is an issue label. Unlike Jira labels (plain strings), Linear labels
+// carry an id; the mirror stores names, so a label renamed upstream changes
+// the stored key the same way a Jira label edit does.
+type Label struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// LabelConn is the nested labels connection on an issue.
+type LabelConn struct {
+	Nodes []Label `json:"nodes"`
+}
+
+// PageInfo is the cursor pagination envelope on every connection.
+type PageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+// Comment is one issue comment. Body is markdown — not ADF. The Jira path
+// stores body_adf; stuffing markdown into that column would be a false
+// mapping, so Linear comments must stay markdown (body_text / raw), and the
+// rendering surface is a post-connector decision. See MAPPING.md, "comments".
+type Comment struct {
+	ID        string `json:"id"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+	User      *User  `json:"user"`
+}
+
+// CommentConn is the nested comments connection on an issue.
+type CommentConn struct {
+	PageInfo PageInfo  `json:"pageInfo"`
+	Nodes    []Comment `json:"nodes"`
+}
+
+// ParentRef is the embedded parent issue. Linear parents are generic sub-issue
+// nesting, not epics; see MAPPING.md, "epic / parent".
+type ParentRef struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+}
+
+// Issue is one row of the issues connection. Timestamps are Linear's verbatim
+// ISO-8601 UTC strings with milliseconds (the format the mirror stores
+// unmodified). ArchivedAt is empty for live issues.
+type Issue struct {
+	ID            string `json:"id"`
+	Identifier    string `json:"identifier"`
+	Number        int    `json:"number"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	URL           string `json:"url"`
+	CreatedAt     string `json:"createdAt"`
+	UpdatedAt     string `json:"updatedAt"`
+	ArchivedAt    string `json:"archivedAt"`
+	Priority      int    `json:"priority"`
+	PriorityLabel string `json:"priorityLabel"`
+	DueDate       string `json:"dueDate"`
+
+	State WorkflowState `json:"state"`
+	Team  struct {
+		ID   string `json:"id"`
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	} `json:"team"`
+	Assignee *User      `json:"assignee"`
+	Creator  *User      `json:"creator"`
+	Labels   LabelConn  `json:"labels"`
+	Parent   *ParentRef `json:"parent"`
+
+	// Comments is the first inline page (CommentsPageSize). A page with
+	// PageInfo.HasNextPage means the issue has more comments than that and
+	// the rest need a follow-up fetch — the flag exists so truncation is
+	// observable, never silent.
+	Comments CommentConn `json:"comments"`
+}
+
+// IssueConnection and its siblings are the standard Linear connection shape.
+type IssueConnection struct {
+	PageInfo PageInfo `json:"pageInfo"`
+	Nodes    []Issue  `json:"nodes"`
+}
+
+type TeamConnection struct {
+	PageInfo PageInfo `json:"pageInfo"`
+	Nodes    []Team   `json:"nodes"`
+}
+
+type WorkflowStateConnection struct {
+	PageInfo PageInfo        `json:"pageInfo"`
+	Nodes    []WorkflowState `json:"nodes"`
+}


### PR DESCRIPTION
`internal/linear` is the GraphQL read path for a Linear workspace: viewer, teams, workflow states, and cursor-paged issues with an `updatedAt` watermark. **Nothing calls it yet** — wiring a second origin is GDK-262 — so what this really lands is the set of facts that connector will need, pinned where they cannot rot.

Measured against the real API (13 read calls, **zero mutations**):

- The `Authorization` header takes the key **bare**. `Bearer <key>` is a 400 whose body says *"Remove the Bearer prefix"*. `TestAuthHeaderIsBareKey` pins it, because that is exactly the kind of thing a later edit "fixes" toward the more familiar shape.
- **Two** budgets, not one: 2500 requests **and** 3,000,000 complexity, both reported per response in `x-ratelimit-*`. `LastRateLimit()` exposes the snapshot — Atlassian never gave us this, so nothing existing had a place for it.
- Incremental sync works: `filter.updatedAt.gte/gt` exist, `orderBy: updatedAt` exists, and `orderDirection` does **not** exist at all.
- `WorkflowState.type` has **seven** values, not the six the ticket assumed — `duplicate` exists, and `triage` appears only on triage-enabled teams. The enum is open, so `MAPPING.md` forbids a silent default: unknown type maps to `new` **and is reported loudly**. A quiet default is how the display-name trap keeps happening.
- Comment bodies are **markdown**, not ADF, and must never land in `body_adf`.

`MAPPING.md` owns the mapping decisions including what stays empty on purpose: `issue_type_id` (Linear has no such axis — a synthetic constant would be gadak-only original data), `epic_key`, `resolution`, Project/Cycle, and `status_changed_at` until a history pass exists. *"Linear has no time-in-status"* is the honest state, not a value we invent.

No `internal/atlhttp` import: that package's headline guarantee is path safety for Atlassian hosts, and Linear has one fixed endpoint with no path parameter. What is worth keeping — retry policy, `Retry-After`, the 64 MiB cap, usage counters — is mirrored with the same semantics rather than coupling this to a host family it never talks to. `ErrAuth` is its own sentinel for the same reason.

**FAIL-first, re-run by the lead:** injecting the key into the 401 error path gives `client_test.go:250: auth rejected: error message leaked the credential`; restoring it passes. 10 tests. `testdata` is scrubbed real captures — UUIDs, names and emails replaced, and the scrubber refuses to write if any original survives.

Gates from cold: `go build` · `go vet` · `go test ./... -count=1` (29 ok) · `tools/doc-checks.sh` · `scripts/scan-internal.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)