### PR TITLE
fix(test): a probe test must assert the answer, not the machine's load (GDK-303)

### DIFF
--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -270,23 +270,56 @@ func resolveNamed(name string, fallbacks []string, look func(string) (string, er
 // changes, the probe degrades to unknown — never to a false positive.
 const mcpNotRegisteredMarker = "No MCP server named"
 
+// probeOutcome says *why* a probe ended, which the *bool cannot: unknown has
+// two causes and they are not interchangeable. A wrong answer is a product
+// bug; running out of time is the machine being busy. Tests that assert which
+// answer the CLI gives must be able to tell the difference, or a loaded
+// machine turns into a red build about the wrong thing (GDK-303).
+type probeOutcome int
+
+const (
+	probeAnswered   probeOutcome = iota // the process exited and we read it
+	probeNotStarted                     // exec failed
+	probeTimedOut                       // mcpProbeTimeout fired first
+)
+
+func (o probeOutcome) String() string {
+	switch o {
+	case probeAnswered:
+		return "answered"
+	case probeNotStarted:
+		return "not-started"
+	case probeTimedOut:
+		return "timed-out"
+	}
+	return "unknown"
+}
+
 // probeClaudeMCP runs `claude mcp get gadak` with a short timeout.
 // Exit 0 is installed=true; exit non-zero with the not-registered wording is
 // a definitive installed=false; any other failure or timeout is unknown (nil).
 // Mirrors cmd/gadak/mcp_install.go mcpInstallClaude's execLookPath("claude") rule
 // for finding the binary; the get probe itself is desktop-status only.
+func probeClaudeMCP(claudePath string) *bool {
+	installed, _ := probeClaudeMCPOutcome(claudePath)
+	return installed
+}
+
+// probeClaudeMCPOutcome is probeClaudeMCP plus the reason. Production reads
+// only the answer; the outcome exists so a test can assert "the CLI said no"
+// rather than "the CLI said no, or we gave up waiting".
 //
 // The timer starts after Start so a starved test goroutine cannot expire the
 // budget before the process exists (CommandContext+WithTimeout before Start
 // returned unknown for an `exit 0` stub under go test ./... load).
-func probeClaudeMCP(claudePath string) *bool {
+func probeClaudeMCPOutcome(claudePath string) (*bool, probeOutcome) {
 	cmd := exec.Command(claudePath, "mcp", "get", "gadak")
 	var out limitedBuf
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	setProbeProcAttr(cmd)
 	if err := cmd.Start(); err != nil {
-		return nil
+		return nil, probeNotStarted
 	}
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
@@ -296,11 +329,11 @@ func probeClaudeMCP(claudePath string) *bool {
 	case err := <-done:
 		if err != nil {
 			if strings.Contains(out.String(), mcpNotRegisteredMarker) {
-				return boolPtr(false)
+				return boolPtr(false), probeAnswered
 			}
-			return nil
+			return nil, probeAnswered
 		}
-		return boolPtr(true)
+		return boolPtr(true), probeAnswered
 	case <-timer.C:
 		killProbe(cmd)
 		// Bound the reap: if Kill did not take, do not pin GET behind a child.
@@ -310,7 +343,7 @@ func probeClaudeMCP(claudePath string) *bool {
 		case <-done:
 		case <-reap.C:
 		}
-		return nil
+		return nil, probeTimedOut
 	}
 }
 

--- a/internal/integrations/integrations_test.go
+++ b/internal/integrations/integrations_test.go
@@ -206,7 +206,22 @@ func TestResolveNPMOrder(t *testing.T) {
 	}
 }
 
+// answerProbeBudget gives the probe far more time than a `#!/bin/sh; exit N`
+// stub can possibly need. Tests that assert *which answer* the CLI gives must
+// not also be asserting that a busy machine can start a process inside 3s:
+// under `go test ./...` parallelism plus outside load, that spawn has exceeded
+// the production budget and turned "the CLI said not-registered" into a
+// timeout, i.e. a red build about the wrong thing (GDK-303). The test that
+// owns the timeout contract sets a short value instead.
+func answerProbeBudget(t *testing.T) {
+	t.Helper()
+	prev := mcpProbeTimeout
+	mcpProbeTimeout = 30 * time.Second
+	t.Cleanup(func() { mcpProbeTimeout = prev })
+}
+
 func TestMCPProbeUnknownWhenMissingOrFail(t *testing.T) {
+	answerProbeBudget(t)
 	old := lookPath
 	t.Cleanup(func() { lookPath = old })
 
@@ -240,6 +255,7 @@ func TestMCPProbeUnknownWhenMissingOrFail(t *testing.T) {
 }
 
 func TestMCPProbeDefinitiveNotRegistered(t *testing.T) {
+	answerProbeBudget(t)
 	// claude's real wording for "not registered" (measured 2026-08-17):
 	// exit 1 + "No MCP server named ...". That is a definitive false, not
 	// an unknown — the UI should offer Install, not shrug.
@@ -268,6 +284,7 @@ func TestMCPProbeDefinitiveNotRegistered(t *testing.T) {
 }
 
 func TestMCPProbeTrueOnExitZero(t *testing.T) {
+	answerProbeBudget(t)
 	dir := t.TempDir()
 	okBin := filepath.Join(dir, "claude")
 	if err := os.WriteFile(okBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
@@ -306,6 +323,39 @@ func TestMCPProbeTimeoutIsUnknown(t *testing.T) {
 	}
 	if got != nil {
 		t.Fatalf("timeout should be unknown, got %v", *got)
+	}
+}
+
+// The two causes of "unknown" must be distinguishable. Without this, a starved
+// machine and a broken CLI produce the same nil, and the answer-asserting tests
+// above fail with a message about the wrong thing (GDK-303).
+func TestProbeOutcomeSeparatesTimeoutFromAnswer(t *testing.T) {
+	dir := t.TempDir()
+
+	slow := filepath.Join(dir, "slow")
+	if err := os.WriteFile(slow, []byte("#!/bin/sh\nsleep 10\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := mcpProbeTimeout
+	mcpProbeTimeout = 50 * time.Millisecond
+	got, outcome := probeClaudeMCPOutcome(slow)
+	mcpProbeTimeout = prev
+	if got != nil || outcome != probeTimedOut {
+		t.Fatalf("slow stub: got=%v outcome=%s want nil/timed-out", got, outcome)
+	}
+
+	answerProbeBudget(t)
+	okBin := filepath.Join(dir, "ok")
+	if err := os.WriteFile(okBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, outcome = probeClaudeMCPOutcome(okBin)
+	if got == nil || !*got || outcome != probeAnswered {
+		t.Fatalf("exit-0 stub: got=%v outcome=%s want true/answered", got, outcome)
+	}
+
+	if _, outcome = probeClaudeMCPOutcome(filepath.Join(dir, "does-not-exist")); outcome != probeNotStarted {
+		t.Fatalf("absent binary: outcome=%s want not-started", outcome)
 	}
 }
 


### PR DESCRIPTION
`go test ./...` on main failed with

```
--- FAIL: TestMCPProbeDefinitiveNotRegistered (3.00s)
FAIL	github.com/midagedev/gadak/internal/integrations	10.552s
```

3.00s is exactly `mcpProbeTimeout`. The test writes a
`#!/bin/sh; echo 'No MCP server named …'; exit 1` stub and asserts the probe
reports a **definitive false**. Under `go test ./...` parallelism plus outside
load, starting and reaping that stub exceeded the 3s production budget, the probe
returned nil, and the test failed about the wrong thing. In isolation it passes
in ~0.8s even at load 36.

**Not new, and not from #21.** The function's own comment already records an
earlier round of this same class: the timer was moved to start *after*
`cmd.Start()` because `CommandContext` + `WithTimeout` "returned unknown for an
`exit 0` stub under go test ./... load". That was a nudge. This is the structure.

## Two changes

**`answerProbeBudget(t)`** gives the three tests that assert *which answer the CLI
gives* 30 seconds — far more than a shell stub can need. They were never
asserting that a busy machine can spawn a process inside 3s, and now they do not.
`TestMCPProbeTimeoutIsUnknown` keeps its 50ms, because the timeout contract is
what that one actually claims. Production stays at 3s.

No assertion is weakened — each test now measures only what it means.

**`probeOutcome`** makes the two causes of "unknown" distinguishable. They are not
interchangeable: a wrong answer is a product bug, running out of time is the
machine being busy. Until now both were a bare `nil`, so nothing could tell them
apart — including the test that failed, which is why the red pointed at the wrong
thing. `probeClaudeMCP` keeps its signature and production reads only the answer;
`probeClaudeMCPOutcome` carries the reason.

## FAIL-first, both directions

- Inject `probeTimedOut → probeAnswered`: the new
  `TestProbeOutcomeSeparatesTimeoutFromAnswer` fails with
  `slow stub: got=<nil> outcome=answered want nil/timed-out`.
- Pin the definitive test's budget to 1ms — the starved machine, simulated — and
  it fails with `not-registered wording: installed=<nil> want false`. **That is
  the original failure reproduced on demand.**

## Gates

`gofmt` clean · `go build` · `go vet` · `go test ./... -count=1` all exit 0 ·
30 packages ok · `tools/check-store-deps.sh` ok — measured at **load 26**, which
is worse than the load ~10 that produced the original red. The package also
passes 5 consecutive runs.

Found while doing the quiet-machine re-measure I owed for GDK-287; the machine
was not quiet, which is how this surfaced.

Closes GDK-303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)