### PR TITLE
ci: two gates this project calls required ran nowhere (GDK-288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,18 @@ jobs:
       - name: Store dependency firewall
         run: bash tools/check-store-deps.sh
 
+      # Example plugin self-tests (make plugins-test). Not path-scoped: a
+      # plugin contract can be broken by a change to the API those plugins
+      # call, not only by edits under examples/plugins/.
+      - name: Example plugin self-tests
+        run: make plugins-test
+
+      # Documentation-factuality contract (tools/doc-checks.sh). Not
+      # path-scoped: a documentation claim can be falsified by a code change
+      # anywhere.
+      - name: Documentation factuality
+        run: bash tools/doc-checks.sh
+
       # The web build has to precede the Go build: go:embed compiles dist/app
       # into the binary, so the serve smoke below exercises the real embedded UI
       # rather than the tracked placeholder.


### PR DESCRIPTION
`make plugins-test` and `tools/doc-checks.sh` are both treated as required by this project — the Makefile defines the first, `CLAUDE.md:53` tells you to run the second before committing — and `grep -n 'plugins-test\|doc-checks' .github/workflows/*.yml` returned nothing. A test that never runs is worse than no test, because it is counted.

The contrast is what makes it a defect rather than a gap: `theme-check` is in CI, the hosted Playwright run is in `pages.yml`, and Omarchy/Scoop/AUR each have their own workflow. These two were simply missed.

## The change

Two steps on the existing `build` job, unconditional and **not** path-scoped, each with a comment saying why — a plugin contract breaks from a change to the API those plugins call, and a documentation claim is falsified by a code change anywhere. A path filter would make both pass precisely when they matter.

Placement is after the store-dependency firewall, before the frontend build: both are source-contract checks with no compile step, so a stale doc or a broken plugin fails before CI pays for `go:embed` and the Go tests.

## Prerequisites, checked rather than assumed

The plugin `test.sh` files call `python3 … --self-test`; they need python3/git/bash and **not** a built `bin/gadak`, Node, or `examples/demo.db`. `doc-checks` needs `sqlite3`, which the `scan` job on the same `ubuntu-latest` already uses without installing it.

## Does this turn CI red?

No — verified cold on `731e71d`:

- `make plugins-test` → exit 0 (three plugins, `self-test ok` each)
- `bash tools/doc-checks.sh` → exit 0, 15 checks passing

doc-checks check 6 (README/STATE_OF_PLAY vs the latest tag) **skips** rather than fails when no tag is reachable, which is what a shallow `actions/checkout@v4` gives it.

## No recurrence gate, deliberately

A scanner comparing Makefile test-ish targets against `ci.yml` needs an allowlist of the deliberate absences — `bench` ("machine variance is too high"), `hosted-demo-test` ("not in CI"), `docker`, `media*`. A check whose allowlist is edited alongside the thing it checks passes forever. Declined with the argument rather than shipped as decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)