### PR TITLE
test(e2e): four bootstrap waits were sleeping, not waiting (GDK-290)

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -167,6 +167,11 @@ export async function walkRows(
     await scroller.evaluate((el) => {
       el.scrollTop += el.clientHeight * 0.8
     })
+    // A render settle, not a boot wait: the virtualised list rebuilds its
+    // window on the frame after scrollTop moves. There is no state to observe
+    // here — the next batch is precisely what this loop is about to read, and
+    // the steps overlap by 20%, so "the rows changed" is not a safe signal
+    // either. One frame plus slack, and `atEnd` above is what ends the loop.
     await scroller.page().waitForTimeout(30)
   }
   await scroller.evaluate((el) => {

--- a/e2e/keys-focus.spec.ts
+++ b/e2e/keys-focus.spec.ts
@@ -65,6 +65,8 @@ test.describe('keys view and ui-focus', () => {
     // unchanged: no NEW requests while hidden.
     await page.waitForTimeout(600)
     const before = hits.length
+    // 500ms poll × 3 plus slack: the contract is that the count stays put
+    // across an elapsed interval; there is no other "poll did not fire" state.
     await page.waitForTimeout(1600)
     expect(
       hits.length,

--- a/e2e/no-bare-timeout.spec.ts
+++ b/e2e/no-bare-timeout.spec.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from '@playwright/test'
+
+/*
+ * GDK-290: a waitForTimeout whose PASS means "N ms elapsed" is the flake class.
+ * A duration wait is allowed only when the line (or the line immediately above)
+ * names why the duration itself is the thing under test (CSS transition, poll
+ * interval, elapsed-threshold). Sleep-to-hope-boot-finished is not that.
+ *
+ * demo/ hosted/ perf/ are their own suites (playwright.config testIgnore).
+ * helpers.ts is outside this round's e2e/*.spec.ts whitelist — walkRows' 30ms
+ * scroll settle is a real duration wait; the lead can add the comment.
+ */
+
+const E2E = dirname(fileURLToPath(import.meta.url))
+const SKIP_DIRS = new Set(['demo', 'hosted', 'perf', '.tmp', 'node_modules'])
+const SKIP_FILES = new Set(['helpers.ts'])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (name.endsWith('.ts')) out.push(p)
+  }
+  return out
+}
+
+function isComment(line: string | undefined): boolean {
+  if (line === undefined) return false
+  const t = line.trim()
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')
+}
+
+export function bareTimeouts(root = E2E): string[] {
+  const hits: string[] = []
+  for (const file of walk(root)) {
+    if (SKIP_FILES.has(relative(root, file))) continue
+    const lines = readFileSync(file, 'utf8').split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      if (!/\.waitForTimeout\s*\(/.test(lines[i])) continue
+      if (lines[i].includes('//') || isComment(lines[i - 1])) continue
+      hits.push(`${relative(root, file)}:${i + 1}: ${lines[i].trim()}`)
+    }
+  }
+  return hits
+}
+
+test('every waitForTimeout in e2e/*.spec.ts names why the duration is the contract', () => {
+  const hits = bareTimeouts()
+  expect(
+    hits,
+    `bare waitForTimeout — add a why-comment on the same line or the line above:\n${hits.join('\n')}`,
+  ).toEqual([])
+})

--- a/e2e/no-bare-timeout.spec.ts
+++ b/e2e/no-bare-timeout.spec.ts
@@ -10,13 +10,12 @@ import { expect, test } from '@playwright/test'
  * interval, elapsed-threshold). Sleep-to-hope-boot-finished is not that.
  *
  * demo/ hosted/ perf/ are their own suites (playwright.config testIgnore).
- * helpers.ts is outside this round's e2e/*.spec.ts whitelist — walkRows' 30ms
- * scroll settle is a real duration wait; the lead can add the comment.
+ * Nothing else is exempt: a helper's sleep flakes every spec that calls it,
+ * so the one place a file-level exemption would hurt most is the helpers.
  */
 
 const E2E = dirname(fileURLToPath(import.meta.url))
 const SKIP_DIRS = new Set(['demo', 'hosted', 'perf', '.tmp', 'node_modules'])
-const SKIP_FILES = new Set(['helpers.ts'])
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const name of readdirSync(dir)) {
@@ -37,7 +36,6 @@ function isComment(line: string | undefined): boolean {
 export function bareTimeouts(root = E2E): string[] {
   const hits: string[] = []
   for (const file of walk(root)) {
-    if (SKIP_FILES.has(relative(root, file))) continue
     const lines = readFileSync(file, 'utf8').split('\n')
     for (let i = 0; i < lines.length; i++) {
       if (!/\.waitForTimeout\s*\(/.test(lines[i])) continue

--- a/e2e/palette.spec.ts
+++ b/e2e/palette.spec.ts
@@ -7,17 +7,28 @@ test.describe('command palette', () => {
     await gotoApp(page)
 
     // Let the post-boot API chatter (bootstrap/write-meta) settle first.
-    // Wait for the boot payload to land, plus a short settle for the trailing
-    // boot requests. Deliberately not networkidle: the app polls for a delta
+    // Wait for the boot payload to land, plus trailing boot / focus-time
+    // pull to finish. Deliberately not networkidle: the app polls for a delta
     // every 15s, so "no network for 500ms" only becomes true after that poll
     // fires, which added 15s to this test for nothing.
     await expect(page.getByText(/534 issues/).first()).toBeVisible({ timeout: 30_000 })
-    await page.waitForTimeout(300)
+    // Same observable ux-p1.spec.ts uses: chip data-state=syncing is
+    // mirrorBusy (focus-time pull or background pass), not a duration.
+    await expect(page.getByTestId('freshness-chip')).not.toHaveAttribute('data-state', 'syncing', {
+      timeout: 30_000,
+    })
 
     const apiDuringType: string[] = []
     page.on('request', (req) => {
       const url = req.url()
-      if (url.includes('/api/') && !url.includes('/ui-focus/')) apiDuringType.push(url)
+      if (!url.includes('/api/') || url.includes('/ui-focus/')) return
+      let path = url
+      try {
+        path = new URL(url).pathname
+      } catch {
+        /* keep raw */
+      }
+      apiDuringType.push(`${req.method()} ${path}`)
     })
 
     await page.keyboard.press('ControlOrMeta+k')
@@ -31,7 +42,7 @@ test.describe('command palette', () => {
 
     expect(
       apiDuringType,
-      `expected no /api/ requests while typing, got:\n${apiDuringType.join('\n')}`,
+      `in-flight /api/ while typing (must be none): ${apiDuringType.join(', ') || '(none)'}`,
     ).toEqual([])
 
     await page.keyboard.press('Enter')

--- a/e2e/person.spec.ts
+++ b/e2e/person.spec.ts
@@ -59,7 +59,12 @@ test.describe('people axis', () => {
   }) => {
     const errors = attachConsoleErrors(page)
     await gotoApp(page)
-    await page.waitForTimeout(300)
+    // Same observable ux-p1.spec.ts uses: chip data-state=syncing is
+    // mirrorBusy (focus-time pull or background pass), not a duration.
+    // Deliberately not networkidle: the 15s delta poll would make that wait 15s.
+    await expect(page.getByTestId('freshness-chip')).not.toHaveAttribute('data-state', 'syncing', {
+      timeout: 30_000,
+    })
 
     // Members ride the bootstrap payload, so matching a person must not cost a
     // request — the same contract the issue section keeps. The ui-focus poll
@@ -69,7 +74,14 @@ test.describe('people axis', () => {
     const apiDuringType: string[] = []
     page.on('request', (req) => {
       const url = req.url()
-      if (url.includes('/api/') && !url.includes('/ui-focus/')) apiDuringType.push(url)
+      if (!url.includes('/api/') || url.includes('/ui-focus/')) return
+      let path = url
+      try {
+        path = new URL(url).pathname
+      } catch {
+        /* keep raw */
+      }
+      apiDuringType.push(`${req.method()} ${path}`)
     })
 
     await page.keyboard.press('ControlOrMeta+k')
@@ -91,7 +103,7 @@ test.describe('people axis', () => {
 
     expect(
       apiDuringType,
-      `expected no /api/ requests while typing, got:\n${apiDuringType.join('\n')}`,
+      `in-flight /api/ while typing (must be none): ${apiDuringType.join(', ') || '(none)'}`,
     ).toEqual([])
 
     await page.keyboard.press('Enter')

--- a/e2e/search-entry.spec.ts
+++ b/e2e/search-entry.spec.ts
@@ -18,12 +18,37 @@ async function openDocuments(page: Page): Promise<void> {
   await expect(page.getByTestId('docs-view')).toBeVisible()
 }
 
-/** Let the boot chatter (bootstrap / write-meta / pages) finish before a spec
- *  starts counting requests. Deliberately not networkidle: the app polls for a
- *  delta every 15s, so "quiet for 500ms" only becomes true after that fires. */
+/** Let the boot chatter (bootstrap / write-meta / pages / focus-time pull)
+ *  finish before a spec starts counting requests. Deliberately not networkidle:
+ *  the app polls for a delta every 15s, so "quiet for 500ms" only becomes true
+ *  after that fires. */
 async function settled(page: Page): Promise<void> {
   await expect(page.getByText(/534 issues/).first()).toBeVisible({ timeout: 30_000 })
-  await page.waitForTimeout(300)
+  // Same observable ux-p1.spec.ts uses. The chip lives on ListView; documents
+  // unmount that column, so the sidebar row (same mirrorBusy sentence) is the
+  // stand-in — it stays mounted on every main-column screen.
+  const chip = page.getByTestId('freshness-chip')
+  if ((await chip.count()) > 0) {
+    await expect(chip).not.toHaveAttribute('data-state', 'syncing', { timeout: 30_000 })
+    return
+  }
+  await expect(page.getByTestId('sidebar-sync-now')).not.toContainText(/Syncing|Fetching/, {
+    timeout: 30_000,
+  })
+}
+
+function recordApiDuringType(page: Page, sink: string[]): void {
+  page.on('request', (req) => {
+    const url = req.url()
+    if (!url.includes('/api/') || url.includes('/ui-focus/')) return
+    let path = url
+    try {
+      path = new URL(url).pathname
+    } catch {
+      /* keep raw */
+    }
+    sink.push(`${req.method()} ${path}`)
+  })
 }
 
 test.describe('search entry points', () => {
@@ -35,10 +60,7 @@ test.describe('search entry points', () => {
     await settled(page)
 
     const apiDuringType: string[] = []
-    page.on('request', (req) => {
-      const url = req.url()
-      if (url.includes('/api/') && !url.includes('/ui-focus/')) apiDuringType.push(url)
-    })
+    recordApiDuringType(page, apiDuringType)
 
     await page.keyboard.press('ControlOrMeta+k')
     const palette = page.getByRole('dialog', { name: 'Command palette' })
@@ -76,7 +98,7 @@ test.describe('search entry points', () => {
 
     expect(
       apiDuringType,
-      `expected no /api/ requests while typing, got:\n${apiDuringType.join('\n')}`,
+      `in-flight /api/ while typing (must be none): ${apiDuringType.join(', ') || '(none)'}`,
     ).toEqual([])
 
     // Choosing one opens the page, the same as it always did from the recent list.
@@ -135,10 +157,7 @@ test.describe('search entry points', () => {
     expect(before).toBeGreaterThan(0)
 
     const apiDuringType: string[] = []
-    page.on('request', (req) => {
-      const url = req.url()
-      if (url.includes('/api/') && !url.includes('/ui-focus/')) apiDuringType.push(url)
-    })
+    recordApiDuringType(page, apiDuringType)
 
     const filter = page.getByTestId('docs-filter-input')
     await filter.click()
@@ -151,7 +170,7 @@ test.describe('search entry points', () => {
 
     expect(
       apiDuringType,
-      `expected no /api/ requests while filtering, got:\n${apiDuringType.join('\n')}`,
+      `in-flight /api/ while filtering (must be none): ${apiDuringType.join(', ') || '(none)'}`,
     ).toEqual([])
 
     // Nothing matched is a state with a way out of it, not a dead end.

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -6,17 +6,28 @@ test.describe('client-side search', () => {
     const errors = attachConsoleErrors(page)
     await gotoApp(page)
 
-    // Wait for the boot payload to land, plus a short settle for the trailing
-    // boot requests. Deliberately not networkidle: the app polls for a delta
+    // Wait for the boot payload to land, plus trailing boot / focus-time
+    // pull to finish. Deliberately not networkidle: the app polls for a delta
     // every 15s, so "no network for 500ms" only becomes true after that poll
     // fires, which added 15s to this test for nothing.
     await expect(page.getByText(/534 issues/).first()).toBeVisible({ timeout: 30_000 })
-    await page.waitForTimeout(300)
+    // Same observable ux-p1.spec.ts uses: chip data-state=syncing is
+    // mirrorBusy (focus-time pull or background pass), not a duration.
+    await expect(page.getByTestId('freshness-chip')).not.toHaveAttribute('data-state', 'syncing', {
+      timeout: 30_000,
+    })
 
     const apiDuringType: string[] = []
     page.on('request', (req) => {
       const url = req.url()
-      if (url.includes('/api/') && !url.includes('/ui-focus/')) apiDuringType.push(url)
+      if (!url.includes('/api/') || url.includes('/ui-focus/')) return
+      let path = url
+      try {
+        path = new URL(url).pathname
+      } catch {
+        /* keep raw */
+      }
+      apiDuringType.push(`${req.method()} ${path}`)
     })
 
     const input = searchInput(page)
@@ -32,7 +43,7 @@ test.describe('client-side search', () => {
 
     expect(
       apiDuringType,
-      `expected no /api/ requests while typing, got:\n${apiDuringType.join('\n')}`,
+      `in-flight /api/ while typing (must be none): ${apiDuringType.join(', ') || '(none)'}`,
     ).toEqual([])
 
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])


### PR DESCRIPTION
Four specs asserted "no `/api/` traffic while typing" after `waitForTimeout(300)`. PASS meant *300 ms elapsed*, not *the bootstrap traffic finished* — so on a slower machine the same four tests are a false green, and the day one goes red it reads as a product bug rather than a timing one.

- `e2e/search.spec.ts:14`
- `e2e/search-entry.spec.ts:26` (inside `settled()`)
- `e2e/palette.spec.ts:15`
- `e2e/person.spec.ts:62`

## The fix

All four wait on the observable `e2e/ux-p1.spec.ts` already reached for when it hit this exact problem: the freshness chip's `data-state` leaving `syncing`, which is `issues.mirrorBusy`.

`search-entry`'s `settled()` needs a second observable, and it says why: the documents screen unmounts `ListView` and the chip with it, so it falls back to the sidebar's sync control, which renders the same busy sentence.

`networkidle` stays ruled out and its comment stays with it — the app polls for a delta every 15 s, so "quiet for 500 ms" only becomes true after that poll fires, which is 15 s this test does not need to pay.

## The two adjacent candidates: judged, not batched

- `e2e/docs-ux.spec.ts:923` — **left.** The duration *is* the contract: a stubbed 500 ms-old pass against a 4000 ms `ACTIVITY_MIN_VISIBLE_MS`, so 1500 ms is "two polls in, still young". A state wait would delete half the threshold test.
- `e2e/narrow-viewport.spec.ts:112` — **left.** Line 108 already asserts `data-detail-open`; the 350 ms waits out a 150 ms slide so geometry is measured at rest. A CSS transition has no other end state.
- `e2e/keys-focus.spec.ts:70` — a poll-interval contract; it got the why-comment it was missing.

## Recurrence

`e2e/no-bare-timeout.spec.ts` fails on a bare `waitForTimeout` unless the line or the one above it says why the duration is the thing under test. It flagged all five sites on the unmodified tree.

The second commit is a lead fix to that gate: it originally exempted `e2e/helpers.ts`, because helpers.ts was outside the round's file whitelist. That is an exemption from how the work was divided, not from anything true about the file — and it is the worst file to exempt, since a helper's sleep flakes every spec that calls it. Exemption dropped; `walkRows`' 30 ms wait now explains itself and stands. FAIL-first for the widened scope reported exactly `helpers.ts:170`.

## Debuggability

Zero-traffic failures now name what was in flight — `in-flight /api/ while typing (must be none): GET /api/v1/issues/meta/write/` — instead of an empty-array mismatch.

## Gates

`npx playwright test --config e2e/playwright.config.ts` — **241 passed**, run cold by the lead after the helpers change, and twice by the round before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)