### PR TITLE
refactor(store): the source-neutral spine, enforced instead of documented (GDK-273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      # Store/source firewall (docs/ARCHITECTURE.md:79). Not path-scoped: any
+      # import-graph edit can break it.
+      - name: Store dependency firewall
+        run: bash tools/check-store-deps.sh
+
       # The web build has to precede the Go build: go:embed compiles dist/app
       # into the binary, so the serve smoke below exercises the real embedded UI
       # rather than the tracked placeholder.

--- a/cmd/gadak/fields.go
+++ b/cmd/gadak/fields.go
@@ -20,6 +20,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/fields"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/jirafields"
 	"github.com/midagedev/gadak/internal/origin"
 )
 
@@ -439,7 +440,7 @@ func cmdFieldsApply(asJSON bool) error {
 		return err
 	}
 
-	specs := fields.Discover(catalog, fill, cfg.Fields)
+	specs := jirafields.Discover(catalog, fill, cfg.Fields)
 	cfg.Fields = specs
 	if err := cfg.Save(); err != nil {
 		return err

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,7 +79,8 @@ section as a directory listing.
 The rule that matters: **`internal/store` does not import `internal/jira`, and
 `internal/jira` never writes SQL.** The jira package produces neutral records;
 the store persists them. That boundary is what makes a second source a new
-package rather than a rewrite (Constitution Article 6).
+package rather than a rewrite (Constitution Article 6). Inspect the live graph
+with `tools/check-store-deps.sh --graph ./internal/store`.
 
 ## Three layers of caching, on purpose
 

--- a/internal/fields/coalesce.go
+++ b/internal/fields/coalesce.go
@@ -1,3 +1,8 @@
+// Package fields holds source-neutral field helpers — coalesce, fill checks,
+// slugs, and write-payload shaping — so internal/store can use them without
+// importing Jira types. SpecIDs exists for that reason: store coalesces on
+// alias+ids+role only. The Jira-shaped half (catalog classify/discover,
+// editmeta resolve) lives in internal/jirafields.
 package fields
 
 import (
@@ -7,7 +12,9 @@ import (
 )
 
 // SpecIDs is the flat shape store and sync use to coalesce without depending on
-// the full FieldSpec when only alias+ids+role are needed.
+// the full FieldSpec when only alias+ids+role are needed. The package boundary
+// exists so store can import this type without pulling Jira REST types onto
+// its graph (docs/ARCHITECTURE.md:79).
 type SpecIDs struct {
 	Alias string
 	IDs   []string

--- a/internal/fields/coalesce_test.go
+++ b/internal/fields/coalesce_test.go
@@ -89,3 +89,9 @@ func TestSuggestAlias(t *testing.T) {
 		t.Errorf("got %q", got)
 	}
 }
+
+func TestNormalizeName(t *testing.T) {
+	if got := NormalizeName("  Severity   Level  "); got != "severity level" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/fields/editable.go
+++ b/internal/fields/editable.go
@@ -4,24 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/midagedev/gadak/internal/config"
-	"github.com/midagedev/gadak/internal/jira"
 )
-
-// EditKind maps a Jira field schema onto the editors the UI has. A field
-// whose schema is none of them has no editor and is left out of editmeta.
-func EditKind(m jira.FieldMeta) string {
-	switch {
-	case m.Schema.Type == "option":
-		return "option"
-	case m.Schema.Type == "user":
-		return "user"
-	case m.Schema.Type == "array" && m.Schema.Items == "version":
-		return "version_array"
-	case m.Schema.Type == "array" && m.Schema.Items == "option":
-		return "multi_option"
-	}
-	return ""
-}
 
 // EditableAlias maps an alias onto candidate field ids and a preferred kind.
 // Specs with an empty Kind are display-only and do not enter the write path.
@@ -54,22 +37,6 @@ func EditableAliases(cfg *config.Config) map[string]EditableAlias {
 		out[alias] = EditableAlias{IDs: []string{id}}
 	}
 	return out
-}
-
-// ResolveEditableID picks the first candidate id present in editmeta.
-func ResolveEditableID(candidates []string, meta map[string]jira.FieldMeta) (id, kind string, ok bool) {
-	for _, cand := range candidates {
-		m, present := meta[cand]
-		if !present {
-			continue
-		}
-		k := EditKind(m)
-		if k == "" {
-			continue
-		}
-		return cand, k, true
-	}
-	return "", "", false
 }
 
 // FieldValue shapes the client's `string | string[] | null` into what Jira wants

--- a/internal/fields/editable_test.go
+++ b/internal/fields/editable_test.go
@@ -6,29 +6,7 @@ import (
 	"testing"
 
 	"github.com/midagedev/gadak/internal/config"
-	"github.com/midagedev/gadak/internal/jira"
 )
-
-func TestEditKind(t *testing.T) {
-	cases := []struct {
-		typ, items, want string
-	}{
-		{"option", "", "option"},
-		{"user", "", "user"},
-		{"array", "version", "version_array"},
-		{"array", "option", "multi_option"},
-		{"string", "", ""},
-		{"array", "component", ""},
-	}
-	for _, tc := range cases {
-		var m jira.FieldMeta
-		m.Schema.Type = tc.typ
-		m.Schema.Items = tc.items
-		if got := EditKind(m); got != tc.want {
-			t.Errorf("EditKind(%s/%s)=%q want %q", tc.typ, tc.items, got, tc.want)
-		}
-	}
-}
 
 func TestValueFromIDs(t *testing.T) {
 	cases := []struct {
@@ -132,33 +110,5 @@ func TestEditableAliasesLegacyWins(t *testing.T) {
 func TestEditableAliasesNilConfig(t *testing.T) {
 	if got := EditableAliases(nil); len(got) != 0 {
 		t.Fatalf("nil cfg → %v", got)
-	}
-}
-
-func TestResolveEditableID(t *testing.T) {
-	meta := map[string]jira.FieldMeta{
-		"customfield_10": func() jira.FieldMeta {
-			var m jira.FieldMeta
-			m.Schema.Type = "option"
-			return m
-		}(),
-		"customfield_skip": func() jira.FieldMeta {
-			var m jira.FieldMeta
-			m.Schema.Type = "string" // no editor
-			return m
-		}(),
-	}
-	// First candidate missing, second present.
-	id, kind, ok := ResolveEditableID([]string{"customfield_missing", "customfield_10"}, meta)
-	if !ok || id != "customfield_10" || kind != "option" {
-		t.Fatalf("got %q %q %v", id, kind, ok)
-	}
-	// Present but no editor kind → skip.
-	if _, _, ok := ResolveEditableID([]string{"customfield_skip"}, meta); ok {
-		t.Fatal("unsupported schema should skip")
-	}
-	// None present.
-	if _, _, ok := ResolveEditableID([]string{"customfield_x"}, meta); ok {
-		t.Fatal("missing id should not resolve")
 	}
 }

--- a/internal/jirafields/classify.go
+++ b/internal/jirafields/classify.go
@@ -1,6 +1,10 @@
-// Package fields classifies and discovers Jira custom fields for the mirror.
+// Package jirafields classifies and discovers Jira custom fields for the mirror.
 // Pure functions only — no network, no database.
-package fields
+//
+// Split from internal/fields so store can import the source-neutral helpers
+// without pulling Jira REST types or atlhttp onto its dependency graph
+// (docs/ARCHITECTURE.md:79).
+package jirafields
 
 import (
 	"strings"

--- a/internal/jirafields/classify_test.go
+++ b/internal/jirafields/classify_test.go
@@ -1,4 +1,4 @@
-package fields
+package jirafields
 
 import (
 	"testing"

--- a/internal/jirafields/discover.go
+++ b/internal/jirafields/discover.go
@@ -1,9 +1,10 @@
-package fields
+package jirafields
 
 import (
 	"sort"
 
 	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/fields"
 	"github.com/midagedev/gadak/internal/jira"
 )
 
@@ -42,7 +43,7 @@ func Discover(catalog []jira.FieldInfo, fill map[string]int, prior []config.Fiel
 			continue
 		}
 		if p.Label != "" {
-			priorAliasByNormLabel[NormalizeName(p.Label)] = p.Alias
+			priorAliasByNormLabel[fields.NormalizeName(p.Label)] = p.Alias
 		}
 		for _, id := range p.IDs {
 			if id != "" {
@@ -64,7 +65,7 @@ func Discover(catalog []jira.FieldInfo, fill map[string]int, prior []config.Fiel
 		if reservedID[f.ID] {
 			continue
 		}
-		norm := NormalizeName(f.Name)
+		norm := fields.NormalizeName(f.Name)
 		if norm == "" {
 			norm = f.ID
 		}
@@ -126,7 +127,7 @@ func Discover(catalog []jira.FieldInfo, fill map[string]int, prior []config.Fiel
 			}
 		}
 		if alias == "" {
-			alias = SuggestAlias(label, primary.ID, usedAliases)
+			alias = fields.SuggestAlias(label, primary.ID, usedAliases)
 		}
 		usedAliases[alias] = true
 		cands = append(cands, candidate{

--- a/internal/jirafields/discover_test.go
+++ b/internal/jirafields/discover_test.go
@@ -1,4 +1,4 @@
-package fields
+package jirafields
 
 import (
 	"reflect"
@@ -96,11 +96,5 @@ func TestDiscoverNonASCIIFallsBackToCF(t *testing.T) {
 	}
 	if got[0].Alias != "cf_10019" {
 		t.Errorf("alias = %q, want cf_10019", got[0].Alias)
-	}
-}
-
-func TestNormalizeName(t *testing.T) {
-	if got := NormalizeName("  Severity   Level  "); got != "severity level" {
-		t.Errorf("got %q", got)
 	}
 }

--- a/internal/jirafields/editable.go
+++ b/internal/jirafields/editable.go
@@ -1,0 +1,35 @@
+package jirafields
+
+import "github.com/midagedev/gadak/internal/jira"
+
+// EditKind maps a Jira field schema onto the editors the UI has. A field
+// whose schema is none of them has no editor and is left out of editmeta.
+func EditKind(m jira.FieldMeta) string {
+	switch {
+	case m.Schema.Type == "option":
+		return "option"
+	case m.Schema.Type == "user":
+		return "user"
+	case m.Schema.Type == "array" && m.Schema.Items == "version":
+		return "version_array"
+	case m.Schema.Type == "array" && m.Schema.Items == "option":
+		return "multi_option"
+	}
+	return ""
+}
+
+// ResolveEditableID picks the first candidate id present in editmeta.
+func ResolveEditableID(candidates []string, meta map[string]jira.FieldMeta) (id, kind string, ok bool) {
+	for _, cand := range candidates {
+		m, present := meta[cand]
+		if !present {
+			continue
+		}
+		k := EditKind(m)
+		if k == "" {
+			continue
+		}
+		return cand, k, true
+	}
+	return "", "", false
+}

--- a/internal/jirafields/editable_test.go
+++ b/internal/jirafields/editable_test.go
@@ -1,0 +1,56 @@
+package jirafields
+
+import (
+	"testing"
+
+	"github.com/midagedev/gadak/internal/jira"
+)
+
+func TestEditKind(t *testing.T) {
+	cases := []struct {
+		typ, items, want string
+	}{
+		{"option", "", "option"},
+		{"user", "", "user"},
+		{"array", "version", "version_array"},
+		{"array", "option", "multi_option"},
+		{"string", "", ""},
+		{"array", "component", ""},
+	}
+	for _, tc := range cases {
+		var m jira.FieldMeta
+		m.Schema.Type = tc.typ
+		m.Schema.Items = tc.items
+		if got := EditKind(m); got != tc.want {
+			t.Errorf("EditKind(%s/%s)=%q want %q", tc.typ, tc.items, got, tc.want)
+		}
+	}
+}
+
+func TestResolveEditableID(t *testing.T) {
+	meta := map[string]jira.FieldMeta{
+		"customfield_10": func() jira.FieldMeta {
+			var m jira.FieldMeta
+			m.Schema.Type = "option"
+			return m
+		}(),
+		"customfield_skip": func() jira.FieldMeta {
+			var m jira.FieldMeta
+			m.Schema.Type = "string" // no editor
+			return m
+		}(),
+	}
+	// First candidate missing, second present.
+	id, kind, ok := ResolveEditableID([]string{"customfield_missing", "customfield_10"}, meta)
+	if !ok || id != "customfield_10" || kind != "option" {
+		t.Fatalf("got %q %q %v", id, kind, ok)
+	}
+	// Present but no editor kind → skip.
+	if _, _, ok := ResolveEditableID([]string{"customfield_skip"}, meta); ok {
+		t.Fatal("unsupported schema should skip")
+	}
+	// None present.
+	if _, _, ok := ResolveEditableID([]string{"customfield_x"}, meta); ok {
+		t.Fatal("missing id should not resolve")
+	}
+}

--- a/internal/server/write.go
+++ b/internal/server/write.go
@@ -14,6 +14,7 @@ import (
 	"github.com/midagedev/gadak/internal/create"
 	"github.com/midagedev/gadak/internal/fields"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/jirafields"
 	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/store"
 	"github.com/midagedev/gadak/internal/sync"
@@ -576,7 +577,7 @@ func (s *server) handleEditMeta(w http.ResponseWriter, r *http.Request) {
 	}
 	out := map[string]any{}
 	for alias, ea := range allow {
-		id, kind, present := fields.ResolveEditableID(ea.IDs, meta)
+		id, kind, present := jirafields.ResolveEditableID(ea.IDs, meta)
 		if !present {
 			continue
 		}
@@ -628,7 +629,7 @@ func (s *server) handleFields(w http.ResponseWriter, r *http.Request) {
 		failJira(w, r, err)
 		return
 	}
-	id, kind, present := fields.ResolveEditableID(ea.IDs, meta)
+	id, kind, present := jirafields.ResolveEditableID(ea.IDs, meta)
 	if !present || kind == "" {
 		fail(w, http.StatusForbidden, "field_not_editable")
 		return

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -15,6 +15,7 @@ import (
 	"github.com/midagedev/gadak/internal/confluence"
 	"github.com/midagedev/gadak/internal/fields"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/jirafields"
 	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/store"
 )
@@ -314,7 +315,7 @@ func runDiscovery(ctx context.Context, c *jira.Client, cfg *config.Config, db *s
 		opts.logf("fields: discovery skipped: %v", err)
 		return nil
 	}
-	specs := fields.Discover(catalog, fill, cfg.Fields)
+	specs := jirafields.Discover(catalog, fill, cfg.Fields)
 	cfg.Fields = specs
 	if err := cfg.Save(); err != nil {
 		return fmt.Errorf("fields: save discovered specs: %w", err)

--- a/tools/check-store-deps.sh
+++ b/tools/check-store-deps.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Enforce the store/source firewall on a package's transitive import graph.
+#
+# Default: fail if ./internal/store depends on internal/jira, internal/atlhttp,
+# or net/http. The rule lives in docs/ARCHITECTURE.md:79 (Constitution Article 6).
+#
+# Usage:
+#   tools/check-store-deps.sh                 # gate ./internal/store
+#   tools/check-store-deps.sh --graph [pkg]   # print module + checked deps
+#
+# Exit 0 = clean (or graph printed), 1 = forbidden dep, 2 = usage error.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+MODULE="github.com/midagedev/gadak"
+DEFAULT_PKG="./internal/store"
+
+usage() {
+  echo "usage: tools/check-store-deps.sh [--graph [pkg]]" >&2
+  exit 2
+}
+
+list_deps() {
+  go list -f '{{join .Deps "\n"}}' "$1"
+}
+
+print_graph() {
+  local pkg="$1"
+  local deps
+  deps="$(list_deps "$pkg")"
+  echo "==> $pkg"
+  echo "-- module packages --"
+  printf '%s\n' "$deps" | grep "^${MODULE}/" | sort || true
+  echo "-- checked paths --"
+  local hit
+  for hit in "${MODULE}/internal/jira" "${MODULE}/internal/atlhttp" "net/http"; do
+    if printf '%s\n' "$deps" | grep -Fxq "$hit"; then
+      echo "PRESENT  $hit"
+    else
+      echo "absent   $hit"
+    fi
+  done
+}
+
+# The case arms below match a package and its subpackages but not a sibling
+# sharing a prefix: internal/jira must not match internal/jirafields, which is
+# exactly the package this firewall's own fix created.
+check_pkg() {
+  local pkg="$1"
+  local deps
+  deps="$(list_deps "$pkg")"
+  local bad=()
+  local seen_jira=0 seen_atlhttp=0 seen_http=0
+  local line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      "${MODULE}/internal/jira"|"${MODULE}/internal/jira"/*)
+        if [[ "$seen_jira" -eq 0 ]]; then
+          bad+=("${MODULE}/internal/jira")
+          seen_jira=1
+        fi
+        ;;
+      "${MODULE}/internal/atlhttp"|"${MODULE}/internal/atlhttp"/*)
+        if [[ "$seen_atlhttp" -eq 0 ]]; then
+          bad+=("${MODULE}/internal/atlhttp")
+          seen_atlhttp=1
+        fi
+        ;;
+      net/http|net/http/*)
+        if [[ "$seen_http" -eq 0 ]]; then
+          bad+=("net/http")
+          seen_http=1
+        fi
+        ;;
+    esac
+  done <<<"$deps"
+  if ((${#bad[@]} > 0)); then
+    echo "FAIL: $pkg depends on forbidden packages:" >&2
+    printf '  %s\n' "${bad[@]}" >&2
+    echo >&2
+    echo "docs/ARCHITECTURE.md:79 — internal/store must not import internal/jira (the store is source-neutral; Jira-shaped types belong behind a connector). The same gate also refuses internal/atlhttp and net/http on this graph." >&2
+    return 1
+  fi
+  echo "OK: $pkg does not depend on internal/jira, internal/atlhttp, or net/http"
+}
+
+MODE="check"
+PKG="$DEFAULT_PKG"
+
+if [[ $# -eq 0 ]]; then
+  :
+elif [[ "$1" == "--graph" ]]; then
+  MODE="graph"
+  if [[ $# -eq 1 ]]; then
+    PKG="$DEFAULT_PKG"
+  elif [[ $# -eq 2 ]]; then
+    PKG="$2"
+  else
+    usage
+  fi
+elif [[ "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+else
+  usage
+fi
+
+if [[ "$MODE" == "graph" ]]; then
+  print_graph "$PKG"
+else
+  check_pkg "$PKG"
+fi


### PR DESCRIPTION
`docs/ARCHITECTURE.md:79` has said for months: **"The rule that matters:
`internal/store` does not import `internal/jira`."** Constitution Article 6 is
*The Store Is Source-Neutral*, and `internal/adf` was split out specifically to
keep it that way.

The rule was broken, and nothing noticed, because nothing checked:

```
$ go list -f '{{join .Deps "\n"}}' ./internal/store | grep midagedev
…/internal/atlhttp
…/internal/fields
…/internal/jira
```

`internal/store/fields.go` imports `internal/fields` for three source-neutral
helpers. But `classify.go`, `discover.go` and `editable.go` in that package
import `internal/jira`, and a package-level import is an import — so the SQLite
spine carried Jira REST types and the Atlassian HTTP transport on its graph.
`net/http` rode along with them, so `ARCHITECTURE.md:73` was broken too and is
now also closed.

This matters now rather than eventually: multi-origin work is live
(`internal/linear` landed unwired, GDK-262 open) and source-neutrality is that
work's precondition.

## The split is by symbol, not by file

`editable.go` mixed both kinds — `EditKind` and `ResolveEditableID` take Jira
types; `EditableAlias`, `EditableAliases`, `FieldValue`, `ValueFromIDs` do not.
Moving the file wholesale would have been wrong in either direction.
`internal/fields` keeps the neutral half; `internal/jirafields` takes the
Jira-shaped half and its tests.

`coalesce.go` already explained that `SpecIDs` exists so store can coalesce
without the full Jira shape. The code intended this boundary; the package never
caught up.

**No behaviour, signature or exported-name change** — the non-test exported
surface diffs empty against HEAD. Sync, server and CLI import both packages,
which is correct; only store is constrained.

## The half that makes it stay fixed

`tools/check-store-deps.sh`, on the CI Go job, deliberately **not** path-scoped:
any edit anywhere in the import graph can break this, so a path filter would
make it a gate that passes exactly when it matters. Details worth noting:

- The failure quotes `ARCHITECTURE.md:79`, so the next person learns the rule
  from the red instead of guessing.
- Its match arms are written so `internal/jira` does not match
  `internal/jirafields` — the sibling this very fix created.
- `--graph <pkg>` prints the graph for any package, so the diagnostic and the
  gate are the same command.

**FAIL-first run by me, not taken on report:** copied into the unmodified tree at
`25ad707`, the gate exits 1 and names all three forbidden packages; in this tree
it exits 0.

## Gates (lead, cold)

`gofmt` clean · `go build` · `go vet` · `go test ./... -count=1` all exit 0 ·
30 packages ok · `tools/check-store-deps.sh` exit 0.

Test count **1478 → 1478**, packages 29 → 30 (the new package). That comparison
is the check that a test file did not get lost in the move, which was this
round's main risk.

One cleanup by me on review: the round left an unused `forbidden_hit()` helper in
the new script (its logic was inlined in `check_pkg`). Removed, and its comment
about the prefix trap moved onto the code that actually implements it.

Refs GDK-273. Sub-issues of GDK-278 (품질개선 v0.16) reference this as the
architecture half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)