### PR TITLE
fix(filter): a priority filter keyed on a display name is zero rows in Korean (GDK-275)

### DIFF
--- a/internal/snapshot/build.go
+++ b/internal/snapshot/build.go
@@ -663,7 +663,7 @@ var (
 	}
 	issueColumns = []string{
 		"item_id", "key", "project_key", "issue_type", "issue_type_id",
-		"status", "status_id", "status_category", "priority", "priority_rank",
+		"status", "status_id", "status_category", "priority", "priority_id", "priority_rank",
 		"assignee", "assignee_id", "assignee_email", "reporter", "reporter_id", "reporter_email",
 		"parent_key", "labels", "components", "fix_versions", "affects_versions",
 		"environment_text", "duedate", "resolution", "created_at", "updated_at",
@@ -735,6 +735,9 @@ func insertRow(tx *sql.Tx, table string, cols []string, data map[string]any) err
 		}
 		if vals[indexOf(cols, "cloned_from")] == nil {
 			vals[indexOf(cols, "cloned_from")] = ""
+		}
+		if vals[indexOf(cols, "priority_id")] == nil {
+			vals[indexOf(cols, "priority_id")] = ""
 		}
 	}
 	if table == "pages" {

--- a/internal/store/pages_test.go
+++ b/internal/store/pages_test.go
@@ -367,9 +367,9 @@ func TestPageLiteAuthorID(t *testing.T) {
 	}
 }
 
-// TestIssueLitePriorityIDOnWire documents the wire field. There is no
-// issues.priority_id column (schema + sync are out of this track), so the
-// value is the empty string — clients fall back to the display name.
+// TestIssueLitePriorityIDOnWire: an issue upserted with PriorityID carries
+// that id through IssueLites JSON. The field is on the wire so clients
+// can match id-first the same way they do for status_id / issue_type_id.
 func TestIssueLitePriorityIDOnWire(t *testing.T) {
 	db := openTemp(t)
 	if err := db.UpsertSource(context.Background(), Source{ID: "jira", Kind: "jira"}); err != nil {
@@ -386,7 +386,7 @@ func TestIssueLitePriorityIDOnWire(t *testing.T) {
 			Issue: Issue{
 				ProjectKey: "NMB", IssueType: "Bug", IssueTypeID: "1",
 				Status: "To Do", StatusID: "1", StatusCategory: "new",
-				Priority: "High",
+				Priority: "High", PriorityID: "2",
 			},
 		}},
 	}); err != nil {
@@ -396,8 +396,8 @@ func TestIssueLitePriorityIDOnWire(t *testing.T) {
 	if err != nil || len(rows) != 1 {
 		t.Fatalf("IssueLites: %v %+v", err, rows)
 	}
-	if rows[0].PriorityID != "" {
-		t.Errorf("PriorityID = %q, want empty until a schema column exists", rows[0].PriorityID)
+	if rows[0].PriorityID != "2" {
+		t.Errorf("PriorityID = %q, want 2", rows[0].PriorityID)
 	}
 	raw, err := json.Marshal(rows[0])
 	if err != nil {

--- a/internal/store/read.go
+++ b/internal/store/read.go
@@ -25,10 +25,10 @@ type IssueLite struct {
 	StatusID       string  `json:"status_id"`
 	StatusCategory string  `json:"status_category"`
 	Priority       *string `json:"priority"`
-	// PriorityID is the stable Jira priority id. Empty until a later schema
-	// column is filled — the field is on the wire so clients can match id-first
-	// the same way they do for status_id / issue_type_id. There is no
-	// issues.priority_id column today (only name + rank).
+	// PriorityID is the stable Jira priority id (issues.priority_id). Empty
+	// on rows a sync has not rewritten since the column was added — clients
+	// fall back to the display name for those, the same way they do for a
+	// missing status_id / issue_type_id.
 	PriorityID    string  `json:"priority_id"`
 	PriorityRank  int     `json:"priority_rank"`
 	Assignee      *string `json:"assignee"`
@@ -69,7 +69,7 @@ const issueLiteSelect = `
 	SELECT i.key, COALESCE(it.title, ''), COALESCE(i.project_key, ''),
 	       COALESCE(i.issue_type, ''), COALESCE(i.issue_type_id, ''),
 	       COALESCE(i.status, ''), COALESCE(i.status_id, ''), COALESCE(i.status_category, ''),
-	       i.priority, i.priority_rank,
+	       i.priority, COALESCE(i.priority_id, ''), i.priority_rank,
 	       i.assignee, i.assignee_id, i.assignee_email, i.reporter, i.reporter_id, i.reporter_email,
 	       i.epic_key, i.parent_key,
 	       COALESCE(i.labels, '[]'), COALESCE(i.components, '[]'), COALESCE(i.fix_versions, '[]'),
@@ -150,7 +150,7 @@ func (db *DB) issueLites(ctx context.Context, query string, args ...any) ([]Issu
 		var labels, components, fixVersions, custom string
 		var reopenReason, clonedFrom string
 		if err := rows.Scan(&v.IssueKey, &v.Summary, &v.ProjectKey, &v.IssueType, &v.IssueTypeID,
-			&v.Status, &v.StatusID, &v.StatusCategory, &v.Priority, &v.PriorityRank,
+			&v.Status, &v.StatusID, &v.StatusCategory, &v.Priority, &v.PriorityID, &v.PriorityRank,
 			&v.Assignee, &v.AssigneeID, &v.AssigneeEmail, &v.Reporter, &v.ReporterID, &v.ReporterEmail,
 			&v.EpicKey, &v.ParentKey,
 			&labels, &components, &fixVersions,

--- a/internal/store/records.go
+++ b/internal/store/records.go
@@ -42,6 +42,7 @@ type Issue struct {
 	StatusID       string
 	StatusCategory string // new | inprogress | done
 	Priority       string
+	PriorityID     string
 	Assignee       string
 	AssigneeID     string
 	AssigneeEmail  string

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -3,7 +3,7 @@ package store
 // migrations are applied in order and the index+1 is the schema version. A
 // released migration is never edited; a schema change is a new entry at the end
 // plus a documented row in specs/000-product/data-model.md.
-var migrations = []string{schemaV1, schemaV2, schemaV3, schemaV4, schemaV5, schemaV6, schemaV7, schemaV8, schemaV9, schemaV10, schemaV11, schemaV12, schemaV13, schemaV14, schemaV15, schemaV16, schemaV17, schemaV18, schemaV19, schemaV20, schemaV21}
+var migrations = []string{schemaV1, schemaV2, schemaV3, schemaV4, schemaV5, schemaV6, schemaV7, schemaV8, schemaV9, schemaV10, schemaV11, schemaV12, schemaV13, schemaV14, schemaV15, schemaV16, schemaV17, schemaV18, schemaV19, schemaV20, schemaV21, schemaV22}
 
 // itemsFTSCreate is the canonical items_fts DDL, quoted verbatim from schemaV1
 // below. Migrations are append-only, so schemaV1 cannot reference this
@@ -424,4 +424,18 @@ CREATE TABLE page_versions (
   PRIMARY KEY (item_id, number)
 );
 CREATE INDEX idx_page_versions_at ON page_versions(item_id, created_at);
+`
+
+// schemaV22 adds issues.priority_id so list filters can key on the stable
+// Jira priority id (names localize per account). Existing rows keep the
+// empty string until the next sync rewrites them; the web filter still falls back to
+// the display name for those rows and for legacy saved views. issues_full
+// is rebuilt because it expanded i.* at CREATE VIEW time (v12) and would
+// otherwise hide the new column from agents.
+const schemaV22 = `
+ALTER TABLE issues ADD COLUMN priority_id TEXT NOT NULL DEFAULT '';
+DROP VIEW issues_full;
+CREATE VIEW issues_full AS
+  SELECT it.title AS summary, i.*
+  FROM issues i JOIN items it ON it.id = i.item_id;
 `

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -26,7 +26,7 @@ var documentedColumns = map[string][]string{
 		"duedate", "resolution", "created_at", "updated_at",
 		"status_changed_at", "resolved_at", "reopen_count", "reopened_at",
 		"assignee_changed_at", "comment_count", "description_adf", "custom", "raw",
-		"reopen_reason", "cloned_from", "hierarchy_level", "epic_key"},
+		"reopen_reason", "cloned_from", "hierarchy_level", "epic_key", "priority_id"},
 	"comments": {"id", "item_id", "external_id", "author", "author_id",
 		"body_adf", "body_text", "created_at", "updated_at"},
 	"attachments":    {"id", "item_id", "external_id", "filename", "mime_type", "size", "author", "created_at", "author_id"},

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -137,16 +137,16 @@ func upsertRecord(tx *sql.Tx, b Batch, r IssueRecord) (bool, error) {
 	}
 	if _, err := tx.Exec(`
 		INSERT INTO issues (item_id, key, project_key, issue_type, issue_type_id,
-			status, status_id, status_category, priority, priority_rank,
+			status, status_id, status_category, priority, priority_id, priority_rank,
 			assignee, assignee_id, assignee_email, reporter, reporter_id, reporter_email, parent_key,
 			labels, components, fix_versions, affects_versions, environment_text,
 			duedate, resolution, created_at, updated_at,
 			status_changed_at, resolved_at, reopen_count, reopened_at, reopen_reason,
 			assignee_changed_at, comment_count, description_adf, custom, raw, cloned_from,
 			hierarchy_level)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		it.ID, it.Key, nz(is.ProjectKey), nz(is.IssueType), nz(is.IssueTypeID),
-		nz(is.Status), nz(is.StatusID), nz(is.StatusCategory), nz(is.Priority), d.PriorityRank,
+		nz(is.Status), nz(is.StatusID), nz(is.StatusCategory), nz(is.Priority), is.PriorityID, d.PriorityRank,
 		nz(is.Assignee), nz(is.AssigneeID), nz(is.AssigneeEmail), nz(is.Reporter),
 		nz(is.ReporterID), nz(is.ReporterEmail), nz(is.ParentKey),
 		jsonArray(is.Labels), jsonArray(is.Components), jsonArray(is.FixVersions),

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -644,6 +644,7 @@ func build(ctx context.Context, c *jira.Client, cfg *config.Config, iss jira.Iss
 	}
 	if f.Priority != nil {
 		issue.Priority = f.Priority.Name
+		issue.PriorityID = f.Priority.ID
 	}
 	if f.Assignee != nil {
 		issue.Assignee, issue.AssigneeID, issue.AssigneeEmail = f.Assignee.DisplayName, f.Assignee.AccountID, f.Assignee.Email

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -413,6 +413,12 @@ func TestFullSyncMapsEverything(t *testing.T) {
 	if one.PriorityRank != 2 {
 		t.Errorf("priority_rank = %d, want 2 (High is second in the site list)", one.PriorityRank)
 	}
+	if one.PriorityID != "2" {
+		t.Errorf("priority_id = %q, want 2 (fixture High id)", one.PriorityID)
+	}
+	if got := db.column(t, "issues", "priority_id", "NMB-1"); got != "2" {
+		t.Errorf("issues.priority_id = %q, want 2", got)
+	}
 	if one.ReopenCount != 1 || one.ReopenedAt == nil || *one.ReopenedAt != "2026-07-20T01:00:00.000Z" {
 		t.Errorf("reopen = %d at %v", one.ReopenCount, one.ReopenedAt)
 	}

--- a/specs/000-product/data-model.md
+++ b/specs/000-product/data-model.md
@@ -122,6 +122,7 @@ The Jira projection. Joined to `items` on `item_id`.
 | `status_id` | TEXT | **Use this for logic** |
 | `status_category` | TEXT | `new` \| `inprogress` \| `done`. Stable across sites |
 | `priority` | TEXT | Display name |
+| `priority_id` | TEXT | Stable source id (v22). Empty (`''`) until a sync rewrites the row. **Use this (or `priority_rank`) for logic**; names are localized |
 | `priority_rank` | INTEGER | Derived: 1 = most urgent, 0 = unset |
 | `assignee` | TEXT | Display name |
 | `assignee_id` | TEXT | Account id |

--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -337,4 +337,57 @@ if [[ -n "$sac_off" ]]; then
 fi
 ok "Windows desktop zip is documented; SAC-off is not offered"
 
+# ── 14. matchesIdFirst id args are real issues columns (GDK-275) ────────
+# The display-name grep (check 7) cannot see this class: an id-first call
+# whose id argument names a column that does not exist is silently
+# name-only. FAIL-first 2026-08-19: web filter passed it.priority_id while
+# schema.go had no issues.priority_id (only name + rank).
+id_first_missing="$(
+  python3 - <<'PY'
+import re
+from pathlib import Path
+
+# Columns created on issues, plus every later ADD COLUMN.
+schema = Path("internal/store/schema.go").read_text()
+cols = set()
+m = re.search(r"CREATE TABLE issues\s*\((.*?)\)\s*;", schema, flags=re.S)
+if not m:
+    print("schema.go: no CREATE TABLE issues")
+    raise SystemExit
+for part in m.group(1).split(","):
+    name = part.strip().split()
+    if name:
+        cols.add(name[0])
+for add in re.finditer(r"ALTER TABLE issues ADD COLUMN (\w+)", schema):
+    cols.add(add.group(1))
+
+# Id argument of matchesIdFirst (and a call that wraps it): it.<field>
+# in web logic. Tests/i18n are excluded the same way as check 7.
+field_re = re.compile(
+    r"matchesIdFirst\s*\([^,]+,\s*it\.([A-Za-z0-9_]+)",
+)
+missing = []
+roots = [Path("web/src/lib"), Path("web/src/components"), Path("web/src/stores")]
+for root in roots:
+    for path in root.rglob("*"):
+        if path.suffix not in {".ts", ".svelte"}:
+            continue
+        if path.name.endswith(".test.ts") or path.name.endswith(".spec.ts"):
+            continue
+        if "/i18n/" in path.as_posix():
+            continue
+        text = path.read_text()
+        for n, line in enumerate(text.splitlines(), 1):
+            for field in field_re.findall(line):
+                if field not in cols:
+                    missing.append(f"{path}:{n}: it.{field} is not an issues column")
+if missing:
+    print("\n".join(missing))
+PY
+)"
+if [[ -n "$id_first_missing" ]]; then
+  fail "matchesIdFirst id argument is not an issues column (GDK-275):"$'\n'"$id_first_missing"
+fi
+ok "matchesIdFirst id arguments are issues columns"
+
 echo "doc-checks: all passed"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,8 +58,8 @@ export interface IssueLite {
   /** Stable Jira issue-type id. Older cached rows may omit it. */
   issue_type_id?: string
   priority: string | null
-  /** Stable Jira priority id. Older cached rows and current mirrors omit it
-   *  (no issues.priority_id column yet) — match falls back to `priority`. */
+  /** Stable Jira priority id. Older cached rows and mirrors not yet
+   *  resynced may omit it or send '' — match falls back to `priority`. */
   priority_id?: string | null
   priority_rank: number | null
   severity: string | null

--- a/web/src/lib/view-config.test.ts
+++ b/web/src/lib/view-config.test.ts
@@ -14,6 +14,7 @@ import {
   isReopen,
   matchesIdFirst,
   missingStatusCategorySeen,
+  priorityNameFallbackSeen,
   normalizeKeys,
   orderColumns,
   parseConfig,
@@ -283,6 +284,23 @@ describe('matchesIdFirst / prioritySortRank (moved from e2e/identity-web.spec.ts
     expect(prioritySortRank(undefined)).toBe(Number.POSITIVE_INFINITY)
     expect(prioritySortRank(1)).toBe(1)
     expect(prioritySortRank(1)).toBeLessThan(prioritySortRank(0))
+  })
+})
+
+describe('priority id-first filter (GDK-275)', () => {
+  test('id token matches; name token still matches via legacy fallback', () => {
+    expect(matchesIdFirst(['2'], '2', '높음')).toBe(true)
+    expect(matchesIdFirst(['높음'], '2', '높음')).toBe(true)
+    expect(matchesIdFirst(['High'], '2', '높음')).toBe(false)
+    expect(matchesIdFirst(['High'], '', 'High')).toBe(true)
+  })
+
+  test('name fallback increments priorityNameFallbackSeen', () => {
+    const before = priorityNameFallbackSeen()
+    expect(matchesIdFirst(['High'], '', 'High', true)).toBe(true)
+    expect(priorityNameFallbackSeen()).toBe(before + 1)
+    expect(matchesIdFirst(['2'], '2', 'High', true)).toBe(true)
+    expect(priorityNameFallbackSeen()).toBe(before + 1)
   })
 })
 

--- a/web/src/lib/view-config.ts
+++ b/web/src/lib/view-config.ts
@@ -574,20 +574,36 @@ export function missingStatusCategorySeen(): number {
 }
 
 /**
+ * Times a priority filter matched by display name rather than by id.
+ * Integer increment only — no per-row log. Read from the console or a test.
+ */
+let priorityNameFallbackCount = 0
+
+export function priorityNameFallbackSeen(): number {
+  return priorityNameFallbackCount
+}
+
+/**
  * Filter token match: id first, display name only as a fallback for legacy
  * saved views that still store a localized name. Empty `selected` is no
  * constraint (same as the other multi-value axes).
+ *
+ * `notePriorityFallback` is the cheap signal for the priority axis: a
+ * silently-empty filter used to be the only symptom when priority_id was
+ * missing. Status/type leave it off.
  */
 export function matchesIdFirst(
   selected: string[],
   id: string | null | undefined,
   name: string | null | undefined,
+  notePriorityFallback = false,
 ): boolean {
   if (selected.length === 0) return true
   const idv = (id ?? '').trim()
   if (idv && selected.includes(idv)) return true
   const namev = name ?? ''
   if (namev && selected.includes(namev)) {
+    if (notePriorityFallback) priorityNameFallbackCount++
     if (import.meta.env?.DEV && idv) {
       console.debug('[filter] name fallback', { id: idv, name: namev })
     }

--- a/web/src/stores/filters.svelte.ts
+++ b/web/src/stores/filters.svelte.ts
@@ -672,7 +672,7 @@ export function filterIssues(
     if (f.reporter_email.length && !f.reporter_email.some((v) => issueMatchesPerson(it, 'reporter', v)))
       continue
     if (f.team_group.length && !(it.team_group && f.team_group.includes(it.team_group))) continue
-    if (f.priority.length && !matchesIdFirst(f.priority, it.priority_id, it.priority)) continue
+    if (f.priority.length && !matchesIdFirst(f.priority, it.priority_id, it.priority, true)) continue
     if (f.severity.length && !(it.severity && f.severity.includes(it.severity))) continue
     if (f.issue_type.length && !matchesIdFirst(f.issue_type, it.issue_type_id, it.issue_type)) continue
     if (!matchesSelected(f.components, it.components)) continue
@@ -1136,6 +1136,7 @@ function buildFacets(
   const reporterLabels = new Map<string, string>()
   const statusLabels = new Map<string, string>()
   const typeLabels = new Map<string, string>()
+  const priorityLabels = new Map<string, string>()
 
   for (const it of all) {
     bump(counters.status_category, effectiveCategory(it))
@@ -1153,7 +1154,13 @@ function buildFacets(
     if (reporter && !reporterLabels.has(reporter))
       reporterLabels.set(reporter, it.reporter || it.reporter_email || reporter)
     if (it.team_group) bump(counters.team_group, it.team_group)
-    if (it.priority) bump(counters.priority, it.priority)
+    {
+      const priorityToken = it.priority_id || it.priority
+      if (priorityToken) {
+        bump(counters.priority, priorityToken)
+        if (!priorityLabels.has(priorityToken)) priorityLabels.set(priorityToken, it.priority || priorityToken)
+      }
+    }
     if (it.severity) bump(counters.severity, it.severity)
     {
       const typeToken = it.issue_type_id || it.issue_type
@@ -1189,7 +1196,13 @@ function buildFacets(
             ? reporterLabels.get(value)
             : undefined
       const named =
-        field === 'status' ? statusLabels.get(value) : field === 'issue_type' ? typeLabels.get(value) : undefined
+        field === 'status'
+          ? statusLabels.get(value)
+          : field === 'issue_type'
+            ? typeLabels.get(value)
+            : field === 'priority'
+              ? priorityLabels.get(value)
+              : undefined
       return { value, count, label: personLabel ?? named ?? facetLabel(field, value, all, members) }
     })
     values.sort((a, b) => b.count - a.count || (a.label < b.label ? -1 : 1))


### PR DESCRIPTION
`matchesIdFirst(f.priority, it.priority_id, it.priority)` has been id-first since it was written, but `it.priority_id` was always empty: there was no `issues.priority_id` column, so "id-first" was in fact name-only. A saved view that stored `High` matches nothing on an account that renders priorities in another language — silently, no error, no empty state that explains it. `status_id` and `issue_type_id` were already carried; priority was the one left behind, even though sorting has always used `priority_rank`.

Jira sends the id already (`jira.IssueFields.Priority` is a `*NamedID`), so this is plumbing. The mapping lives in `internal/sync`, not `internal/store`, because the store must not import `internal/jira` (`docs/ARCHITECTURE.md:79`, gated since #22).

## The class this closes

Every enumeration site of the issue columns had to carry it:

- `internal/store/schema.go` — `schemaV22`, appended
- `internal/store/write.go` — the INSERT column list, placeholders and values
- `internal/store/read.go` — select + scan
- `internal/snapshot/build.go` — the explicit `issueColumns` list; a column missing there is silently absent from the hosted demo and `export-static`

`schemaV22` also rebuilds `issues_full`: the view expanded `i.*` at CREATE VIEW time, so agents would not have seen the new column otherwise. The view body is byte-identical to its two previous definitions apart from that.

The facet now writes `priority_id || priority` with a label map, copying what `status` and `issue_type` already do, so new selections store an id while the menu still shows the human name. The name fallback in `matchesIdFirst` stays for legacy saved views and keeps its tests; stored views are not migrated.

**The fix takes effect after a sync, not on upgrade.** Existing mirror rows keep `''` until a sync rewrites them, and the name fallback carries them until it does — consistent with the mirror being a disposable cache. `examples/demo.db` is deliberately not regenerated here; that is byte-golden work.

## Recurrence

`tools/doc-checks.sh` check 14 asserts that every column named as the id argument of `matchesIdFirst` is a real column of `issues` in `schema.go`. The old defect was not a display-name literal, so the existing name guard could never have caught it.

FAIL-first, re-run by the lead: removing the `ALTER` from `schemaV22` reproduces

```
FAIL: matchesIdFirst id argument is not an issues column (GDK-275):
web/src/stores/filters.svelte.ts:675: it.priority_id is not an issues column
```

at exit 1; with the migration in place, `ok: matchesIdFirst id arguments are issues columns`.

## Debuggability

`priorityNameFallbackSeen()` counts matches that fell back to the name, following `missingStatusCategorySeen()` from #23 rather than inventing a second mechanism.

## Gates (lead-run, cold, after rebase onto `ffd351f`)

| Gate | Result |
| --- | --- |
| `go build` / `go vet` | rc=0 |
| `go test ./... -count=1` | rc=0, 30 packages ok |
| `tools/check-store-deps.sh` | rc=0 |
| `make typecheck` | rc=0, 4250 files, 0 errors |
| `npm run test:unit` | rc=0, 34 files / 349 tests |
| `tools/doc-checks.sh` | rc=0, all passed |
| `npx playwright test` | rc=0, 240 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)