### PR TITLE
docs: the FAQ promised agents cannot write the mirror; the code opens it rw (GDK-306)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -51,9 +51,12 @@ in it.
 ## Several things open the same SQLite file — is that safe?
 
 Yes, by construction: the mirror runs in WAL mode, so one writer (the sync
-loop) and any number of readers coexist; `gadak sql` and the MCP server open
-the file **read-only** (`mode=ro`). The web UI reads through the same
-store layer. You can run all of them at once — that is the intended shape.
+loop) and any number of readers coexist. The MCP server opens the file with
+`store.Open` (read-write; it runs migrations). `gadak sql` opens it with
+`store.OpenReadOnly` (SQLite `mode=ro`). Agent SQL is a second connection:
+`gadak_query` uses `mode=ro` and rejects anything that is not SELECT or WITH.
+The web UI reads through the same store layer. You can run all of them at once
+— that is the intended shape.
 
 ## Why not the official Atlassian MCP / a Forge app / a browser extension?
 

--- a/tools/doc-checks.sh
+++ b/tools/doc-checks.sh
@@ -497,4 +497,147 @@ if [[ -n "$second_category_mappers" ]]; then
 fi
 ok "effectiveCategory is the only status-category mapper in web/"
 
+# ── 16. Doc open-mode claims match the surface's store.Open* (GDK-306) ──
+# Class: a sentence that says how a surface opens the mirror must name the
+# function that surface actually calls. This is not "FAQ contains store.Open"
+# — if ensureDB switches to OpenReadOnly, a sentence that still says
+# store.Open must fail, and the reverse too.
+#
+# Owners are discovered from package layout, not a roster of today's files:
+#   the MCP server → store.Open* in internal/mcp/*.go (non-test)
+#   gadak sql      → store.Open* in cmd/gadak/sql.go
+# gadak_query / "query path" / "query tool" is the SQL connection
+# (sqlguard.runQuery, mode=ro), not the server open — those sentences are
+# not an MCP-server claim.
+#
+# FAIL-first 2026-08-19: docs/FAQ.md said the MCP server opens the file
+# read-only / mode=ro while internal/mcp/server.go called store.Open.
+open_mode_drift=$(
+  python3 - <<'GDK306PY'
+import re
+from pathlib import Path
+
+OPEN_CALL = re.compile(r"\bstore\.(OpenReadOnly|Open)\s*\(")
+QUERY_PATH = re.compile(r"gadak_query|query path|query tool", re.I)
+MCP_SURFACE = re.compile(r"\bthe MCP server\b|\bgadak mcp\b", re.I)
+SQL_SURFACE = re.compile(r"\bgadak sql\b", re.I)
+NAMED_RO = re.compile(r"\bstore\.OpenReadOnly\b")
+NAMED_RW = re.compile(r"\bstore\.Open\b")
+MODE_RO = re.compile(r"mode=ro|\bread-only\b|읽기 전용", re.I)
+SKIP_DIR = {"decisions", "node_modules", "dist", "e2e", "web"}
+SKIP_FILE = {"CHANGELOG.md"}
+
+
+def strip_go_comments(text):
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    out = []
+    for line in text.splitlines():
+        if "//" in line:
+            line = line[: line.index("//")]
+        out.append(line)
+    return "\n".join(out)
+
+
+def open_calls(paths):
+    found = []
+    for path in paths:
+        if path.name.endswith("_test.go"):
+            continue
+        text = strip_go_comments(path.read_text())
+        for i, line in enumerate(text.splitlines(), 1):
+            for m in OPEN_CALL.finditer(line):
+                found.append((path.as_posix(), i, m.group(1)))
+    return found
+
+
+def one_open(label, found):
+    if not found:
+        print("%s: no store.Open* call in production sources" % label)
+        return None
+    names = {n for _, _, n in found}
+    if len(names) != 1:
+        print("%s: mixed store.Open* calls — %s" % (
+            label, "; ".join("%s:%s %s" % t for t in found)))
+        return None
+    return names.pop()
+
+
+def sentences(text):
+    tick = chr(96)
+    fence = tick * 3
+    text = re.sub(re.escape(fence) + ".*?" + re.escape(fence), " ", text, flags=re.S)
+    out = []
+    buf = []
+    in_tick = False
+    for ch in text:
+        if ch == tick:
+            in_tick = not in_tick
+            buf.append(ch)
+            continue
+        if not in_tick and ch == ".":
+            buf.append(ch)
+            s = "".join(buf).strip()
+            if s:
+                out.append(re.sub(r"\s+", " ", s))
+            buf = []
+            continue
+        buf.append(ch)
+    tail = re.sub(r"\s+", " ", "".join(buf)).strip()
+    if tail:
+        out.append(tail)
+    return out
+
+
+def named_open(sentence):
+    if NAMED_RO.search(sentence):
+        return "OpenReadOnly"
+    if NAMED_RW.search(sentence):
+        return "Open"
+    return None
+
+
+def mode_open(sentence):
+    if MODE_RO.search(sentence):
+        return "OpenReadOnly"
+    return None
+
+
+mcp_open = one_open("MCP server", open_calls(Path("internal/mcp").glob("*.go")))
+sql_open = one_open("gadak sql", open_calls([Path("cmd/gadak/sql.go")]))
+if mcp_open is None or sql_open is None:
+    raise SystemExit
+
+docs = []
+for path in Path(".").rglob("*.md"):
+    if any(p in SKIP_DIR for p in path.parts):
+        continue
+    if path.name in SKIP_FILE:
+        continue
+    docs.append(path)
+
+hits = []
+for path in sorted(docs):
+    for sent in sentences(path.read_text()):
+        if MCP_SURFACE.search(sent):
+            claimed = named_open(sent)
+            if claimed is None and not QUERY_PATH.search(sent):
+                claimed = mode_open(sent)
+            if claimed and claimed != mcp_open:
+                hits.append("%s: MCP server claim %s but internal/mcp calls store.%s — %s" % (
+                    path.as_posix(), claimed, mcp_open, sent[:160]))
+        if SQL_SURFACE.search(sent):
+            claimed = named_open(sent) or mode_open(sent)
+            if claimed and claimed != sql_open:
+                hits.append("%s: gadak sql claim %s but cmd/gadak/sql.go calls store.%s — %s" % (
+                    path.as_posix(), claimed, sql_open, sent[:160]))
+
+if hits:
+    print("\n".join(hits))
+GDK306PY
+)
+if [[ -n "$open_mode_drift" ]]; then
+  fail "a doc claim about how a surface opens the mirror disagrees with that surface's store.Open* call (GDK-306):"$'\n'"$open_mode_drift"
+fi
+ok "doc claims about how MCP / gadak sql open the mirror match store.Open*"
+
 echo "doc-checks: all passed"


### PR DESCRIPTION
`docs/FAQ.md:53-56` said `gadak sql` **and the MCP server** open the mirror read-only (`mode=ro`). `internal/mcp/server.go:235` calls `store.Open` — read-write, and it runs migrations. Only `gadak sql` really opens read-only (`cmd/gadak/sql.go:32`, `store.OpenReadOnly`).

Not a one-word typo: the sentence makes a **safety claim** — that an agent cannot touch the mirror — and the claim was false.

## What the FAQ says now

It names the function each surface actually calls, and it surfaces the part that *does* keep the spirit of the old promise, which the old sentence buried: the agent's own SQL is a separate connection opened `mode=ro`, and `rejectNonSelect` refuses anything that is not a single SELECT or WITH (`internal/mcp/sqlguard.go:31-35`, `:174`, `:179`). So the tool surface an agent drives **is** read-only, even though the server's handle is not.

## Why not the other direction

Making MCP open read-only looks like the better product answer and is wrong:

| | |
|---|---|
| Migrations | `store.Open` runs `migrate()` (`internal/store/store.go:72`). For an **MCP-only** user — Claude Desktop, no `serve`, no `sync` — that first tool call is the only thing that migrates the mirror after an upgrade |
| FTS repair | `store.Open` runs `repairItemsFTS` (`:79`); read-only leaves a broken `items_fts` that never rebuilds, so Search fails instead of recovering |
| Types | `Open` returns `*store.DB`, `OpenReadOnly` returns `*sql.DB` — not a swap, it does not compile |
| The worry that would have justified it | does **not** apply: no `RecordVisit` / `RecordSearch` / `RecordRecent` anywhere under `internal/mcp/` |

A viable version would be a new `store` constructor giving a `*store.DB` over `mode=ro` while skipping migrate/repair — recommended against unless something else is guaranteed to have migrated first.

## Recurrence: check 16

In the shape of checks 7, 14 and 15 — a repo-wide class scan, not a spelling test. It **discovers** which `store.Open*` each surface actually calls from the package layout, then fails when a doc sentence about that surface claims the other one. Sentences about `gadak_query` / the query path are excluded, since that is the SQL connection rather than the server open.

**FAIL-first both ways**, which is what makes it a contract:

- forward, with the old sentence: `MCP server claim OpenReadOnly but internal/mcp calls store.Open`
- reverse, run by the lead with `store.Open` flipped to `store.OpenReadOnly` in `internal/mcp`: `MCP server claim Open but internal/mcp calls store.OpenReadOnly`

## Lead-verified independently

Agent SQL really is `mode=ro` plus `rejectNonSelect`; there is no visit or search recording under `internal/mcp`; `store.Open` really does call `migrate()` and `repairItemsFTS`.

`bash tools/doc-checks.sh` — 17 checks, exit 0. No Go changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)