### PR TITLE
fix(web): a status name is not a category — stop guessing "done" (GDK-272)

### DIFF
--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -129,9 +129,10 @@ fi
 # pipe-table grep cannot see `['Highest', 'High', ...]` because there is
 # no `\|`. High/Medium/Low are omitted — too many other meanings.
 #
-# Deliberately not matched (would fail the current tree; sibling issue):
-#   - view-config.ts RESOLVED_STATUS_NAMES (legacy fallback when
-#     status_category is absent)
+# Done-status display names (GDK-272): Jira-default KO names that used to
+# be a fallback set when status_category was absent. Lowercase 'done' /
+# 'resolved' / 'closed' are not listed — they are also category keys or
+# other-field values (RangeField 'resolved', GitHub PR 'closed').
 name_hits="$(
   grep -RInE \
     --include='*.ts' --include='*.svelte' \
@@ -150,6 +151,9 @@ name_hits="$(
     -e "['\"]Lowest['\"]" \
     -e "['\"]In Progress['\"]" \
     -e "['\"]Sub-task['\"]" \
+    -e "['\"]해결됨['\"]" \
+    -e "['\"]종료['\"]" \
+    -e "['\"]완료['\"]" \
     web/src/lib web/src/components web/src/stores \
     | grep -v '/i18n/' \
     || true

--- a/web/src/components/detail/HistoryTimeline.svelte
+++ b/web/src/components/detail/HistoryTimeline.svelte
@@ -2,28 +2,14 @@
   /*
    * Change history timeline ([detail]).
    * Compact status/assignee/priority changes (from→to, by, relative time).
-   * Reopen (resolved → unresolved status transition) gets a red point.
+   * Reopen (done-category → non-done) gets a red point.
    */
   import { t } from '../../lib/i18n'
   import type { HistoryEntry } from '../../lib/types'
-  import { RESOLVED_STATUS_NAMES } from '../../lib/view-config'
+  import { isReopen } from '../../lib/view-config'
   import { relativeTime, absoluteTime } from './format'
 
   let { history }: { history: HistoryEntry[] } = $props()
-
-  function isResolved(s: string | null): boolean {
-    return !!s && RESOLVED_STATUS_NAMES.has(s.trim().toLowerCase())
-  }
-
-  /**
-   * Is this status transition a reopen (resolved→unresolved)? Prefer server
-   * before/after categories; only fall back to status names (locale-dependent).
-   */
-  function isReopen(e: HistoryEntry): boolean {
-    if (e.field !== 'status') return false
-    if (e.from_category || e.to_category) return e.from_category === 'done' && e.to_category !== 'done'
-    return isResolved(e.from) && !isResolved(e.to)
-  }
 
   /** Field label (via i18n). */
   function fieldLabel(f: string): string {

--- a/web/src/lib/view-config.test.ts
+++ b/web/src/lib/view-config.test.ts
@@ -4,12 +4,16 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { en } from './i18n/en'
 import { ko } from './i18n/ko'
+import type { IssueLite } from './types'
 import {
   KEYS_CAP,
   configToParams,
   defaultGroupBy,
+  effectiveCategory,
   emptyConfig,
+  isReopen,
   matchesIdFirst,
+  missingStatusCategorySeen,
   normalizeKeys,
   orderColumns,
   parseConfig,
@@ -392,5 +396,89 @@ describe('GDK-35 keys cap', () => {
     expect(ko['filter.keysCapped']).toContain('{shown}')
     expect(ko['filter.keysCapped']).toContain('키')
     expect(ko['filter.keysCapped']).not.toContain('이슈')
+  })
+})
+
+function issueRow(status: string, status_category: string): IssueLite {
+  return { status, status_category } as IssueLite
+}
+
+describe('effectiveCategory (GDK-272)', () => {
+  test('trusted category is returned as-is', () => {
+    expect(effectiveCategory(issueRow('Anything', 'new'))).toBe('new')
+    expect(effectiveCategory(issueRow('Anything', 'inprogress'))).toBe('inprogress')
+    expect(effectiveCategory(issueRow('Anything', 'done'))).toBe('done')
+  })
+
+  test("empty category + status 완료 is not 'done'", () => {
+    expect(effectiveCategory(issueRow('완료', ''))).not.toBe('done')
+  })
+
+  test("empty category + status Done is not 'done'", () => {
+    expect(effectiveCategory(issueRow('Done', ''))).not.toBe('done')
+  })
+
+  test("empty category + status Shipped is not 'done'", () => {
+    expect(effectiveCategory(issueRow('Shipped', ''))).not.toBe('done')
+  })
+
+  test('empty category increments missingStatusCategorySeen', () => {
+    const before = missingStatusCategorySeen()
+    effectiveCategory(issueRow('완료', ''))
+    expect(missingStatusCategorySeen()).toBe(before + 1)
+  })
+
+  test('trusted category does not increment missingStatusCategorySeen', () => {
+    const before = missingStatusCategorySeen()
+    effectiveCategory(issueRow('완료', 'done'))
+    expect(missingStatusCategorySeen()).toBe(before)
+  })
+})
+
+describe('isReopen (GDK-272)', () => {
+  test('done-category → non-done is a reopen', () => {
+    expect(isReopen({ field: 'status', from_category: 'done', to_category: 'inprogress' })).toBe(true)
+    expect(isReopen({ field: 'status', from_category: 'done', to_category: 'new' })).toBe(true)
+  })
+
+  test('non-done → done is not a reopen', () => {
+    expect(isReopen({ field: 'status', from_category: 'inprogress', to_category: 'done' })).toBe(false)
+  })
+
+  test('non-status field is never a reopen', () => {
+    expect(isReopen({ field: 'assignee', from_category: 'done', to_category: 'inprogress' })).toBe(false)
+  })
+
+  test('both categories empty is not a reopen, even when names look resolved', () => {
+    const korean = {
+      field: 'status',
+      from: '완료',
+      to: '진행 중',
+      from_category: null as string | null,
+      to_category: null as string | null,
+    }
+    const english = {
+      field: 'status',
+      from: 'Done',
+      to: 'To Do',
+      from_category: '',
+      to_category: '',
+    }
+    const custom = {
+      field: 'status',
+      from: 'Shipped',
+      to: 'To Do',
+      from_category: null as string | null,
+      to_category: null as string | null,
+    }
+    expect(isReopen(korean)).toBe(false)
+    expect(isReopen(english)).toBe(false)
+    expect(isReopen(custom)).toBe(false)
+  })
+
+  test('empty categories increment missingStatusCategorySeen', () => {
+    const before = missingStatusCategorySeen()
+    isReopen({ field: 'status', from_category: null, to_category: null })
+    expect(missingStatusCategorySeen()).toBe(before + 1)
   })
 })

--- a/web/src/lib/view-config.ts
+++ b/web/src/lib/view-config.ts
@@ -14,7 +14,7 @@
 
 import { config, feature, type GadakFeatures } from './config'
 import { columnLabel } from './i18n'
-import type { DeployState, IssueLite } from './types'
+import type { DeployState, HistoryEntry, IssueLite } from './types'
 
 /* ── Filter state ── */
 
@@ -561,20 +561,17 @@ export function configToParams(config: ViewConfig): Record<string, string | null
 
 /* ── Filter application helpers ── */
 
-/**
- * Fallback when status_category is missing. Status names vary by site/account language
- * and cannot be trusted, so keep only generic names that mean the same on every Jira.
- */
-export const RESOLVED_STATUS_NAMES = new Set([
-  'resolved',
-  'closed',
-  'done',
-  '해결됨',
-  '종료',
-  '완료',
-])
-
 export type StatusCategory = 'new' | 'inprogress' | 'done'
+
+/**
+ * Times a category decision ran with an empty status_category.
+ * Integer increment only — no per-row log. Read from the console or a test.
+ */
+let missingStatusCategoryCount = 0
+
+export function missingStatusCategorySeen(): number {
+  return missingStatusCategoryCount
+}
 
 /**
  * Filter token match: id first, display name only as a fallback for legacy
@@ -608,12 +605,25 @@ export function prioritySortRank(rank: number | null | undefined): number {
   return rank
 }
 
-/** Trust server status_category first; fall back to status name only when absent. */
+/** Trust a real new|inprogress|done status_category; otherwise 'inprogress'. Never a status name. */
 export function effectiveCategory(issue: IssueLite): StatusCategory {
   const sc = (issue.status_category ?? '').toLowerCase()
   if (sc === 'new' || sc === 'inprogress' || sc === 'done') return sc
-  if (RESOLVED_STATUS_NAMES.has((issue.status ?? '').trim().toLowerCase())) return 'done'
+  if (!sc) missingStatusCategoryCount++
   return 'inprogress'
+}
+
+/**
+ * Reopen is a done-category → non-done status transition. Never a name match.
+ * When both from_category and to_category are empty, return false: an unpainted
+ * badge is a missing hint; a wrongly painted one is a false claim about the
+ * issue's history.
+ */
+export function isReopen(e: Pick<HistoryEntry, 'field' | 'from_category' | 'to_category'>): boolean {
+  if (e.field !== 'status') return false
+  if (e.from_category || e.to_category) return e.from_category === 'done' && e.to_category !== 'done'
+  missingStatusCategoryCount++
+  return false
 }
 
 /**


### PR DESCRIPTION
`RESOLVED_STATUS_NAMES` held `resolved`/`closed`/`done`/`해결됨`/`종료`/`완료`, and
two readers consulted it whenever the server sent no category: `effectiveCategory`
returned `done` on a name match, and HistoryTimeline's local `isReopen` painted a
reopen badge from `isResolved(from) && !isResolved(to)`.

This is the trap the repo names first. `status = 'In Progress'` is silently zero
rows on a Korean account; `docs/STATE_OF_PLAY.md` hard-won #4 says a reopen is a
done-category → non-done transition and **never** a name match. The set's own
comment claimed it kept "only generic names that mean the same on every Jira" —
`완료` is not a generic name, so the premise contradicted itself.

## It was not dead code

`internal/server/read.go:445` fills `from_category` from
`view.categories[FromID]`, and `read.go:650` seeds that map **only from status ids
a currently-mirrored issue occupies**. Any status the issue passed through that
nothing currently holds — a status removed from the workflow, say — arrives with
no category, and the name decides.

So it also broke on an **English** site with a custom done status ("Verified",
"Shipped"), not only on a third language. The audit round rated this
medium-confidence; verifying that seeding path is what promoted it to a
confirmed Highest defect.

## What changed

- `effectiveCategory` trusts a real `new|inprogress|done` and otherwise returns
  `inprogress`. No name is consulted.
- `isReopen` moved into `view-config.ts` as the **single owner** of the reopen
  rule, and returns false when both categories are empty: an unpainted badge is a
  missing hint, a wrongly painted one is a false claim about the issue's history.
- `matchesIdFirst`'s name fallback is deliberately untouched — that is the
  documented compatibility path for legacy saved views, a different decision.

## Recurrence, and a correction to my own spec

`tools/doc-checks.sh` now matches `'해결됨'`, `'종료'`, `'완료'` as display-name
literals in web logic. Its old comment said this table was *"deliberately not
matched (would fail the current tree; sibling issue)"* — the round found that was
**only a comment, not a grep exclusion**; `view-config.ts` was already in the scan
path. So the work was adding patterns that catch the table, not removing an
exemption. My spec had that wrong and the round said so.

Lowercase `done`/`resolved`/`closed` stay out of the pattern on purpose: they are
also category keys and other-field values (a RangeField `resolved`, a GitHub PR
`closed`).

**FAIL-first run by me:** reintroducing `new Set(['완료', '해결됨'])` into
view-config.ts makes doc-checks fail and name the file and line; removing it
returns exit 0.

`effectiveCategory` had **no unit test at all** before this. 11 new cases now
cover the trusted values, an empty category with a Korean status name, `'Done'`,
a custom `'Shipped'`, and the reopen predicate.

## Debuggability

The failure mode was silence — nobody could tell a category was missing and
something guessed. `missingStatusCategorySeen()` counts how often a category
decision ran without a category. Integer increment, no per-row logging.

## Gates (lead, cold)

svelte-check 4250 files / **0 errors** · vitest 34 files / **347 tests** (was
336) · `tools/doc-checks.sh` all passed · **Playwright 240 passed** (mandatory
here — `web/` changed).

Closes GDK-272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)