### PR TITLE
fix(linear): a bare sentinel is invisible to the one function that detects a dead credential (GDK-274)

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -22,7 +22,6 @@ package linear
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,12 +44,26 @@ const maxPageSize = 250
 // while making a page worth committing.
 const defaultPageSize = 50
 
-// ErrAuth is a rejected credential (HTTP 401 or 403). It deliberately does
-// not unwrap to atlhttp.ErrAuth: that sentinel's identity is "Atlassian
-// credential rejected", and importing the Atlassian transport package for a
-// Linear client would couple this package to a host family it never talks to.
-// A future sync wiring keys on errors.Is(err, linear.ErrAuth).
-var ErrAuth = errors.New("linear: credential rejected")
+// authError is a rejected Linear credential (HTTP 401 or 403). Error() keeps
+// the "linear:" prefix so last_error names the source. RejectedCredential
+// satisfies the duck-typed marker IsRejectedCredential already publishes, so
+// a future Watch wiring is detected without a per-source branch and without
+// importing atlhttp (this package is not an Atlassian client; see the
+// package comment).
+//
+// A comparable value type plus the package-level ErrAuth var keeps
+// errors.Is(err, linear.ErrAuth) working for existing and future callers.
+type authError struct{}
+
+func (authError) Error() string       { return "linear: credential rejected" }
+func (authError) RejectedCredential() {}
+
+// ErrAuth is the Linear-named rejected credential. Callers keep using
+// errors.Is(err, linear.ErrAuth). It deliberately does not unwrap to
+// atlhttp.ErrAuth: that sentinel's identity is "Atlassian credential
+// rejected", and importing the Atlassian transport package for a Linear
+// client would couple this package to a host family it never talks to.
+var ErrAuth error = authError{}
 
 // Client talks to one Linear workspace over GraphQL, read-only.
 type Client struct {

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -214,6 +215,27 @@ func TestAuthFailureBecomesErrAuthWithoutRetry(t *testing.T) {
 		if calls != 1 {
 			t.Errorf("status %d: attempts = %d, want 1 — a bad credential must not burn the rate budget", status, calls)
 		}
+	}
+}
+
+// TestErrAuthSatisfiesRejectedCredential pins the duck-typed marker
+// IsRejectedCredential already publishes. This package must not import
+// atlhttp (Linear is not an Atlassian host), so the assertion uses a local
+// copy of the method set. errors.Is(err, ErrAuth) must keep working.
+func TestErrAuthSatisfiesRejectedCredential(t *testing.T) {
+	if ErrAuth.Error() != "linear: credential rejected" {
+		t.Fatalf("ErrAuth = %q, want the existing linear: prefix so last_error names the source", ErrAuth)
+	}
+	wrapped := fmt.Errorf("POST /graphql: %w (401 Unauthorized)", ErrAuth)
+	if !errors.Is(wrapped, ErrAuth) {
+		t.Fatalf("errors.Is(%v, ErrAuth) = false", wrapped)
+	}
+	var rc interface{ RejectedCredential() }
+	if !errors.As(ErrAuth, &rc) {
+		t.Fatal("ErrAuth must implement RejectedCredential so IsRejectedCredential sees it without a sync branch")
+	}
+	if !errors.As(wrapped, &rc) {
+		t.Fatal("wrapped ErrAuth must still implement RejectedCredential")
 	}
 }
 

--- a/internal/sync/watch_auth_test.go
+++ b/internal/sync/watch_auth_test.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +19,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/confluence"
 	"github.com/midagedev/gadak/internal/jira"
+	"github.com/midagedev/gadak/internal/linear"
 )
 
 // Watch tests inject Tick so they do not sit on EffectiveSyncIntervalSec's
@@ -49,6 +54,8 @@ const (
 //	  happy:    TestIsRejectedCredential (third-source implementer is detected)
 //	  boundary: TestIsRejectedCredential (transport error is not); TestEveryWatchSourceHasAuthCoverage
 //	            TestApplyWatchErrThirdSource (fatal vs skip, by construction)
+//	            TestEveryOriginClientAuthSentinelIsRejectedCredential (every var ErrAuth, including linear)
+//	            TestApplyWatchErrLinearSentinel (a dead Linear token must mark the source dead)
 //	skip is per-credential
 //	  happy:    TestWatchConfluenceResumesAfterCredentialReload (new token retries)
 //	  boundary: same test, hits stay frozen while Reload keeps the old token
@@ -594,6 +601,18 @@ func TestIsRejectedCredential(t *testing.T) {
 	if !IsRejectedCredential(fmtWrap(atlhttp.ErrAuth)) {
 		t.Fatal("wrapped atlhttp.ErrAuth not detected")
 	}
+	if !IsRejectedCredential(linear.ErrAuth) {
+		t.Fatal("linear.ErrAuth not detected — a future Watch wiring will retry a dead Linear token forever")
+	}
+	if !IsRejectedCredential(fmtWrap(linear.ErrAuth)) {
+		t.Fatal("wrapped linear.ErrAuth not detected")
+	}
+	if errors.Is(linear.ErrAuth, atlhttp.ErrAuth) {
+		t.Fatal("linear.ErrAuth must not unwrap to atlhttp.ErrAuth — that sentinel's identity is Atlassian")
+	}
+	if !errors.Is(fmtWrap(linear.ErrAuth), linear.ErrAuth) {
+		t.Fatal("wrapped linear.ErrAuth must still match errors.Is(..., linear.ErrAuth)")
+	}
 	if !IsRejectedCredential(thirdAuth{}) {
 		t.Fatal("third-source RejectedCredential implementer not detected — the class is still open")
 	}
@@ -691,6 +710,146 @@ func TestEveryWatchSourceHasAuthCoverage(t *testing.T) {
 		if !seen[id] {
 			t.Errorf("auth table lists %q but defaultWatchSources does not", id)
 		}
+	}
+}
+
+// originClientAuthSentinels is every origin-client var ErrAuth in this
+// repository, keyed by the internal/ directory that declares it.
+//
+// TestEveryWatchSourceHasAuthCoverage cannot hold this list: it also
+// requires unwrap to atlhttp.ErrAuth, which is correct for Do-based
+// Atlassian clients and forbidden for Linear (package comment on
+// internal/linear: not an Atlassian host family). A hand list of values
+// is unavoidable — you cannot construct linear.ErrAuth without importing
+// linear — so originClientErrAuthDirs walks internal/ and fails if a new
+// var ErrAuth appears without a row here.
+var originClientAuthSentinels = []struct {
+	dir       string
+	err       error
+	atlassian bool
+}{
+	{dir: "atlhttp", err: atlhttp.ErrAuth, atlassian: true},
+	{dir: "jira", err: jira.ErrAuth, atlassian: true},
+	{dir: "confluence", err: confluence.ErrAuth, atlassian: true},
+	{dir: "linear", err: linear.ErrAuth, atlassian: false},
+}
+
+func TestEveryOriginClientAuthSentinelIsRejectedCredential(t *testing.T) {
+	known := map[string]bool{}
+	for _, row := range originClientAuthSentinels {
+		known[row.dir] = true
+		if row.err == nil {
+			t.Errorf("internal/%s ErrAuth is nil", row.dir)
+			continue
+		}
+		if !IsRejectedCredential(row.err) {
+			t.Errorf("internal/%s ErrAuth %v is not IsRejectedCredential — a dead credential will be retried forever", row.dir, row.err)
+		}
+		if !IsRejectedCredential(fmtWrap(row.err)) {
+			t.Errorf("wrapped internal/%s ErrAuth not detected", row.dir)
+		}
+		unwraps := errors.Is(row.err, atlhttp.ErrAuth)
+		if row.atlassian && !unwraps {
+			t.Errorf("internal/%s ErrAuth must unwrap to atlhttp.ErrAuth", row.dir)
+		}
+		if !row.atlassian && unwraps {
+			t.Errorf("internal/%s ErrAuth must not unwrap to atlhttp.ErrAuth — that sentinel's identity is Atlassian", row.dir)
+		}
+	}
+	found := originClientErrAuthDirs(t)
+	for dir := range found {
+		if !known[dir] {
+			t.Errorf("internal/%s declares var ErrAuth but is not in originClientAuthSentinels — add it so a wrongly-built sentinel goes red before anyone wires it", dir)
+		}
+	}
+	for dir := range known {
+		if !found[dir] {
+			t.Errorf("originClientAuthSentinels lists %s but no var ErrAuth was found under internal/%s", dir, dir)
+		}
+	}
+}
+
+func originClientErrAuthDirs(t *testing.T) map[string]bool {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	internal := filepath.Join(root, "internal")
+	found := map[string]bool{}
+	err := filepath.WalkDir(internal, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "vendor", "node_modules", "dist", "testdata", "scratch":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !srcDeclaresVarErrAuth(string(data)) {
+			return nil
+		}
+		rel, err := filepath.Rel(internal, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		found[filepath.ToSlash(rel)] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return found
+}
+
+func srcDeclaresVarErrAuth(src string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		s := strings.TrimSpace(line)
+		if s == "" || strings.HasPrefix(s, "//") {
+			continue
+		}
+		if strings.HasPrefix(s, "var ErrAuth ") || strings.HasPrefix(s, "var ErrAuth=") {
+			return true
+		}
+		// var ( ErrAuth = ... ) block form
+		if strings.HasPrefix(s, "ErrAuth =") || strings.HasPrefix(s, "ErrAuth=") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestApplyWatchErrLinearSentinel: Linear is not a Watch source yet, but the
+// moment it is appended to defaultWatchSources the same applyWatchErr path
+// must already treat its sentinel as a dead credential. Otherwise Watch
+// retries the token forever and last_error stays empty.
+func TestApplyWatchErrLinearSentinel(t *testing.T) {
+	db := newMirror(t)
+	ctx := context.Background()
+	dead := map[string]bool{}
+	src := watchSource{id: "linear", failLog: "linear sync failed: %v", fatal: false}
+	if err := applyWatchErr(ctx, db.DB, src, linear.ErrAuth, func(string, ...any) {}, dead); err != nil {
+		t.Fatalf("non-fatal linear source returned %v, want continue", err)
+	}
+	if !dead["linear"] {
+		t.Fatal("linear.ErrAuth not marked dead — Watch would retry a dead Linear token forever")
+	}
+	st, err := db.SyncState(ctx, "linear")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.LastError == nil || !strings.Contains(*st.LastError, "linear:") {
+		t.Fatalf("last_error = %v, want linear: so doctor/sql can name the source", st.LastError)
 	}
 }
 


### PR DESCRIPTION
`internal/linear/client.go:48` was `var ErrAuth = errors.New("linear: credential rejected")`, and its comment said a future sync wiring would key on `errors.Is(err, linear.ErrAuth)`.

But the owner of that rule is `internal/sync/run.go:22` `IsRejectedCredential`, and it recognises exactly two things — an error implementing `atlhttp.RejectedCredential`, or one that unwraps to `atlhttp.ErrAuth`. A bare `errors.New` is neither. `run.go`'s own comment states the contract: *"A source that is not built on atlhttp still implements the method."*

`internal/sync/watch_auth_test.go` had already written down what that costs: **"the source will retry a dead credential forever."** So the moment Linear is appended to the Watch sources, an expired token is retried silently and forever and `last_error` stays empty — the user sees "sync is not working" with nothing to read.

Latent today (no importer yet), which is the argument for closing it *now*: it is one wiring away, and the wiring issue is what will be under time pressure. This is also code that landed this week (`5a4afae`, GDK-263) and the lead's review missed it.

## The fix

`ErrAuth` is a comparable zero-size type with `Error()` and `RejectedCredential()`. That satisfies the duck-typed marker the owner already publishes, so:

- **no per-source branch** in `IsRejectedCredential` — `run.go:16` exists precisely to forbid one, and `run.go` is untouched
- **no atlhttp import** — that sentinel's identity is "Atlassian credential rejected", and this package never talks to that host family
- `errors.Is(err, linear.ErrAuth)` keeps working for every existing and future caller, wrapped or not, because the value stays comparable behind `var ErrAuth error`

## Recurrence — the list defends itself

A list of sentinel *values* is unavoidable: you cannot construct `linear.ErrAuth` without importing linear. And a hand-maintained list edited alongside the thing it checks is the failure mode this repo has a standing rule about.

So `originClientErrAuthDirs` walks `internal/` for `var ErrAuth` declarations, and `TestEveryOriginClientAuthSentinelIsRejectedCredential` fails **both ways** — a directory that declares one without a row, and a row with no declaration behind it. Each row also asserts the atlhttp-unwrap direction, which is required for the `Do`-based Atlassian clients and forbidden for Linear.

## FAIL-first, reproduced by the lead

Against `6b5af5b`'s `client.go` — three tests red:

```
--- FAIL: TestIsRejectedCredential
    linear.ErrAuth not detected — a future Watch wiring will retry a dead Linear token forever
--- FAIL: TestEveryOriginClientAuthSentinelIsRejectedCredential
    internal/linear ErrAuth … is not IsRejectedCredential — a dead credential will be retried forever
--- FAIL: TestApplyWatchErrLinearSentinel
```

And the roster's own guard, verified by adding a throwaway `internal/fakeorigin` with a bare `var ErrAuth`:

```
internal/fakeorigin declares var ErrAuth but is not in originClientAuthSentinels
  — add it so a wrongly-built sentinel goes red before anyone wires it
```

## Layer 3 declined, with a reason

The "count repeated failures not judged a credential rejection" counter belongs on the Watch loop, which is `run.go` — read-only for this round, and the very file the fix is careful not to touch. Worth a follow-up; not worth widening the blast radius here.

## Gates, lead-run

`go build ./...` and `go vet ./...` clean · `go test ./... -count=1` 30 packages ok · `go test ./internal/sync/ ./internal/linear/ -count=2 -race` ok (43.1s / 1.5s, under six-round contention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)