### PR TITLE
fix(store): a contended write died instantly because busy_timeout never saw it (GDK-305)

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -202,6 +202,10 @@ func openSQLite(path string, readOnly bool) (*sql.DB, error) {
 	if readOnly {
 		mode = "ro"
 	}
+	// Single-writer one-shot. busy_timeout is already set. Do not add WAL:
+	// the snapshot is a shareable artifact and build.go forces journal_mode
+	// DELETE on the dest so the output is a single file. synchronous is left
+	// at SQLite's default for the same reason — it is part of what ships.
 	dsn := "file:" + path + "?mode=" + mode +
 		"&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)"
 	db, err := sql.Open("sqlite", dsn)

--- a/internal/store/feed.go
+++ b/internal/store/feed.go
@@ -168,6 +168,10 @@ func (db *DB) MarkFeedRead(ctx context.Context, opts MarkFeedReadOpts) (MarkFeed
 	}
 	updated := 0
 	err = db.write(ctx, func(tx *sql.Tx) error {
+		// Reset per attempt: write() retries SQLITE_BUSY, which re-runs this
+		// callback from the start, and a counter captured out here would count
+		// the abandoned attempt's rows too (GDK-305).
+		updated = 0
 		for id := range want {
 			res, err := tx.Exec(`
 				INSERT INTO feed_reads (event_id, read_at) VALUES (?, ?)

--- a/internal/store/local.go
+++ b/internal/store/local.go
@@ -227,7 +227,7 @@ func OpenReadOnly(path string) (*sql.DB, error) {
 	if err := EnsureLocal(path); err != nil {
 		log.Printf("store: local.db: %v", err)
 	}
-	return sql.Open("sqlite", "file:"+path+"?mode=ro")
+	return sql.Open("sqlite", "file:"+path+"?mode=ro&_pragma=busy_timeout(5000)")
 }
 
 // VisitKind is visits.kind / searches.opened_kind: "issue" or "page".

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/midagedev/gadak/internal/config"
@@ -35,7 +36,8 @@ type DB struct {
 	path          string
 	schemaVersion int
 
-	mu sync.Mutex // single-writer discipline, see write()
+	mu               sync.Mutex // process-local writer serialisation, see write()
+	writeBusyRetries atomic.Uint64
 }
 
 // Now returns UTC now in config.ISOMilli. The server hands this value to
@@ -55,12 +57,7 @@ func Open(path string) (*DB, error) {
 			return nil, err
 		}
 	}
-	dsn := "file:" + path + "?" + strings.Join([]string{
-		"_pragma=busy_timeout(5000)",
-		"_pragma=journal_mode(WAL)",
-		"_pragma=foreign_keys(1)",
-		"_pragma=synchronous(NORMAL)",
-	}, "&")
+	dsn := mirrorDSN(path)
 	sqlDB, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
@@ -163,11 +160,95 @@ func (db *DB) migrate() error {
 	})
 }
 
-// write runs fn in a transaction. One mutex is the whole single-writer story:
-// concurrent writers under WAL would just trade this lock for SQLITE_BUSY.
+// mirrorDSN is the Open DSN. _txlock=immediate makes BeginTx take the write
+// lock up front so a read-then-write callback cannot upgrade a deferred
+// transaction (that upgrade returns SQLITE_BUSY without consulting
+// busy_timeout). modernc.org/sqlite v1.56.0: driver.go documents _txlock,
+// sqlite.go stores it as conn.beginMode, tx.go issues "begin "+beginMode.
+func mirrorDSN(path string) string {
+	return "file:" + path + "?" + strings.Join([]string{
+		"_pragma=busy_timeout(5000)",
+		"_pragma=journal_mode(WAL)",
+		"_pragma=foreign_keys(1)",
+		"_pragma=synchronous(NORMAL)",
+		"_txlock=immediate",
+	}, "&")
+}
+
+// writeBusyAttempts is 2 because each attempt can already block for the 5s
+// busy_timeout. One retry covers SQLITE_BUSY_SNAPSHOT (which does not wait)
+// and a writer that dropped the lock on the timeout edge. A third attempt
+// would stack another 5s onto a request that already waited 10s.
+const writeBusyAttempts = 2
+
+// writeBusyBackoff is 1% of busy_timeout(5000). Code 5 has already waited 5s;
+// code 517 returns immediately and needs a beat for the other transaction
+// to commit.
+const writeBusyBackoff = 50 * time.Millisecond
+
+// sqliteCodeError is the modernc.org/sqlite v1.56.0 *Error surface: Code()
+// returns the SQLite result code. That driver's Error() string appends
+// " (SQLITE_BUSY)" only for primary 5, so 517 is "database is locked (517)"
+// with no suffix — do not match the prose.
+type sqliteCodeError interface {
+	error
+	Code() int
+}
+
+func sqliteBusy(err error) bool {
+	var se sqliteCodeError
+	if !errors.As(err, &se) {
+		return false
+	}
+	switch se.Code() {
+	case 5: // SQLITE_BUSY
+		return true
+	case 517: // SQLITE_BUSY_SNAPSHOT
+		return true
+	default:
+		return false
+	}
+}
+
+func retryBusy(ctx context.Context, retries *atomic.Uint64, fn func() error) error {
+	var last error
+	for attempt := 1; attempt <= writeBusyAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		last = fn()
+		if last == nil || !sqliteBusy(last) || attempt == writeBusyAttempts {
+			return last
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		retries.Add(1)
+		timer := time.NewTimer(writeBusyBackoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return last
+}
+
+// write runs fn in a transaction. db.mu serialises writers in this process.
+// Other processes (serve, desktop, CLI, plugins) are separate connections:
+// SQLite's lock, busy_timeout, BEGIN IMMEDIATE, and a bounded SQLITE_BUSY
+// retry cover those. Short overlapping writes are fine; the failure mode this
+// retry exists for is another process holding the write lock.
 func (db *DB) write(ctx context.Context, fn func(*sql.Tx) error) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
+	return retryBusy(ctx, &db.writeBusyRetries, func() error {
+		return db.writeOnce(ctx, fn)
+	})
+}
+
+func (db *DB) writeOnce(ctx context.Context, fn func(*sql.Tx) error) error {
 	tx, err := db.sql.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -177,6 +258,12 @@ func (db *DB) write(ctx context.Context, fn func(*sql.Tx) error) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+// WriteBusyRetries is how many times write() has retried SQLITE_BUSY (5 or
+// 517) on this handle. Same shape as PoolStats: a cheap accessor, no logs.
+func (db *DB) WriteBusyRetries() uint64 {
+	return db.writeBusyRetries.Load()
 }
 
 // nz maps an absent string to SQL NULL. data-model.md defines NULL as "unknown

--- a/internal/store/store_busy_test.go
+++ b/internal/store/store_busy_test.go
@@ -1,0 +1,281 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWriteReadThenWriteAgainstHeldTxn is FAIL-first for GDK-305: a deferred
+// SELECT-then-INSERT while another *DB holds an uncommitted write returns
+// SQLITE_BUSY immediately (busy_timeout is not consulted on a lock upgrade).
+// With _txlock=immediate the busy moves to BEGIN, which waits, so releasing
+// the holder lets the write succeed. The assertion is the error (nil vs busy),
+// not a duration.
+func TestWriteReadThenWriteAgainstHeldTxn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gadak.db")
+	holder := openTemp(t, path)
+	if err := holder.UpsertSource(context.Background(), Source{ID: "jira", Kind: "jira"}); err != nil {
+		t.Fatal(err)
+	}
+	challenger, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { challenger.Close() })
+
+	ctx := context.Background()
+	holdTx, err := holder.sql.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holdTx.Rollback()
+	if _, err := holdTx.Exec(`INSERT INTO items (id, source_id, kind, key, updated_at)
+		VALUES ('jira:hold', 'jira', 'issue', 'NMB-HOLD', '2026-08-04T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- challenger.write(ctx, func(tx *sql.Tx) error {
+			select {
+			case <-started:
+			default:
+				close(started)
+			}
+			var n int
+			if err := tx.QueryRow(`SELECT COUNT(*) FROM items`).Scan(&n); err != nil {
+				return err
+			}
+			_, err := tx.Exec(`INSERT INTO items (id, source_id, kind, key, updated_at)
+				VALUES ('jira:up', 'jira', 'issue', 'NMB-UP', '2026-08-04T00:00:00Z')`)
+			return err
+		})
+	}()
+
+	select {
+	case <-started:
+		// Deferred BEGIN: the callback ran while the other connection still
+		// holds the write lock. That is the upgrade that ignores busy_timeout.
+		err := <-done
+		t.Fatalf("write callback ran under held lock: %v", err)
+	case err := <-done:
+		t.Fatalf("write returned before callback: %v", err)
+	case <-time.After(time.Second):
+		// BEGIN is waiting in busy_timeout. Drop the holder so it can proceed.
+		// This case is a blocked-BEGIN detector, not a duration assertion.
+		if err := holdTx.Rollback(); err != nil {
+			t.Fatal(err)
+		}
+		err := <-done
+		if err != nil {
+			t.Fatalf("write after holder released: %v", err)
+		}
+	}
+}
+
+func TestOpenReadOnlyBusyTimeout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gadak.db")
+	db, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ro.Close() })
+
+	var got string
+	if err := ro.QueryRow(`PRAGMA busy_timeout`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "5000" {
+		t.Fatalf("OpenReadOnly busy_timeout = %s, want 5000", got)
+	}
+}
+
+func TestSQLiteBusyCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{fmt.Errorf("database is locked (5) (SQLITE_BUSY)"), false}, // prose only, no Code()
+		{codeErr{code: 5, msg: "database is locked (5) (SQLITE_BUSY)"}, true},
+		{codeErr{code: 517, msg: "database is locked (517)"}, true},
+		{fmt.Errorf("wrap: %w", codeErr{code: 5, msg: "busy"}), true},
+		{fmt.Errorf("wrap: %w", codeErr{code: 517, msg: "snapshot"}), true},
+		{codeErr{code: 261, msg: "SQLITE_BUSY_RECOVERY"}, false},
+		{codeErr{code: 773, msg: "SQLITE_BUSY_TIMEOUT"}, false},
+		{codeErr{code: 6, msg: "SQLITE_LOCKED"}, false},
+		{errors.New("constraint failed"), false},
+		{sql.ErrNoRows, false},
+		{context.Canceled, false},
+	}
+	for _, c := range cases {
+		if got := sqliteBusy(c.err); got != c.want {
+			t.Errorf("sqliteBusy(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+func TestWriteDoesNotRetryNonBusy(t *testing.T) {
+	db := openTemp(t)
+	before := db.WriteBusyRetries()
+	sentinel := errors.New("not busy")
+	err := db.write(context.Background(), func(*sql.Tx) error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got %v, want sentinel", err)
+	}
+	if got := db.WriteBusyRetries(); got != before {
+		t.Fatalf("WriteBusyRetries %d → %d, want unchanged", before, got)
+	}
+}
+
+func TestWriteBusyRetryThenSucceeds(t *testing.T) {
+	db := openTemp(t)
+	calls := 0
+	err := retryBusy(context.Background(), &db.writeBusyRetries, func() error {
+		calls++
+		if calls == 1 {
+			return codeErr{code: 5, msg: "database is locked (5) (SQLITE_BUSY)"}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if got := db.WriteBusyRetries(); got != 1 {
+		t.Fatalf("WriteBusyRetries = %d, want 1", got)
+	}
+}
+
+func TestWriteBusyRetryHonoursCancel(t *testing.T) {
+	db := openTemp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := retryBusy(ctx, &db.writeBusyRetries, func() error {
+		calls++
+		cancel()
+		return codeErr{code: 517, msg: "database is locked (517)"}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (must not start another attempt)", calls)
+	}
+}
+
+func TestWriteBusyRetryDoesNotRetryForever(t *testing.T) {
+	db := openTemp(t)
+	calls := 0
+	busy := codeErr{code: 5, msg: "database is locked (5) (SQLITE_BUSY)"}
+	err := retryBusy(context.Background(), &db.writeBusyRetries, func() error {
+		calls++
+		return busy
+	})
+	if !sqliteBusy(err) {
+		t.Fatalf("got %v, want busy", err)
+	}
+	if calls != writeBusyAttempts {
+		t.Fatalf("calls = %d, want %d", calls, writeBusyAttempts)
+	}
+	if got := db.WriteBusyRetries(); got != uint64(writeBusyAttempts-1) {
+		t.Fatalf("WriteBusyRetries = %d, want %d", got, writeBusyAttempts-1)
+	}
+}
+
+func TestMirrorDSNTxlockImmediate(t *testing.T) {
+	t.Parallel()
+	dsn := mirrorDSN("x")
+	if !strings.Contains(dsn, "_txlock=immediate") {
+		t.Fatalf("mirror DSN missing _txlock=immediate: %s", dsn)
+	}
+}
+
+func TestWriteCanceledContextDoesNotCallFn(t *testing.T) {
+	db := openTemp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+	err := db.write(ctx, func(*sql.Tx) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("fn ran on a canceled context")
+	}
+}
+
+// A retry re-runs the callback from the start, so a counter the callback
+// closes over has to be reset inside it. UpsertIssues, UpsertPages,
+// DeleteItems and the feed mark-read all count rows into a variable declared
+// outside their db.write call and return it; without the reset the abandoned
+// attempt's rows are counted again and the caller is told more changed than
+// did. Both shapes run here, so the failing one is demonstrated rather than
+// described (GDK-305).
+func TestWriteRetryDoesNotDoubleCountCallerCounters(t *testing.T) {
+	rows := []string{"a", "b", "c"}
+
+	for _, tc := range []struct {
+		name  string
+		reset bool
+		want  int
+	}{
+		{name: "counter reset inside the callback", reset: true, want: len(rows)},
+		{name: "counter captured outside (the bug)", reset: false, want: 2 * len(rows)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTemp(t)
+			attempts := 0
+			counted := 0
+			err := db.write(context.Background(), func(*sql.Tx) error {
+				attempts++
+				if tc.reset {
+					counted = 0
+				}
+				for range rows {
+					counted++
+				}
+				if attempts == 1 {
+					return codeErr{code: 5, msg: "database is locked (5) (SQLITE_BUSY)"}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attempts != 2 {
+				t.Fatalf("attempts = %d, want 2 — the retry did not re-run the callback", attempts)
+			}
+			if counted != tc.want {
+				t.Fatalf("counted = %d, want %d", counted, tc.want)
+			}
+		})
+	}
+}
+
+type codeErr struct {
+	code int
+	msg  string
+}
+
+func (e codeErr) Error() string { return e.msg }
+func (e codeErr) Code() int     { return e.code }

--- a/internal/store/write.go
+++ b/internal/store/write.go
@@ -36,6 +36,10 @@ func (db *DB) UpsertIssues(ctx context.Context, b Batch) (int, error) {
 	}
 	changed := 0
 	err := db.write(ctx, func(tx *sql.Tx) error {
+		// Reset per attempt: write() retries SQLITE_BUSY, which re-runs this
+		// callback from the start, and a counter captured out here would count
+		// the abandoned attempt's rows too (GDK-305).
+		changed = 0
 		sources := map[string]bool{}
 		for _, r := range b.Records {
 			ok, err := upsertRecord(tx, b, r)
@@ -412,6 +416,10 @@ func (db *DB) UpsertPages(ctx context.Context, records []PageRecord) (int, error
 	}
 	changed := 0
 	err := db.write(ctx, func(tx *sql.Tx) error {
+		// Reset per attempt: write() retries SQLITE_BUSY, which re-runs this
+		// callback from the start, and a counter captured out here would count
+		// the abandoned attempt's rows too (GDK-305).
+		changed = 0
 		// known project keys once per batch for bare-text issue-key filtering
 		known, err := loadKnownProjectKeys(tx)
 		if err != nil {
@@ -668,6 +676,10 @@ func (db *DB) DeleteItems(ctx context.Context, sourceID string, keys []string) (
 	deleted := 0
 	at := Now()
 	err := db.write(ctx, func(tx *sql.Tx) error {
+		// Reset per attempt: write() retries SQLITE_BUSY, which re-runs this
+		// callback from the start, and a counter captured out here would count
+		// the abandoned attempt's rows too (GDK-305).
+		deleted = 0
 		for _, key := range keys {
 			var id string
 			var rowid int64


### PR DESCRIPTION
## Measured, not inferred

A research harness against gadak's real `store.Open` DSN (modernc.org/sqlite v1.56.0, SQLite 3.53.3):

```
scenario lock-upgrade-held-writer (deferred SELECT then INSERT)
  error "database is locked (5) (SQLITE_BUSY)"   elapsed_ms 0     busy_timeout_honoured no
scenario begin-immediate-held-writer (BEGIN IMMEDIATE)
  error "database is locked (5) (SQLITE_BUSY)"   elapsed_ms 5066  busy_timeout_honoured yes
scenario busy-snapshot (read, other commits, then write)
  error "database is locked (517)"               elapsed_ms 0     busy_timeout_honoured no
```

**`elapsed_ms 0` is the finding.** `_pragma=busy_timeout(5000)` was already set and does nothing on a lock *upgrade*: SQLite skips the busy handler when a wait could deadlock. 517 is `SQLITE_BUSY_SNAPSHOT`, immediate for the same reason. `BEGIN IMMEDIATE` waits the full 5066 ms — the correct behaviour for a contended writer.

`db.write` opened `BeginTx(ctx, nil)` — a deferred transaction — and callbacks like `DeleteItems` and `PruneConfluenceSpaces` SELECT before they DELETE. That is the upgrade shape. Nothing anywhere in `internal/store` or `internal/sync` retried busy; the only occurrence of that string was a comment claiming the mutex was "the whole single-writer story". It is not — `db.mu` is process-local, and eleven non-test sites open this mirror, with `serve`, the desktop app, `sync`, the write verbs and plugins as separate OS processes on one file.

**Honest scope:** short overlapping writes were already fine — 320 same-process and 80 two-process writes, zero errors. The failure needs another process *holding* the write lock when an upgrade arrives.

## The fix

1. **`_txlock=immediate`** on the mirror DSN, which moves the failure from an un-retryable mid-transaction upgrade to `BEGIN`, where the timeout applies. Driver support verified in the module cache: `driver.go:150` documents it, `sqlite.go:337` stores it as `c.beginMode`, `tx.go:23` issues `"begin " + c.beginMode`.
2. **A bounded busy retry in `write`.** Detection is `errors.As` onto the driver's `Code()` accessor, not its prose — modernc appends `" (SQLITE_BUSY)"` for primary 5 only, so 517 arrives bare. Two attempts, because each can already sit for the 5 s timeout; 50 ms backoff, 1% of it; a cancelled context stops before starting another.
3. The stale comment says what is actually true.
4. `OpenReadOnly` had **no** `busy_timeout` at all and now has one.

The snapshot DSN is deliberately left alone: `build.go` already forces `journal_mode=DELETE` on the destination because a snapshot is a shareable artifact, and its journal mode is part of what ships.

## The one way this change could introduce a bug

A retry re-runs the callback, which is a new contract for callers. Four counted rows into a variable declared *outside* their `write` call and returned it — `UpsertIssues`, `UpsertPages`, `DeleteItems`, feed mark-read — so a retry would report more changed than did. Each now resets inside the callback.

Every `write` body was walked to find the rest; they are either locals or plain assignments a retry overwrites. `TestWriteRetryDoesNotDoubleCountCallerCounters` runs both shapes, so the failing one is demonstrated rather than described. The reset is defence: with `_txlock=immediate`, today's busy lands at `BEGIN`, before the callback runs at all.

## Recurrence

`TestWriteReadThenWriteAgainstHeldTxn` — two handles on one path, one holding an uncommitted write, the other reading then writing. It asserts the **error**, not a duration. FAIL-first on the unmodified source: `database is locked (5) (SQLITE_BUSY)` in 0.02 s.

`WriteBusyRetries()` follows `PoolStats()` (GDK-270): a cheap accessor, no hot-path logging.

## Gates, lead-run

- `go build ./...`, `go vet ./...`, `bash tools/check-store-deps.sh` — clean
- `go test ./... -count=1` — 30 packages ok
- `go test ./internal/store/ -count=2 -race` — ok, 77.8 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)