### PR TITLE
refactor(web): five functions answered "what category is this?" and disagreed (GDK-279)

### DIFF
--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -390,4 +390,111 @@ if [[ -n "$id_first_missing" ]]; then
 fi
 ok "matchesIdFirst id arguments are issues columns"
 
+# ── 15. One owner for "what category is this status?" (GDK-279) ─────────
+# The display-name grep (check 7) cannot see this class: two functions that
+# both lowercase a raw status_category and return the 3-bucket set can
+# disagree on the same key (list used effectiveCategory, the transition
+# control used normalizeCategory; complete/todo painted differently).
+# The owner is effectiveCategory. A second mapper of that shape is the
+# recurrence. Color/rank adapters that consume the owner's buckets are not
+# mappers. FAIL-first 2026-08-19: unmodified tree listed effectiveCategory
+# and normalizeCategory.
+second_category_mappers=$(
+  python3 - <<'GDK279PY'
+import re
+from pathlib import Path
+
+FUNC_START = re.compile(r"(?:export\s+)?function\s+([A-Za-z0-9_]+)\s*\(")
+# Bare bucket return — not return "bg-status-done" or return categoryMetaOf(...).
+BUCKET_RETURN = re.compile(r"return\s+['\"](?:new|inprogress|done)['\"]")
+HAS_NEW = re.compile(r"['\"]new['\"]")
+HAS_DONE = re.compile(r"['\"]done['\"]")
+# `const c = (key || '').toLowerCase()` — the local a mapper then branches on.
+LOWERED_ASSIGN = re.compile(r"\b(?:const|let|var)\s+([A-Za-z0-9_$]+)\s*=[^;\n]*\.toLowerCase\(\)")
+# `key.toLowerCase() === 'done'` — the same decision without the local.
+LOWERED_INLINE_CMP = re.compile(
+    r"\.toLowerCase\(\)\s*[=!]==?\s*['\"](?:new|inprogress|done)['\"]"
+    r"|['\"](?:new|inprogress|done)['\"]\s*[=!]==?\s*[^;\n]*\.toLowerCase\(\)"
+)
+
+def function_bodies(text):
+    for m in FUNC_START.finditer(text):
+        name = m.group(1)
+        depth_paren = 0
+        depth_brace = 0
+        body_start = None
+        for j in range(m.end() - 1, len(text)):
+            ch = text[j]
+            if ch == "(":
+                depth_paren += 1
+            elif ch == ")":
+                depth_paren -= 1
+            elif ch == "{" and depth_paren == 0:
+                if body_start is None:
+                    body_start = j
+                    depth_brace = 1
+                else:
+                    depth_brace += 1
+            elif ch == "}" and depth_paren == 0 and body_start is not None:
+                depth_brace -= 1
+                if depth_brace == 0:
+                    yield name, m.start(), text[body_start : j + 1]
+                    break
+
+def is_category_mapper(body):
+    # Class: lowercase a raw key yourself, then compare *that* against the
+    # bucket names. What the function returns is not the tell — BulkBar's
+    # catDot returned 'bg-status-done' and its jiraRank returned a number, and
+    # both were still second opinions on "what category is this?" (found by the
+    # lead reviewing GDK-279, after a return-shaped version of this check
+    # missed them).
+    #
+    # Two shapes are deliberately not this class:
+    #   - an adapter that calls effectiveCategory and switches on its result —
+    #     it lowercases nothing of its own;
+    #   - BreakdownBar's groupColor, which lowercases for 'fail'/'pass' and
+    #     delegates the category branch to categoryMetaOf. Merely mentioning
+    #     'new' and 'done' somewhere in the body is not enough.
+    if ".toLowerCase(" not in body:
+        return False
+    if not (HAS_NEW.search(body) and HAS_DONE.search(body)):
+        return False
+    if LOWERED_INLINE_CMP.search(body):
+        return True
+    for var in {m.group(1) for m in LOWERED_ASSIGN.finditer(body)}:
+        if re.search(r"\b%s\b\s*[=!]==?\s*['\"](?:new|inprogress|done)['\"]" % re.escape(var), body):
+            return True
+        if re.search(r"['\"](?:new|inprogress|done)['\"]\s*[=!]==?\s*\b%s\b" % re.escape(var), body):
+            return True
+    return False
+
+hits = []
+roots = [Path("web/src/lib"), Path("web/src/components"), Path("web/src/stores")]
+for root in roots:
+    for path in root.rglob("*"):
+        if path.suffix not in {".ts", ".svelte"}:
+            continue
+        if path.name.endswith(".test.ts") or path.name.endswith(".spec.ts"):
+            continue
+        if "/i18n/" in path.as_posix():
+            continue
+        text = path.read_text()
+        for name, start, body in function_bodies(text):
+            if not is_category_mapper(body):
+                continue
+            line = text.count("\n", 0, start) + 1
+            hits.append((path.as_posix(), line, name))
+
+owners = [h for h in hits if h[2] == "effectiveCategory"]
+others = [h for h in hits if h[2] != "effectiveCategory"]
+if len(owners) != 1 or others:
+    for p, n, name in hits:
+        print("%s:%s: %s" % (p, n, name))
+GDK279PY
+)
+if [[ -n "$second_category_mappers" ]]; then
+  fail "web has a second status-category mapper — fold aliases in effectiveCategory only (GDK-279):"$'\n'"$second_category_mappers"
+fi
+ok "effectiveCategory is the only status-category mapper in web/"
+
 echo "doc-checks: all passed"

--- a/web/src/components/detail/EpicProgress.svelte
+++ b/web/src/components/detail/EpicProgress.svelte
@@ -11,7 +11,7 @@
   import type { IssueLite } from '../../lib/types'
   import { issues } from '../../stores/issues.svelte'
   import { selection } from '../../stores/selection.svelte'
-  import { CATEGORY_META, categoryOf } from '../../lib/format'
+  import { categoryMetaOf, categoryOf } from '../../lib/format'
   import Section from './Section.svelte'
 
   let { issueKey }: { issueKey: string } = $props()
@@ -50,7 +50,7 @@
         <div
           class="h-full rounded-full transition-[width]"
           style:width="{percent}%"
-          style:background={CATEGORY_META.done.color}
+          style:background={categoryMetaOf('done').color}
         ></div>
       </div>
     </div>
@@ -66,7 +66,7 @@
           >
             <span
               class="h-1.5 w-1.5 flex-none rounded-full"
-              style:background={CATEGORY_META[categoryOf(child)].color}
+              style:background={categoryMetaOf(categoryOf(child)).color}
               title={child.status}
             ></span>
             <span class="w-[76px] flex-none truncate font-mono text-micro font-medium text-accent-text">

--- a/web/src/components/detail/RelatedIssues.svelte
+++ b/web/src/components/detail/RelatedIssues.svelte
@@ -18,7 +18,7 @@
   import type { IssueLite } from '../../lib/types'
   import { issues } from '../../stores/issues.svelte'
   import { selection } from '../../stores/selection.svelte'
-  import { CATEGORY_META, categoryOf } from '../../lib/format'
+  import { categoryMetaOf, categoryOf } from '../../lib/format'
 
   let {
     refKeys = [],
@@ -71,7 +71,7 @@
           {#if row.issue}
             <span
               class="block h-full w-full rounded-full"
-              style:background={CATEGORY_META[categoryOf(row.issue)].color}
+              style:background={categoryMetaOf(categoryOf(row.issue)).color}
               title={row.issue.status}
             ></span>
           {/if}

--- a/web/src/components/detail/format.ts
+++ b/web/src/components/detail/format.ts
@@ -1,20 +1,11 @@
 /*
  * Shared format helpers for the detail panel ([detail]).
- * Pure functions only: relative time, status-category normalize, etc.
+ * Pure functions only: relative time, browse URL, etc.
  */
 
 import { jiraBrowseUrl } from '../../lib/config'
 import type { StatusCategory } from '../../lib/types'
 import { absTime as i18nAbsTime, relativeTime as i18nRelativeTime } from '../../lib/i18n'
-
-/** Normalize Jira status_category strings into the UI's 3 buckets. */
-export function normalizeCategory(raw: string | null | undefined): StatusCategory {
-  const c = (raw ?? '').toLowerCase()
-  if (c === 'done' || c === 'complete' || c === 'completed') return 'done'
-  if (c === 'new' || c === 'todo' || c === 'to do') return 'new'
-  // "indeterminate" (in progress) and anything else → inprogress
-  return 'inprogress'
-}
 
 /** Status category → semantic color token name (app.css @theme --color-status-*). */
 export function categoryColor(cat: StatusCategory): string {

--- a/web/src/components/list/BreakdownBar.svelte
+++ b/web/src/components/list/BreakdownBar.svelte
@@ -2,8 +2,8 @@
   /* Section the list by a chosen field and summarize top distribution in one line. */
   import { t } from '../../lib/i18n'
   import { filters } from '../../stores/filters.svelte'
-  import { CATEGORY_META } from '../../lib/format'
-  import { groupByEnabled, type GroupBy, type StatusCategory } from '../../lib/view-config'
+  import { categoryMetaOf } from '../../lib/format'
+  import { groupByEnabled, type GroupBy } from '../../lib/view-config'
   import Icon, { type IconName } from '../ui/Icon.svelte'
 
   const ALL_OPTIONS: { key: GroupBy; label: string }[] = [
@@ -52,8 +52,8 @@
   }
 
   function groupColor(key: string, index: number): string {
-    if (filters.display.group_by === 'status_category' && key in CATEGORY_META) {
-      return CATEGORY_META[key as StatusCategory].color
+    if (filters.display.group_by === 'status_category' && (key === 'new' || key === 'inprogress' || key === 'done')) {
+      return categoryMetaOf(key).color
     }
     if (filters.display.group_by === 'development_test_result') {
       if (key.toLowerCase() === 'fail') return 'var(--color-status-reopen)'

--- a/web/src/components/list/BulkBar.svelte
+++ b/web/src/components/list/BulkBar.svelte
@@ -26,6 +26,7 @@
   import { issues } from '../../stores/issues.svelte'
   import { write } from '../../stores/write.svelte'
   import { recentOf } from '../../lib/recency'
+  import { effectiveCategory } from '../../lib/view-config'
   import { onOutsideClick } from '../../lib/dom-actions'
   import Avatar from './Avatar.svelte'
 
@@ -37,18 +38,15 @@
   let running = $state(false)
   let progress = $state<{ done: number; total: number }>({ done: 0, total: 0 })
 
-  /** Category rank (forward-direction sort priority). */
+  /** Category rank (forward-direction sort priority), via the category owner. */
   function jiraRank(key: string): number {
-    const c = (key || '').toLowerCase()
-    if (c === 'new') return 0
-    if (c === 'done') return 2
-    return 1
+    const c = effectiveCategory(key)
+    return c === 'new' ? 0 : c === 'done' ? 2 : 1
   }
+  /** Jira statusCategory key → dot color class (via the single category owner). */
   function catDot(key: string): string {
-    const c = (key || '').toLowerCase()
-    if (c === 'done') return 'bg-status-done'
-    if (c === 'new') return 'bg-status-new'
-    return 'bg-status-inprogress'
+    const c = effectiveCategory(key)
+    return c === 'done' ? 'bg-status-done' : c === 'new' ? 'bg-status-new' : 'bg-status-inprogress'
   }
 
   interface StatusOption {

--- a/web/src/components/list/GroupHeader.svelte
+++ b/web/src/components/list/GroupHeader.svelte
@@ -6,7 +6,7 @@
   import { t } from '../../lib/i18n'
   import type { IssueGroup } from '../../stores/filters.svelte'
   import { selection } from '../../stores/selection.svelte'
-  import { CATEGORY_META } from '../../lib/format'
+  import { categoryMetaOf } from '../../lib/format'
   import type { StatusCategory } from '../../lib/view-config'
 
   let {
@@ -55,8 +55,8 @@
     <span class="flex flex-none items-center gap-2">
       {#each order as c (c)}
         {#if group.counts.category[c] > 0}
-          <span class="flex items-center gap-1 text-micro text-text-muted" title={CATEGORY_META[c].label}>
-            <span class="h-1.5 w-1.5 rounded-full" style:background={CATEGORY_META[c].color}></span>
+          <span class="flex items-center gap-1 text-micro text-text-muted" title={categoryMetaOf(c).label}>
+            <span class="h-1.5 w-1.5 rounded-full" style:background={categoryMetaOf(c).color}></span>
             {group.counts.category[c]}
           </span>
         {/if}

--- a/web/src/components/list/IssueRow.svelte
+++ b/web/src/components/list/IssueRow.svelte
@@ -24,7 +24,7 @@
   import { bulk } from '../../stores/bulk.svelte'
   import { watches } from '../../stores/watches.svelte'
   import { favorites } from '../../stores/favorites.svelte'
-  import { categoryOf, CATEGORY_META, relativeTime, absTime, highlightSegments } from '../../lib/format'
+  import { categoryOf, categoryMetaOf, relativeTime, absTime, highlightSegments } from '../../lib/format'
   import { calendarDay } from '../../lib/calendar'
   import Marks from '../ui/Marks.svelte'
   import { matchEvidence } from '../../lib/search-match'
@@ -51,7 +51,7 @@
   } = $props()
 
   const cat = $derived(categoryOf(issue))
-  const catMeta = $derived(CATEGORY_META[cat])
+  const catMeta = $derived(categoryMetaOf(cat))
   const isFavorite = $derived(favorites.keys.has(issue.issue_key))
   const isWatching = $derived(watches.keys.has(issue.issue_key))
   // Stale (time in current status). Badge is day-based — floor at 1 so sub-day reads "day 1".

--- a/web/src/components/write/StatusTransition.svelte
+++ b/web/src/components/write/StatusTransition.svelte
@@ -15,7 +15,7 @@
   import { write } from '../../stores/write.svelte'
   import { me } from '../../stores/me.svelte'
   import { recentOf } from '../../lib/recency'
-  import { normalizeCategory } from '../detail/format'
+  import { effectiveCategory } from '../../lib/view-config'
   import { onEscape, onOutsideClick } from '../../lib/dom-actions'
 
   let { issue }: { issue: IssueLite } = $props()
@@ -28,26 +28,22 @@
   let busyId = $state<string | null>(null)
   let listEl = $state<HTMLDivElement | null>(null)
 
-  const cat = $derived(normalizeCategory(issue.status_category))
+  const cat = $derived(effectiveCategory(issue))
   const dotClass = $derived(
     cat === 'done' ? 'bg-status-done' : cat === 'new' ? 'bg-status-new' : 'bg-status-inprogress',
   )
 
-  /** Jira statusCategory key → dot color class. */
+  /** Jira statusCategory key → dot color class (via the single category owner). */
   function catDot(key: string): string {
-    const c = (key || '').toLowerCase()
-    if (c === 'done') return 'bg-status-done'
-    if (c === 'new') return 'bg-status-new'
-    return 'bg-status-inprogress'
+    const c = effectiveCategory(key)
+    return c === 'done' ? 'bg-status-done' : c === 'new' ? 'bg-status-new' : 'bg-status-inprogress'
   }
 
   /** Current category rank (new=0, inprogress=1, done=2) — for forward-direction. */
   const curRank = $derived(cat === 'new' ? 0 : cat === 'done' ? 2 : 1)
   function jiraRank(key: string): number {
-    const c = (key || '').toLowerCase()
-    if (c === 'new') return 0
-    if (c === 'done') return 2
-    return 1 // indeterminate etc.
+    const c = effectiveCategory(key)
+    return c === 'new' ? 0 : c === 'done' ? 2 : 1
   }
 
   /** Sorted transitions (local first → fallback). */

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -176,28 +176,6 @@ export function categoryMetaOf(cat: StatusCategory): { label: string; color: str
   return { label: categoryLabel(cat), color }
 }
 
-/** @deprecated prefer categoryMetaOf — kept as getter-style for call sites. */
-export const CATEGORY_META: Record<StatusCategory, { get label(): string; color: string }> = {
-  new: {
-    get label() {
-      return categoryLabel('new')
-    },
-    color: 'var(--color-status-new)',
-  },
-  inprogress: {
-    get label() {
-      return categoryLabel('inprogress')
-    },
-    color: 'var(--color-status-inprogress)',
-  },
-  done: {
-    get label() {
-      return categoryLabel('done')
-    },
-    color: 'var(--color-status-done)',
-  },
-}
-
 export function categoryOf(issue: IssueLite): StatusCategory {
   return effectiveCategory(issue)
 }

--- a/web/src/lib/view-config.test.ts
+++ b/web/src/lib/view-config.test.ts
@@ -9,6 +9,7 @@ import {
   KEYS_CAP,
   configToParams,
   defaultGroupBy,
+  categoryFallbackSeen,
   effectiveCategory,
   emptyConfig,
   isReopen,
@@ -450,6 +451,53 @@ describe('effectiveCategory (GDK-272)', () => {
     const before = missingStatusCategorySeen()
     effectiveCategory(issueRow('완료', 'done'))
     expect(missingStatusCategorySeen()).toBe(before)
+  })
+
+  test('Jira REST key indeterminate folds to inprogress', () => {
+    expect(effectiveCategory(issueRow('Anything', 'indeterminate'))).toBe('inprogress')
+    expect(effectiveCategory('indeterminate')).toBe('inprogress')
+    expect(effectiveCategory('INDETERMINATE')).toBe('inprogress')
+  })
+
+  test('migrated aliases: todo → new, complete/completed → done', () => {
+    expect(effectiveCategory(issueRow('Anything', 'todo'))).toBe('new')
+    expect(effectiveCategory('todo')).toBe('new')
+    expect(effectiveCategory('TODO')).toBe('new')
+    expect(effectiveCategory(issueRow('Anything', 'complete'))).toBe('done')
+    expect(effectiveCategory('complete')).toBe('done')
+    expect(effectiveCategory('completed')).toBe('done')
+    expect(effectiveCategory('COMPLETED')).toBe('done')
+  })
+
+  test("display name 'to do' is not a category key (GDK-272)", () => {
+    expect(effectiveCategory('to do')).toBe('inprogress')
+    expect(effectiveCategory(issueRow('To Do', 'to do'))).toBe('inprogress')
+  })
+
+  test('unknown non-empty key increments categoryFallbackSeen', () => {
+    const before = categoryFallbackSeen()
+    expect(effectiveCategory(issueRow('Anything', 'undefined'))).toBe('inprogress')
+    expect(categoryFallbackSeen()).toBe(before + 1)
+  })
+
+  test('trusted keys and folded aliases do not increment categoryFallbackSeen', () => {
+    const before = categoryFallbackSeen()
+    effectiveCategory(issueRow('Anything', 'new'))
+    effectiveCategory(issueRow('Anything', 'inprogress'))
+    effectiveCategory(issueRow('Anything', 'done'))
+    effectiveCategory('indeterminate')
+    effectiveCategory('todo')
+    effectiveCategory('complete')
+    effectiveCategory('completed')
+    expect(categoryFallbackSeen()).toBe(before)
+  })
+
+  test('empty category increments missingStatusCategorySeen, not categoryFallbackSeen', () => {
+    const missingBefore = missingStatusCategorySeen()
+    const fallbackBefore = categoryFallbackSeen()
+    effectiveCategory(issueRow('완료', ''))
+    expect(missingStatusCategorySeen()).toBe(missingBefore + 1)
+    expect(categoryFallbackSeen()).toBe(fallbackBefore)
   })
 })
 

--- a/web/src/lib/view-config.ts
+++ b/web/src/lib/view-config.ts
@@ -584,6 +584,16 @@ export function priorityNameFallbackSeen(): number {
 }
 
 /**
+ * Times effectiveCategory took the unknown-key fallback (non-empty, not a
+ * trusted key or folded alias). Integer increment only — no per-row log.
+ */
+let categoryFallbackCount = 0
+
+export function categoryFallbackSeen(): number {
+  return categoryFallbackCount
+}
+
+/**
  * Filter token match: id first, display name only as a fallback for legacy
  * saved views that still store a localized name. Empty `selected` is no
  * constraint (same as the other multi-value axes).
@@ -621,11 +631,26 @@ export function prioritySortRank(rank: number | null | undefined): number {
   return rank
 }
 
-/** Trust a real new|inprogress|done status_category; otherwise 'inprogress'. Never a status name. */
-export function effectiveCategory(issue: IssueLite): StatusCategory {
-  const sc = (issue.status_category ?? '').toLowerCase()
-  if (sc === 'new' || sc === 'inprogress' || sc === 'done') return sc
+/**
+ * Trust a real new|inprogress|done status_category. Fold Jira's
+ * indeterminate (REST key for in progress) and the aliases the deleted
+ * web mappers already accepted (todo → new, complete/completed → done).
+ * Never a status display name.
+ *
+ * Accepts an issue or a raw key so the list, the transition control, and
+ * transition to_category strings share one decision.
+ */
+export function effectiveCategory(issueOrCat: IssueLite | string | null | undefined): StatusCategory {
+  const raw =
+    typeof issueOrCat === 'string' || issueOrCat == null
+      ? (issueOrCat ?? '')
+      : (issueOrCat.status_category ?? '')
+  const sc = raw.toLowerCase()
+  if (sc === 'new' || sc === 'todo') return 'new'
+  if (sc === 'inprogress' || sc === 'indeterminate') return 'inprogress'
+  if (sc === 'done' || sc === 'complete' || sc === 'completed') return 'done'
   if (!sc) missingStatusCategoryCount++
+  else categoryFallbackCount++
   return 'inprogress'
 }
 


### PR DESCRIPTION
Two audit rounds found this from different directions. The list coloured an issue with `effectiveCategory` while the transition control coloured the same issue with `normalizeCategory` — and on `complete` and `todo` the two returned different answers, visible in a single screen.

Five opinions, not four:

| Mapper | Problem |
|---|---|
| `web/src/lib/view-config.ts:611` `effectiveCategory` | did not handle `indeterminate` |
| `web/src/components/detail/format.ts:11` `normalizeCategory` | `complete`/`completed` → `done`, `todo` → `new` |
| `web/src/components/write/StatusTransition.svelte:37` | local `catDot` / `jiraRank` |
| `web/src/components/list/BulkBar.svelte:41` | the same pair again (found during review) |
| `internal/jql/match.go:74` | the Go cousin — the reference answer, unchanged |

`indeterminate` is not hypothetical: it is what Jira's REST API calls "in progress".

## One owner

`effectiveCategory` is now the only function in `web/` that lowercases a raw status key. It folds `indeterminate` → `inprogress` to match `internal/jql/match.go:74`, and takes over `complete`/`completed`/`todo` from the mappers being deleted.

`'to do'` is deliberately **not** carried over. It is a display name, and GDK-272 removed name guessing from this function on purpose — `tools/doc-checks.sh` check 7 guards that.

`normalizeCategory` is deleted. `StatusTransition` and `BulkBar` now call the owner and switch on its three buckets, which is an adapter rather than a second opinion.

`CATEGORY_META`'s five consumers moved to `categoryMetaOf` and the table is gone — the migration, not the deletion, since deleting `categoryMetaOf` would have been nine lines and left the codebase pointing at the worse of the two. Same tokens; no rendered change.

## Recurrence: check 15

A repo-wide class scan in `tools/doc-checks.sh`, in the shape of checks 7 and 14 rather than a second scanner.

The lead widened it during review. The round's version keyed on *returning a bare bucket*, which caught only two of the five — it missed `BulkBar`'s `catDot` (returns `'bg-status-done'`) and `jiraRank` (returns a number), which were exactly as much a second opinion as the ones it caught. The tell is now **lowercasing a key yourself and comparing that against the bucket names**, which leaves `BreakdownBar`'s `groupColor` alone: it lowercases for `'fail'`/`'pass'` and delegates the category branch to `categoryMetaOf`.

FAIL-first, with the four original files restored from `731e71d`:

```
web/src/lib/view-config.ts:625: effectiveCategory
web/src/components/write/StatusTransition.svelte:37: catDot
web/src/components/write/StatusTransition.svelte:46: jiraRank
web/src/components/detail/format.ts:11: normalizeCategory
web/src/components/list/BulkBar.svelte:41: jiraRank
web/src/components/list/BulkBar.svelte:47: catDot
```

After: one hit, the owner.

## Debuggability

`categoryFallbackSeen()` follows `missingStatusCategorySeen` (GDK-272) and `priorityNameFallbackSeen` (GDK-275) rather than inventing a third shape. It increments only on a non-empty unknown key.

## Known remainder

`isReopen` still tests `from_category === 'done'` directly. Changelog keys from Jira are `new`/`indeterminate`/`done`, so `indeterminate !== 'done'` already counts as a reopen; routing it through the owner would fold empty into `inprogress` and change that behaviour. Left as-is deliberately.

## Gates, lead-run cold

- `make typecheck` — 4250 files, 0 errors
- `npm run test:unit` — 355 passed
- `bash tools/doc-checks.sh` — 16 checks
- `npx playwright test --config e2e/playwright.config.ts` — 240 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)