### PR TITLE
tools: see the Omarchy VM without a client, and keep its address out of the repo (GDK-225/227)

### DIFF
--- a/docs/runbooks/omarchy-vm.md
+++ b/docs/runbooks/omarchy-vm.md
@@ -1,0 +1,182 @@
+# Omarchy QEMU guest (operator VM)
+
+How to reach the Arch + Hyprland guest used to verify Omarchy install
+and menu-extension work. Facts below were checked from this Mac on
+2026-08-18. Do not treat an unverified step as done.
+
+This is not a CI path. The guest lives on another machine and is reached
+over the tailnet.
+
+**No addresses in this file.** The machine name, the tailnet hostname, the
+IP, and the account names are the operator's, and this repository is public —
+knowing them buys an outsider nothing here, and publishing them costs
+something. The commands below read them from the environment instead:
+
+| Variable | What |
+| --- | --- |
+| `OMARCHY_VM_HOST` | SSH target for the Windows host (an alias from your own `~/.ssh/config`) |
+| `OMARCHY_VNC_HOST`, `OMARCHY_VNC_PORT` | where the tailnet forward answers |
+| `VNC_PASSWORD` | the QEMU VNC password — env only, never a flag |
+| `VMDIR` | the VM directory on WSL (`~/omarchy-vm` on this setup) |
+
+`scripts/scan-internal.sh` refuses a tailnet hostname or a `100.64/10`
+address in any tracked file, so a later edit cannot quietly put them back.
+
+## What is running
+
+| Layer | What it is (checked) |
+| --- | --- |
+| Windows host | reached by an SSH alias from the operator's own config; default shell is PowerShell |
+| WSL2 | `wsl.exe -e bash`, Ubuntu 24.04.1, kernel `6.6.114.1-microsoft-standard-WSL2` |
+| QEMU | `qemu-system-x86_64 -name omarchy`, 6 vCPU, 8G, KVM, virtio-vga, OVMF, disk `~/omarchy-vm/disk.qcow2` |
+| VNC | QEMU `-vnc 127.0.0.1:1` (RFB 3.8, security type 2). On WSL that is `127.0.0.1:5901` |
+| Tailnet forward | `tailscale serve --tcp=5901` on the Windows host → WSL `127.0.0.1:5901`. Funnel is **off**, so the port exists only inside the tailnet. |
+| Guest SSH forward | QEMU user-net `hostfwd=tcp:127.0.0.1:2223-:22`. QEMU is listening. Guest `sshd` is `inactive` and `disabled`. |
+| Guest OS | `ID=omarchy` `ID_LIKE=arch`. `omarchy-version` printed `4.0.0.r1772.gf32ebbd-1`. `/usr/share/omarchy/version` is `4.0.0.alpha`. `/etc/os-release` `VERSION_ID` matches the `omarchy-version` string. |
+| Guest session | Hyprland, hostname `omarchy`. `systemctl --user is-system-running` → `running` (184 units, 0 failed, systemd 261.2-1-arch). Framebuffer 1280×800. RFB desktop name `QEMU (omarchy)`. |
+
+QEMU argv (password field redacted) as seen on 2026-08-18:
+
+```
+qemu-system-x86_64 -name omarchy -machine q35,accel=kvm -cpu host -smp 6 -m 8G
+  -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd
+  -drive if=pflash,format=raw,file=$VMDIR/OVMF_VARS.fd
+  -drive file=$VMDIR/disk.qcow2,if=virtio,format=qcow2,discard=unmap
+  -device virtio-vga -display none
+  -object secret,id=vncpass,data=<redacted>
+  -vnc 127.0.0.1:1,password-secret=vncpass
+  -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2223-:22
+  -device virtio-net-pci,netdev=net0 -device qemu-xhci -device usb-tablet
+  -pidfile $VMDIR/qemu.pid -daemonize
+  -cdrom $VMDIR/omarchy-hangul.iso -boot order=d
+```
+
+The guest desktop is a configured Omarchy install (session up since
+2026-08-15), even though the QEMU line still has the hangul ISO and
+`-boot order=d`. Guest `sshd` is what is down, not the desktop.
+
+## Reach the screen from this Mac
+
+Password is `VNC_PASSWORD` in the environment, never a flag
+(`tools/vnc-snap.py` reads `os.environ.get("VNC_PASSWORD")` and the
+argparse help says so). Do not put the value in the shell history, in
+`ps`, or in this file.
+
+```bash
+# RFB banner check (no password):
+nc -z "$OMARCHY_VNC_HOST" "$OMARCHY_VNC_PORT"
+
+# One full-frame PNG. Requires Crypto.Cipher.DES and Pillow already on this Mac.
+# Do not pip-install.
+python3 tools/vnc-snap.py \
+  --host "$OMARCHY_VNC_HOST" --port "$OMARCHY_VNC_PORT" \
+  --out /tmp/omarchy-state.png
+```
+
+`--host`, `--port`, `--out` are required. `--timeout` defaults to 20
+seconds. `--do ACTION` is optional and repeatable; it runs before the
+capture. Actions implemented: `key:NAME`, `combo:Super+Return`,
+`type:TEXT`, `enter`, `sleep:SEC`, `click:X,Y`.
+
+Verified Hyprland bindings (from the on-screen keybindings overlay, then
+exercised):
+
+- `Escape` dismissed the overlay
+- `Super+Return` opened a terminal (prompt `~ ❯`, window title `Work  1:<user>`)
+
+QEMU drops the shift key if you send a shifted keysym alone. `type:`
+holds `Shift_L` and sends the unshifted US key, with a 25 ms gap
+between characters.
+
+Write PNGs outside the repo. This tool is not a CI job: it talks to an
+operator host.
+
+## Reach a shell on the WSL host (read the VM, do not install packages)
+
+```bash
+ssh "$OMARCHY_VM_HOST" "wsl.exe -e bash -s" <<'EOF'
+whoami
+ps -ef | grep '[q]emu-system-x86_64 -name omarchy'
+ss -lntp | grep -E '5901|2223'
+cat -n $VMDIR/start.sh
+EOF
+```
+
+Do not run `tailscale serve --tcp=5901 off`. Do not turn on funnel. Do not
+install packages on Windows or WSL.
+
+## Start / stop the guest
+
+Scripts live in `$VMDIR/` on WSL:
+`start.sh`, `stop.sh`, `qemu.pid`, `disk.qcow2`,
+`omarchy-4.0.0.iso`, `omarchy-hangul.iso`.
+
+`start.sh` (checked):
+
+- Refuses to start a second copy if `qemu.pid` is alive (`already running` + exit 0).
+- Default `ISO` is `$HOME/omarchy-vm/omarchy-4.0.0.iso`.
+- If that ISO exists **and** `BOOT_DISK` is not `1`, it adds
+  `-cdrom "$ISO" -boot order=d`.
+- Otherwise it adds `-boot order=c` (disk).
+- The running process was **not** the default ISO: it used
+  `omarchy-hangul.iso`. An `ISO=...` override or a hand-built argv did that.
+
+`stop.sh` kills the pid in `qemu.pid` (or `pkill`s the named QEMU line)
+and removes the pidfile.
+
+To boot the disk without the CD (only when you intend to restart the
+guest; this tears down the Hyprland session):
+
+```bash
+ssh "$OMARCHY_VM_HOST" "wsl.exe -e bash -s" <<'EOF'
+$VMDIR/stop.sh
+BOOT_DISK=1 $VMDIR/start.sh
+# then: nc -w 3 127.0.0.1 2223;  guest sshd may still be disabled
+EOF
+```
+
+A 2026-08-18 session left the guest up (Aether open, user session since
+2026-08-15) and did **not** run that restart.
+
+## Guest SSH
+
+From WSL, `nc` to `127.0.0.1:2223` succeeds (QEMU is listening).
+`ssh -p 2223` to the WSL user, `omarchy@`, and `root@` all timed out
+on the banner. Inside the guest:
+
+```
+systemctl is-active sshd    # inactive
+systemctl is-enabled sshd   # disabled
+```
+
+Rebooting with `BOOT_DISK=1` does not by itself start `sshd`. Enable it
+on the guest if a later round needs a shell without VNC.
+
+## What the guest already has (checked over VNC)
+
+Commands were typed in the Hyprland terminal and read back from the
+PNG. `command -v omarchy-plugin` printed nothing; the plugin CLIs are
+hyphenated (`omarchy-plugin-list`, …).
+
+| Item | Result |
+| --- | --- |
+| Version | `omarchy-version` → `4.0.0.r1772.gf32ebbd-1`. Also `/usr/share/omarchy/bin/omarchy`. |
+| Web app install | `/usr/share/omarchy/bin/omarchy-webapp-install` exists (159 lines). Header: `omarchy:args=[name url icon-url-or-name [custom-exec] [mime-types]]`. Fewer than 3 args opens a `gum` prompt (`Name>`). It is **not** URL-only. |
+| How a web app opens | Desktop `Exec` defaults to `omarchy-launch-webapp $APP_URL`. That 13-line script reads `xdg-settings get default-web-browser`, falls back to `chromium.desktop` unless the default is chrome/brave/edge/opera/vivaldi/helium, and execs `setsid uwsm-app -- <browser-exec> --app="$1"`. This guest's default is `chromium.desktop`. |
+| Menu extension | `~/.config/omarchy/extensions/` exists. It contains `omarchy-menu.jsonc` (stock commented schema + examples). IDs are object keys; dotted ids nest (`personal.notes`). Fields documented in that file: `icon`, `label`, `action`, `target`, `provider`, `aliases`, `description`, `when`, `checked`. |
+| Plugin CLI | No `omarchy plugin` argv. Present: `omarchy-plugin-clone`, `-enable`, `-disable`, `-list`, `-remove`, `-update`, `-validate`. `omarchy-plugin-list` prints first-party plugins (`omarchy.menu` is one). |
+| Plugin manifest | Example `/usr/share/omarchy/shell/plugins/panels/clock/manifest.json`: `"schemaVersion": 1`, plus `id`, `name`, `version`, `kinds`, `entryPoints`. |
+| Theme hook | `~/.config/omarchy/hooks/theme-set.d/` exists. On this guest it holds only `show-theme-notification.sample`. |
+| `colors.toml` | Per-theme files under `/usr/share/omarchy/themes/<name>/colors.toml` (catppuccin starts `mode = "dark"`). |
+| systemd --user | Works (`running`, 0 failed). `gadak install-service` on Linux writes a systemd user unit; this guest can host that path. |
+| IME | `fcitx5` is on PATH and running (`/usr/bin/fcitx5 --disable notificationitem`). Locale `en_US.UTF-8`, X11 layout `us`. No hangul indicator was visible on the bar. `fcitx5-hangul` package query was not completed (typed command was eaten). |
+| Do not install gadak | AUR packaging is a different track. This guest was not given a gadak binary. |
+
+## Do not
+
+- Read or write `~/.gadak/` or `~/.config/gadak-dev/` on this Mac.
+- Talk to a real Atlassian site from this path.
+- Put the VNC password in source, docs, logs, or process arguments.
+- `tailscale serve … off`, or turn on funnel.
+- Install software on the Windows host or in WSL.
+- Commit PNGs.

--- a/scripts/scan-internal.sh
+++ b/scripts/scan-internal.sh
@@ -41,6 +41,13 @@ PAT_TOKEN='ATATT[A-Za-z0-9+/=_-]{20,}|ATCTT[A-Za-z0-9+/=_-]{20,}'
 # atlassian_api_token regex exactly.
 PAT_LINEAR='lin_api_[A-Za-z0-9]{20,}'
 PAT_HOST='atlassian\.net'
+# Operator machines, not product content. A tailnet MagicDNS name or a
+# 100.64/10 CGNAT address identifies a device on someone's private
+# network; it is useless to an outsider and it is not ours to publish.
+# Added when a runbook for the Omarchy verification VM (docs/runbooks/
+# omarchy-vm.md) arrived carrying a tailnet hostname, its IP, and two
+# account names. That runbook now reads them from the environment.
+PAT_TAILNET='[A-Za-z0-9-]+\.[A-Za-z0-9-]+\.ts\.net|\b100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}\b'
 
 # Deployment-specific words, resolved from outside this file (see header).
 PAT_COMPANY=""
@@ -118,7 +125,7 @@ fi
 
 if [[ -s "$text_list" ]]; then
   # shellcheck disable=SC2046
-  grep -nHE "$PAT_TOKEN|$PAT_LINEAR" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true
+  grep -nHE "$PAT_TOKEN|$PAT_LINEAR|$PAT_TAILNET" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true
   if [[ -n "$PAT_COMPANY" ]]; then
     # shellcheck disable=SC2046
     grep -niHE "$PAT_COMPANY" -- $(cat "$text_list") 2>/dev/null >>"$hits_file" || true

--- a/tools/vnc-snap.py
+++ b/tools/vnc-snap.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Capture one full-frame PNG from a VNC (RFB 3.8) server.
+
+Built for the Omarchy QEMU guest that is reachable from this Mac only over
+the tailnet (the VNC port is bound on the WSL loopback and forwarded with
+`tailscale serve`). The picture is the only way a text session can see
+whether the guest is on the installer, a Hyprland desktop, or a boot
+console.
+
+The password is read from VNC_PASSWORD, never from argv: `ps` lists
+command lines, and a flag would land in shell history. Do not put the
+value in this file, in logs, or in error text.
+
+This tool is not a CI job. It talks to an operator-owned host that is not
+on the runner, and a green/red result there would not mean anything about
+the tree.
+
+Requires: pycryptodome (Crypto.Cipher.DES) and Pillow. No pip install —
+those two are already on the machine this was written on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import struct
+import sys
+import time
+
+# Security type 2 (VNC Authentication) as used by QEMU -vnc password-secret=.
+SEC_VNC = 2
+SEC_NONE = 1
+
+# Client → server
+MSG_SET_PIXEL_FORMAT = 0
+MSG_SET_ENCODINGS = 2
+MSG_FB_UPDATE_REQUEST = 3
+MSG_KEY_EVENT = 4
+MSG_POINTER_EVENT = 5
+
+# A short X11 keysym table for --do combo:/key: actions. Printable
+# Latin-1 is sent as the code point itself (RFB uses X keysyms).
+KEYSYMS = {
+    "Escape": 0xFF1B,
+    "Return": 0xFF0D,
+    "Linefeed": 0xFF0A,
+    "Tab": 0xFF09,
+    "BackSpace": 0xFF08,
+    "space": 0x0020,
+    "Super_L": 0xFFE7,  # Meta_L; Super_L 0xFFEB is also sent (see send_combo)
+    "Super_R": 0xFFEC,
+    "Meta_L": 0xFFE7,
+    "Alt_L": 0xFFE9,
+    "Shift_L": 0xFFE1,
+    "Control_L": 0xFFE3,
+    "F1": 0xFFBE,
+    "F2": 0xFFBF,
+    "F3": 0xFFC0,
+    "F4": 0xFFC1,
+}
+
+# Server → client
+SMSG_FB_UPDATE = 0
+SMSG_SET_COLORMAP = 1
+SMSG_BELL = 2
+SMSG_CUT_TEXT = 3
+
+ENC_RAW = 0
+
+# 32-bpp little-endian truecolour, red@16 green@8 blue@0 (BGRX in memory).
+PIXEL_FORMAT = struct.pack(
+    "!BBBBHHHBBBxxx",
+    32,  # bits-per-pixel
+    24,  # depth
+    0,  # big-endian-flag
+    1,  # true-colour-flag
+    255,
+    255,
+    255,  # rgb max
+    16,
+    8,
+    0,  # rgb shift
+)
+
+
+class VNCError(RuntimeError):
+    pass
+
+
+class Deadline:
+    def __init__(self, seconds: float) -> None:
+        self.end = time.monotonic() + seconds
+
+    def remaining(self) -> float:
+        left = self.end - time.monotonic()
+        if left <= 0:
+            raise VNCError("timed out waiting for the VNC server")
+        return left
+
+
+def recvn(sock: socket.socket, n: int, deadline: Deadline) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        sock.settimeout(deadline.remaining())
+        try:
+            chunk = sock.recv(n - len(buf))
+        except socket.timeout as e:
+            raise VNCError("timed out waiting for the VNC server") from e
+        if not chunk:
+            raise VNCError(
+                f"VNC connection closed after {len(buf)} bytes, wanted {n}"
+            )
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def sendall(sock: socket.socket, data: bytes, deadline: Deadline) -> None:
+    view = memoryview(data)
+    while view:
+        sock.settimeout(deadline.remaining())
+        try:
+            n = sock.send(view)
+        except socket.timeout as e:
+            raise VNCError("timed out sending to the VNC server") from e
+        if n == 0:
+            raise VNCError("VNC connection closed while sending")
+        view = view[n:]
+
+
+def _reverse_bits(byte: int) -> int:
+    # VNC DES keys are the password bytes with each byte's bits reversed
+    # (LSB-first). Skipping this makes authentication fail with no extra hint.
+    return int(f"{byte:08b}"[::-1], 2)
+
+
+def vnc_des_response(password: str, challenge: bytes) -> bytes:
+    if len(challenge) != 16:
+        raise VNCError(f"VNC challenge was {len(challenge)} bytes, want 16")
+    try:
+        from Crypto.Cipher import DES
+    except ImportError as e:
+        raise VNCError(
+            "Crypto.Cipher.DES is missing (pycryptodome). "
+            "Do not pip-install on this machine; use the copy already present."
+        ) from e
+    raw = password.encode("utf-8")[:8].ljust(8, b"\x00")
+    key = bytes(_reverse_bits(b) for b in raw)
+    return DES.new(key, DES.MODE_ECB).encrypt(challenge)
+
+
+def handshake(sock: socket.socket, password: str, deadline: Deadline) -> tuple[int, int, str]:
+    banner = recvn(sock, 12, deadline)
+    if not banner.startswith(b"RFB "):
+        raise VNCError(f"not an RFB server (banner={banner!r})")
+    # Speak 3.8 even if the server offered something older; QEMU sends 003.008.
+    sendall(sock, b"RFB 003.008\n", deadline)
+
+    ntypes = recvn(sock, 1, deadline)[0]
+    if ntypes == 0:
+        (reason_len,) = struct.unpack("!I", recvn(sock, 4, deadline))
+        reason = recvn(sock, reason_len, deadline).decode("utf-8", "replace")
+        raise VNCError(f"server refused security negotiation: {reason}")
+    types = list(recvn(sock, ntypes, deadline))
+    if SEC_VNC not in types:
+        raise VNCError(
+            f"server did not offer VNC Authentication (type 2); offered {types}"
+        )
+    sendall(sock, bytes([SEC_VNC]), deadline)
+
+    challenge = recvn(sock, 16, deadline)
+    sendall(sock, vnc_des_response(password, challenge), deadline)
+
+    (result,) = struct.unpack("!I", recvn(sock, 4, deadline))
+    if result != 0:
+        extra = ""
+        # RFB 3.8 may follow a failed result with a reason string.
+        try:
+            (reason_len,) = struct.unpack("!I", recvn(sock, 4, deadline))
+            if 0 < reason_len < 4096:
+                extra = recvn(sock, reason_len, deadline).decode("utf-8", "replace")
+        except VNCError:
+            extra = ""
+        if extra:
+            raise VNCError(f"VNC authentication failed ({extra})")
+        raise VNCError("VNC authentication failed")
+
+    # ClientInit: shared desktop (do not kick an existing viewer).
+    sendall(sock, b"\x01", deadline)
+
+    init = recvn(sock, 24, deadline)
+    width, height = struct.unpack("!HH", init[:4])
+    (name_len,) = struct.unpack("!I", init[20:24])
+    if name_len > 1_000_000:
+        raise VNCError(f"implausible desktop name length {name_len}")
+    name = recvn(sock, name_len, deadline).decode("utf-8", "replace")
+    return width, height, name
+
+
+def setup_raw(sock: socket.socket, deadline: Deadline) -> None:
+    # SetPixelFormat: 3 pad bytes after the type.
+    sendall(sock, bytes([MSG_SET_PIXEL_FORMAT, 0, 0, 0]) + PIXEL_FORMAT, deadline)
+    # SetEncodings: Raw only, so the decoder stays a byte copy.
+    sendall(
+        sock,
+        struct.pack("!BBH i", MSG_SET_ENCODINGS, 0, 1, ENC_RAW),
+        deadline,
+    )
+
+
+def request_raw_frame(
+    sock: socket.socket, width: int, height: int, deadline: Deadline
+) -> None:
+    sendall(
+        sock,
+        struct.pack("!BBHHHH", MSG_FB_UPDATE_REQUEST, 0, 0, 0, width, height),
+        deadline,
+    )
+
+
+def key_event(sock: socket.socket, keysym: int, down: bool, deadline: Deadline) -> None:
+    sendall(
+        sock,
+        struct.pack("!BBHI", MSG_KEY_EVENT, 1 if down else 0, 0, keysym & 0xFFFFFFFF),
+        deadline,
+    )
+
+
+def tap_key(sock: socket.socket, keysym: int, deadline: Deadline) -> None:
+    key_event(sock, keysym, True, deadline)
+    key_event(sock, keysym, False, deadline)
+
+
+def resolve_keysym(name: str) -> list[int]:
+    """Return one or more keysyms to press for a named key.
+
+    Super is sent as both Super_L (0xFFEB) and Meta_L (0xFFE7): QEMU/Hyprland
+    bindings disagree on which one Super generates, and sending both down
+    before the key is the cheap way to hit either mapping.
+    """
+    if name in ("Super", "Super_L", "Mod4"):
+        return [0xFFEB, 0xFFE7]
+    if name in KEYSYMS:
+        return [KEYSYMS[name]]
+    if len(name) == 1:
+        return [ord(name)]
+    raise VNCError(f"unknown key name {name!r}")
+
+
+def send_combo(sock: socket.socket, spec: str, deadline: Deadline) -> None:
+    parts = [p for p in spec.split("+") if p]
+    if not parts:
+        raise VNCError("empty combo")
+    mods = []
+    for p in parts[:-1]:
+        mods.extend(resolve_keysym(p))
+    keys = resolve_keysym(parts[-1])
+    for m in mods:
+        key_event(sock, m, True, deadline)
+    for k in keys:
+        tap_key(sock, k, deadline)
+    for m in reversed(mods):
+        key_event(sock, m, False, deadline)
+
+
+# QEMU's VNC path maps keysyms through a US keycode table. Sending the
+# shifted keysym alone (e.g. 0x2a for '*') arrives as the unshifted key
+# ('8'). Hold Shift_L and send the unshifted US key instead.
+_US_SHIFT = {
+    "!": "1",
+    "@": "2",
+    "#": "3",
+    "$": "4",
+    "%": "5",
+    "^": "6",
+    "&": "7",
+    "*": "8",
+    "(": "9",
+    ")": "0",
+    "_": "-",
+    "+": "=",
+    "{": "[",
+    "}": "]",
+    "|": "\\",
+    ":": ";",
+    '"': "'",
+    "<": ",",
+    ">": ".",
+    "?": "/",
+    "~": "`",
+}
+
+
+def _key_gap(deadline: Deadline) -> None:
+    # QEMU drops or coalesces RFB KeyEvents when they arrive back-to-back.
+    end = time.monotonic() + 0.025
+    while True:
+        left = end - time.monotonic()
+        if left <= 0:
+            return
+        deadline.remaining()
+        time.sleep(min(left, 0.025))
+
+
+def type_text(sock: socket.socket, text: str, deadline: Deadline) -> None:
+    for ch in text:
+        if ch == "\n":
+            tap_key(sock, KEYSYMS["Return"], deadline)
+            _key_gap(deadline)
+            continue
+        if ch == "\t":
+            tap_key(sock, KEYSYMS["Tab"], deadline)
+            _key_gap(deadline)
+            continue
+        if ord(ch) < 0x20 or ord(ch) > 0xFF:
+            raise VNCError(f"cannot type character U+{ord(ch):04X}")
+        if ch in _US_SHIFT or ch.isupper():
+            base = _US_SHIFT.get(ch, ch.lower())
+            key_event(sock, KEYSYMS["Shift_L"], True, deadline)
+            tap_key(sock, ord(base), deadline)
+            key_event(sock, KEYSYMS["Shift_L"], False, deadline)
+        else:
+            tap_key(sock, ord(ch), deadline)
+        _key_gap(deadline)
+
+
+def pointer(sock: socket.socket, x: int, y: int, mask: int, deadline: Deadline) -> None:
+    sendall(
+        sock,
+        struct.pack("!BBHH", MSG_POINTER_EVENT, mask & 0xFF, x & 0xFFFF, y & 0xFFFF),
+        deadline,
+    )
+
+
+def run_actions(
+    sock: socket.socket, actions: list[str], deadline: Deadline
+) -> None:
+    """Run --do actions in order.
+
+    Forms (no password, no host secrets — just key names and typed text):
+      key:Escape
+      combo:Super+Return
+      type:uname -a
+      enter
+      sleep:0.4
+      click:100,200
+    """
+    for raw in actions:
+        if raw == "enter":
+            tap_key(sock, KEYSYMS["Return"], deadline)
+            continue
+        if raw.startswith("sleep:"):
+            sec = float(raw.split(":", 1)[1])
+            if sec < 0 or sec > 30:
+                raise VNCError(f"sleep out of range: {sec}")
+            # Sleep is wall time; keep the RFB deadline from firing mid-wait
+            # by requiring the caller to pass a timeout that covers it.
+            end = time.monotonic() + sec
+            while True:
+                left = end - time.monotonic()
+                if left <= 0:
+                    break
+                deadline.remaining()
+                time.sleep(min(left, 0.05))
+            continue
+        if raw.startswith("key:"):
+            for k in resolve_keysym(raw.split(":", 1)[1]):
+                tap_key(sock, k, deadline)
+            continue
+        if raw.startswith("combo:"):
+            send_combo(sock, raw.split(":", 1)[1], deadline)
+            continue
+        if raw.startswith("type:"):
+            type_text(sock, raw.split(":", 1)[1], deadline)
+            continue
+        if raw.startswith("click:"):
+            coords = raw.split(":", 1)[1]
+            xs, ys = coords.split(",", 1)
+            x, y = int(xs), int(ys)
+            pointer(sock, x, y, 0, deadline)
+            pointer(sock, x, y, 1, deadline)
+            pointer(sock, x, y, 0, deadline)
+            continue
+        raise VNCError(f"unknown --do action {raw!r}")
+
+
+def skip_colormap(sock: socket.socket, deadline: Deadline) -> None:
+    recvn(sock, 1, deadline)  # padding
+    _first, n = struct.unpack("!HH", recvn(sock, 4, deadline))
+    recvn(sock, n * 6, deadline)
+
+
+def skip_cut_text(sock: socket.socket, deadline: Deadline) -> None:
+    recvn(sock, 3, deadline)  # padding
+    (length,) = struct.unpack("!I", recvn(sock, 4, deadline))
+    if length > 16_000_000:
+        raise VNCError(f"ServerCutText length {length} is implausible")
+    recvn(sock, length, deadline)
+
+
+def paint_raw(
+    canvas: bytearray, width: int, x: int, y: int, w: int, h: int, pixels: bytes
+) -> None:
+    # canvas is packed RGB, 3 bytes/pixel. pixels is BGRX, 4 bytes/pixel.
+    if w <= 0 or h <= 0:
+        return
+    if len(pixels) != w * h * 4:
+        raise VNCError(
+            f"raw rectangle {w}x{h} needed {w * h * 4} bytes, got {len(pixels)}"
+        )
+    for row in range(h):
+        src = row * w * 4
+        dst = ((y + row) * width + x) * 3
+        for col in range(w):
+            b = pixels[src + col * 4]
+            g = pixels[src + col * 4 + 1]
+            r = pixels[src + col * 4 + 2]
+            canvas[dst + col * 3] = r
+            canvas[dst + col * 3 + 1] = g
+            canvas[dst + col * 3 + 2] = b
+
+
+def read_framebuffer(
+    sock: socket.socket, width: int, height: int, deadline: Deadline
+) -> bytes:
+    canvas = bytearray(width * height * 3)
+    painted = False
+    while not painted:
+        kind = recvn(sock, 1, deadline)[0]
+        if kind == SMSG_SET_COLORMAP:
+            skip_colormap(sock, deadline)
+            continue
+        if kind == SMSG_BELL:
+            continue
+        if kind == SMSG_CUT_TEXT:
+            skip_cut_text(sock, deadline)
+            continue
+        if kind != SMSG_FB_UPDATE:
+            raise VNCError(f"unexpected server message type {kind}")
+        recvn(sock, 1, deadline)  # padding
+        (nrects,) = struct.unpack("!H", recvn(sock, 2, deadline))
+        if nrects == 0:
+            continue
+        for _ in range(nrects):
+            x, y, w, h, enc = struct.unpack("!HHHHi", recvn(sock, 12, deadline))
+            if enc != ENC_RAW:
+                raise VNCError(
+                    f"server sent encoding {enc} at {w}x{h}+{x}+{y}; only Raw (0) is supported"
+                )
+            if x < 0 or y < 0 or x + w > width or y + h > height:
+                raise VNCError(
+                    f"rectangle {w}x{h}+{x}+{y} is outside {width}x{height}"
+                )
+            pixels = recvn(sock, w * h * 4, deadline)
+            paint_raw(canvas, width, x, y, w, h, pixels)
+        painted = True
+    return bytes(canvas)
+
+
+def save_png(path: str, width: int, height: int, rgb: bytes) -> None:
+    try:
+        from PIL import Image
+    except ImportError as e:
+        raise VNCError(
+            "PIL is missing (Pillow). "
+            "Do not pip-install on this machine; use the copy already present."
+        ) from e
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    Image.frombytes("RGB", (width, height), rgb).save(path, "PNG")
+
+
+def snap(
+    host: str,
+    port: int,
+    out: str,
+    timeout: float,
+    actions: list[str] | None = None,
+) -> dict:
+    password = os.environ.get("VNC_PASSWORD")
+    if password is None or password == "":
+        raise VNCError("VNC_PASSWORD is not set")
+    deadline = Deadline(timeout)
+    try:
+        sock = socket.create_connection((host, port), timeout=deadline.remaining())
+    except OSError as e:
+        raise VNCError(f"could not connect to {host}:{port}: {e}") from e
+    try:
+        width, height, name = handshake(sock, password, deadline)
+        setup_raw(sock, deadline)
+        if actions:
+            run_actions(sock, actions, deadline)
+        request_raw_frame(sock, width, height, deadline)
+        rgb = read_framebuffer(sock, width, height, deadline)
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+    save_png(out, width, height, rgb)
+    size = os.path.getsize(out)
+    return {
+        "width": width,
+        "height": height,
+        "bytes": size,
+        "out": out,
+        "name": name,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Capture one PNG from an RFB 3.8 VNC server. "
+        "Password comes from VNC_PASSWORD, not from a flag."
+    )
+    p.add_argument("--host", required=True, help="VNC host (name or address)")
+    p.add_argument("--port", required=True, type=int, help="VNC TCP port")
+    p.add_argument("--out", required=True, help="PNG path to write")
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=20.0,
+        help="overall deadline in seconds (default 20)",
+    )
+    p.add_argument(
+        "--do",
+        action="append",
+        default=[],
+        metavar="ACTION",
+        help="optional input before the capture: key:Escape, combo:Super+Return, "
+        "type:TEXT, enter, sleep:SEC, click:X,Y (repeatable, in order)",
+    )
+    args = p.parse_args(argv)
+    if args.port <= 0 or args.port > 65535:
+        print("vnc-snap: --port must be 1..65535", file=sys.stderr)
+        return 2
+    if args.timeout <= 0:
+        print("vnc-snap: --timeout must be positive", file=sys.stderr)
+        return 2
+    try:
+        info = snap(args.host, args.port, args.out, args.timeout, actions=args.do)
+    except VNCError as e:
+        print(f"vnc-snap: {e}", file=sys.stderr)
+        return 1
+    print(
+        f"ok {info['width']}x{info['height']} {info['bytes']}B {info['out']} "
+        f"name={info['name']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The Omarchy epic was gated on *"no Arch+Hyprland environment, so do not start"*. There is one now — a QEMU guest on another machine, reachable only inside the tailnet — but nothing here could look at it: this Mac has no VNC client, and installing one was not on the table.

`tools/vnc-snap.py` speaks RFB 3.8 with the two libraries already present (pycryptodome's DES, Pillow) and writes a PNG. The VNC auth detail that fails silently if you miss it: **the DES key is the password with each byte's bits reversed**. It can also send keys and clicks before the capture, which is how the guest was inspected without guest SSH — `sshd` is `inactive` **and** `disabled`, which is the real reason the earlier "still on the installer" reading was wrong. The guest is a three-day-old Hyprland session.

The password only ever arrives in `VNC_PASSWORD`, never argv, so it stays out of `ps` and shell history.

`docs/runbooks/omarchy-vm.md` records the two premises the tracker had wrong:
- `omarchy-webapp-install` takes **name + url + icon**. Fewer than three arguments opens a `gum` wizard, and `--help` *starts* that wizard rather than printing help.
- The version command is `omarchy-version`, not `omarchy --version`.

It also confirms `~/.config/omarchy/extensions/omarchy-menu.jsonc` exists with a documented schema, and that `systemctl --user` works — the path `gadak install-service` needs on Linux.

**Privacy fix by the lead.** What the round delivered carried the operator's tailnet hostname, its IP, and two account names. This repository is public, so those are gone: the commands read `OMARCHY_VM_HOST` / `OMARCHY_VNC_HOST` / `OMARCHY_VNC_PORT` / `VMDIR` from the environment, and `scripts/scan-internal.sh` now refuses a `*.ts.net` name or a `100.64/10` address in any tracked file. Removing the strings is the fix; the pattern is what stops the next runbook from bringing them back.

FAIL-first: a file containing `host-a.example-net.ts.net` fails the scan, and so does one with a `100.x` CGNAT address; the tree without them passes. The pattern deliberately does not match the range shorthand `100.64/10`, which is why the scanner and the runbook can name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)