### PR TITLE
fix(web): a focused button lost Enter to the list cursor (GDK-276)

### DIFF
--- a/e2e/keys-focus.spec.ts
+++ b/e2e/keys-focus.spec.ts
@@ -167,3 +167,110 @@ test.describe('keys view and ui-focus', () => {
     expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
   })
 })
+
+/*
+ * GDK-276: Enter on focused chrome must run that control's action, not
+ * open-cursor. keys-focus owns this (focus + key) rather than keys-order
+ * (ks= grouping). lastKeyCmd is the permanent keymap debug surface.
+ *
+ * Covered with existing hooks only: filter-add, columns-menu, docs-documents
+ * (testids) and Sort (title — DisplayMenu.svelte has no testid; we do not
+ * add one). Breakdown is the same class but not in the audit's four.
+ */
+function lastKeyCmd(page: Page): Promise<string | null> {
+  return page.locator('html').getAttribute('data-last-key-cmd')
+}
+
+test.describe('Enter on focused chrome (GDK-276)', () => {
+  test('filter, columns, sort, and documents activate on Enter', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    // Below 1440 the detail overlay covers the list toolbar (list-menus-esc).
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await gotoApp(page)
+    // The steal only happens once a list cursor exists (the boot-normal state).
+    await page.keyboard.press('j')
+    await expect(page.locator('[data-cursor="true"]')).toHaveCount(1)
+
+    const add = page.getByTestId('filter-add')
+    await add.focus()
+    await expect(add).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible()
+    expect(await lastKeyCmd(page)).toBe('ignore')
+    await expect(page.getByTestId('issue-detail-panel')).not.toHaveClass(/is-open/)
+    await page.keyboard.press('Escape')
+    await expect(page.getByText('Properties', { exact: true })).toBeHidden()
+
+    const columns = page.getByTestId('columns-menu')
+    await columns.focus()
+    await expect(columns).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('Visible columns', { exact: true })).toBeVisible()
+    expect(await lastKeyCmd(page)).toBe('ignore')
+    await expect(page.getByTestId('issue-detail-panel')).not.toHaveClass(/is-open/)
+    await page.keyboard.press('Escape')
+    await expect(page.getByText('Visible columns', { exact: true })).toBeHidden()
+
+    const sort = page.getByTitle('Sort options')
+    await sort.focus()
+    await expect(sort).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('button', { name: '↓ Desc', exact: true })).toBeVisible()
+    expect(await lastKeyCmd(page)).toBe('ignore')
+    await expect(page.getByTestId('issue-detail-panel')).not.toHaveClass(/is-open/)
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('button', { name: '↓ Desc', exact: true })).toBeHidden()
+
+    const docs = page.getByTestId('docs-documents')
+    await docs.focus()
+    await expect(docs).toBeFocused()
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('docs-view')).toBeVisible()
+    expect(await lastKeyCmd(page)).toBe('ignore')
+
+    expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('Enter on body still opens the list cursor', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    await page.keyboard.press('j')
+    await expect(page.locator('[data-cursor="true"]')).toHaveCount(1)
+
+    await page.evaluate(() => {
+      const active = document.activeElement
+      if (active instanceof HTMLElement) active.blur()
+    })
+
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('issue-detail-panel')).toHaveClass(/is-open/)
+    expect(await lastKeyCmd(page)).toBe('open-cursor')
+
+    expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('search box and palette keep Enter local', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    await page.keyboard.press('j')
+    await expect(page.locator('[data-cursor="true"]')).toHaveCount(1)
+
+    const search = page.getByTestId('search-input')
+    await search.focus()
+    await expect(search).toBeFocused()
+    await page.keyboard.press('Enter')
+    expect(await lastKeyCmd(page)).toBe('ignore')
+    await expect(page.getByTestId('issue-detail-panel')).not.toHaveClass(/is-open/)
+
+    await page.keyboard.press('ControlOrMeta+k')
+    const palette = page.getByRole('dialog', { name: 'Command palette' })
+    await expect(palette).toBeVisible()
+    await page.keyboard.type('zzz-no-such-action')
+    expect(await lastKeyCmd(page)).toBe('ignore')
+    await expect(palette).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(palette).toBeHidden()
+
+    expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})

--- a/web/src/lib/keymap.svelte.ts
+++ b/web/src/lib/keymap.svelte.ts
@@ -33,6 +33,12 @@ export interface KeyContext {
   ctrlKey: boolean
   altKey: boolean
   inEditable: boolean
+  /**
+   * True when Enter already belongs to the event target (native activation).
+   * Distinct from inEditable: a focused button is not a text field, but the
+   * browser will click it on Enter and the keymap must not steal that key.
+   */
+  enterActivating: boolean
   settingsOpen: boolean
   newIssueOpen: boolean
   serverSettingsOpen: boolean
@@ -86,6 +92,7 @@ export function keyContext(over: Partial<KeyContext> = {}): KeyContext {
     ctrlKey: false,
     altKey: false,
     inEditable: false,
+    enterActivating: false,
     settingsOpen: false,
     newIssueOpen: false,
     serverSettingsOpen: false,
@@ -141,10 +148,56 @@ export function narrowFieldTestId(ctx: {
   return NARROW_FIELD_TESTID.issues
 }
 
+function isHtmlish(el: EventTarget | null): el is HTMLElement {
+  if (el == null || typeof el !== 'object') return false
+  if (typeof HTMLElement !== 'undefined') return el instanceof HTMLElement
+  return typeof (el as HTMLElement).tagName === 'string'
+}
+
 export function isEditableTarget(el: EventTarget | null): boolean {
-  if (!el || !(el instanceof HTMLElement)) return false
+  if (!isHtmlish(el)) return false
   const tag = el.tagName
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable
+}
+
+/**
+ * True when Enter is already this element's activation key. One owner for
+ * "does the browser (or contenteditable) consume Enter?" so chrome buttons
+ * are not a growing tag-name list next to open-cursor.
+ *
+ * In: button, a[href], summary, contenteditable, input types the browser
+ * activates on Enter (button/submit/reset/image/file).
+ * Out: ARIA role=button (the browser does not activate it; IssueRow and
+ * DocRow use it, and those rows must keep open-cursor), role=link/menuitem/
+ * tab/switch, generic tabindex, checkbox/radio (Space, and already
+ * isEditableTarget), select/textarea (already isEditableTarget).
+ */
+function activatesOnEnter(el: HTMLElement): boolean {
+  if (el.isContentEditable) return true
+  const tag = el.tagName
+  if (tag === 'BUTTON' || tag === 'SUMMARY') return true
+  if (tag === 'A') return el.hasAttribute('href')
+  if (tag === 'INPUT') {
+    const type = (el.getAttribute('type') ?? 'text').toLowerCase()
+    return (
+      type === 'button' ||
+      type === 'submit' ||
+      type === 'reset' ||
+      type === 'image' ||
+      type === 'file'
+    )
+  }
+  return false
+}
+
+export function isEnterActivatingTarget(el: EventTarget | null): boolean {
+  if (!isHtmlish(el)) return false
+  let node: HTMLElement | null = el
+  while (node) {
+    if (activatesOnEnter(node)) return true
+    node = node.parentElement
+  }
+  return false
 }
 
 /**
@@ -191,6 +244,7 @@ export function resolveGlobalKey(ctx: KeyContext): KeyCommand {
   if (ctx.listActive && (key === 'j' || key === 'k')) {
     return { type: 'move-list', dir: key === 'j' ? 1 : -1 }
   }
+  if (key === 'Enter' && ctx.enterActivating) return { type: 'ignore' }
   if (key === 'Enter' && cursorKey) return { type: 'open-cursor' }
 
   if (key === 'Escape') {
@@ -267,6 +321,7 @@ function contextFromEvent(e: KeyboardEvent, host: GlobalKeyHost): KeyContext {
     ctrlKey: e.ctrlKey,
     altKey: e.altKey,
     inEditable: isEditableTarget(e.target),
+    enterActivating: isEnterActivatingTarget(e.target),
     settingsOpen: host.write.settingsOpen,
     newIssueOpen: host.write.newIssueOpen,
     serverSettingsOpen: host.serverSettingsOpen,

--- a/web/src/lib/keymap.test.ts
+++ b/web/src/lib/keymap.test.ts
@@ -3,11 +3,121 @@ import {
   DETAIL_TESTID,
   NARROW_FIELD_TESTID,
   isBootHoldKey,
+  isEditableTarget,
+  isEnterActivatingTarget,
   keyContext,
   narrowFieldTestId,
   replayHeldListKeys,
   resolveGlobalKey,
 } from './keymap.svelte'
+
+type EnterWant = 'ignore' | 'open-cursor'
+
+/** Duck-typed event target so the table runs in the node vitest project. */
+function fakeTarget(
+  tag: string,
+  attrs: Record<string, string> = {},
+  extra: { isContentEditable?: boolean; parent?: EventTarget | null } = {},
+): EventTarget {
+  return {
+    tagName: tag.toUpperCase(),
+    isContentEditable: Boolean(extra.isContentEditable),
+    parentElement: extra.parent ?? null,
+    getAttribute: (name: string) => (name in attrs ? attrs[name] : null),
+    hasAttribute: (name: string) => name in attrs,
+  } as unknown as EventTarget
+}
+
+function resolveEnterOn(row: { target: EventTarget }) {
+  return resolveGlobalKey(
+    keyContext({
+      key: 'Enter',
+      listActive: true,
+      cursorKey: 'NMB-1',
+      inEditable: isEditableTarget(row.target),
+      enterActivating: isEnterActivatingTarget(row.target),
+    }),
+  )
+}
+
+const ENTER_TARGET_CASES: {
+  shape: string
+  target: EventTarget
+  inEditable: boolean
+  activates: boolean
+  want: EnterWant
+}[] = [
+  {
+    shape: 'button',
+    target: fakeTarget('button'),
+    inEditable: false,
+    activates: true,
+    want: 'ignore',
+  },
+  {
+    shape: 'span inside button',
+    target: fakeTarget('span', {}, { parent: fakeTarget('button') }),
+    inEditable: false,
+    activates: true,
+    want: 'ignore',
+  },
+  {
+    shape: 'a[href]',
+    target: fakeTarget('a', { href: '#' }),
+    inEditable: false,
+    activates: true,
+    want: 'ignore',
+  },
+  {
+    shape: 'input[type=text]',
+    target: fakeTarget('input', { type: 'text' }),
+    inEditable: true,
+    activates: false,
+    want: 'ignore',
+  },
+  {
+    shape: 'input[type=checkbox]',
+    target: fakeTarget('input', { type: 'checkbox' }),
+    inEditable: true,
+    activates: false,
+    want: 'ignore',
+  },
+  {
+    shape: 'div',
+    target: fakeTarget('div'),
+    inEditable: false,
+    activates: false,
+    want: 'open-cursor',
+  },
+  {
+    shape: 'body',
+    target: fakeTarget('body'),
+    inEditable: false,
+    activates: false,
+    want: 'open-cursor',
+  },
+  {
+    shape: 'list row',
+    target: fakeTarget('div', { 'data-issue-key': 'NMB-1', role: 'button' }),
+    inEditable: false,
+    activates: false,
+    want: 'open-cursor',
+  },
+  {
+    shape: 'role="button"',
+    target: fakeTarget('div', { role: 'button' }),
+    inEditable: false,
+    activates: false,
+    want: 'open-cursor',
+  },
+  {
+    shape: 'contenteditable',
+    target: fakeTarget('div', { contenteditable: 'true' }, { isContentEditable: true }),
+    inEditable: true,
+    activates: true,
+    want: 'ignore',
+  },
+]
 
 describe('narrow field / detail testid map', () => {
   test('testids match the nodes the shell already mounts', () => {
@@ -126,6 +236,44 @@ describe('resolveGlobalKey', () => {
     expect(resolveGlobalKey(keyContext({ key: 'Enter', cursorKey: 'NMB-1' }))).toEqual({
       type: 'ignore',
     })
+  })
+
+  /*
+   * GDK-276: Enter on a control the browser already activates must not become
+   * open-cursor. The table is the decision (target shape → ignore | open-cursor).
+   */
+  test.each(ENTER_TARGET_CASES)('Enter on $shape is $want', (row) => {
+    expect(isEditableTarget(row.target), `${row.shape} isEditableTarget`).toBe(row.inEditable)
+    expect(isEnterActivatingTarget(row.target), `${row.shape} isEnterActivatingTarget`).toBe(
+      row.activates,
+    )
+    expect(resolveEnterOn(row).type).toBe(row.want)
+  })
+
+  test('j still moves the list when a button would own Enter', () => {
+    expect(
+      resolveGlobalKey(
+        keyContext({
+          key: 'j',
+          listActive: true,
+          cursorKey: 'NMB-1',
+          enterActivating: true,
+        }),
+      ),
+    ).toEqual({ type: 'move-list', dir: 1 })
+  })
+
+  test('paletteOpen and inEditable still swallow Enter (search / palette)', () => {
+    expect(
+      resolveGlobalKey(
+        keyContext({ key: 'Enter', listActive: true, cursorKey: 'NMB-1', paletteOpen: true }),
+      ),
+    ).toEqual({ type: 'ignore' })
+    expect(
+      resolveGlobalKey(
+        keyContext({ key: 'Enter', listActive: true, cursorKey: 'NMB-1', inEditable: true }),
+      ),
+    ).toEqual({ type: 'ignore' })
   })
 
   test('Escape: browse, then menu (pass), then bulk, then detail', () => {


### PR DESCRIPTION
Focus the filter-add button, press Enter — nothing. Same for Columns, Sort, and the sidebar documents entry, in both locales. Found by the v0.16 release audit doing real keyboard walks (axis 6).

**The cause.** The keymap's guard against stealing keys is `inEditable`, which only knows `INPUT` / `TEXTAREA` / `SELECT` / contenteditable. A focused `type=button` is none of those, so `Enter && cursorKey → open-cursor` ate the key. A list cursor after boot is the *normal* state, so this fired constantly.

**Why not just widen `isEditableTarget`.** It means "the user is typing, swallow everything" — widening it would also drop `j`/`k`/`/`/`?` on chrome, which is existing behaviour. The property that actually matters is a different one: *Enter is already this element's activation key.* That gets its own owner, `isEnterActivatingTarget`, consulted before the cursor branch.

| | |
|---|---|
| **In** | `button`, `a[href]`, `summary`, contenteditable, and the input types the browser activates on Enter (button/submit/reset/image/file). Ancestor-walked, so a span inside a button counts. |
| **Out** | ARIA `role="button"` — the browser does not activate it, and `IssueRow`/`DocRow` are exactly that. Those rows must keep `open-cursor`, which is what the line exists for and is not the bug. Also `role=link/menuitem/tab/switch`, bare `tabindex`, checkbox/radio (Space, and already editable). |

`ignore` is a no-op with no `preventDefault`, so the browser goes on to click the button itself.

**Confirmed unchanged**: the command palette (`paletteOpen` returns `ignore` first), the search box (INPUT → editable → ignore), and `open-cursor` from the list or `body`.

**Two tiers of gate, both FAIL-first.** The unit table in `keymap.test.ts` drives every target shape through the Enter decision — the cheap gate that will actually catch a regression; it failed on `button` and `a[href]` before the fix. The e2e walks the real chrome controls in `keys-focus.spec.ts`. Worth noting: the first e2e draft passed for the *wrong* reason — with no cursor established, `Enter && cursorKey` is already `ignore`. It now presses `j` first, which is the boot-normal state the bug needs.

`document.documentElement.dataset.lastKeyCmd` was already permanent, so the e2e asserts on it rather than adding a second observability path.

**Known gap**: `DisplayMenu.svelte:51-61` (the Sort trigger) has no `data-testid`, so the walk reaches it by `title="Sort options"`, the same way `list-menus-esc.spec.ts` does. No `web/` component was edited to add a test hook.

**Gates, re-run cold by the lead on the rebased tree**: `make typecheck` exit 0 (4250 files, 0 errors) · `npm run test:unit` exit 0 (34 files, 367 tests) · `npx playwright test` exit 0 (244 passed). Counts match the delegate's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)