### PR TITLE
fix(server,workspace,origin): three mutexes held across disk IO (GDK-282)

### DIFF
--- a/internal/origin/lock_io_test.go
+++ b/internal/origin/lock_io_test.go
@@ -1,0 +1,97 @@
+package origin
+
+import (
+	"os"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+)
+
+func seedStandalone(t *testing.T, name string) *config.Config {
+	t.Helper()
+	dir, err := config.DirFor(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := config.LoadFor(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded.Kind = config.KindStandalone
+	if err := loaded.Save(); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err = config.LoadFor(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}
+
+// TestStandaloneSessionReleasesLockDuringOpen is the GDK-282 recurrence
+// gate for site 3: two persist paths must construct at once. The signal is
+// structural (TryLock + a second construct hook), not a wall-clock compare.
+func TestStandaloneSessionReleasesLockDuringOpen(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() {
+		_ = Close()
+		config.SetProfile("")
+	})
+
+	cfgA := seedStandalone(t, "alpha")
+	cfgB := seedStandalone(t, "beta")
+	pathA := PersistPath(cfgA.Directory())
+	pathB := PersistPath(cfgB.Directory())
+
+	aStarted := make(chan struct{})
+	aHold := make(chan struct{})
+	bStarted := make(chan struct{})
+	t.Cleanup(func() {
+		testBeforeStandalone = nil
+		select {
+		case <-aHold:
+		default:
+			close(aHold)
+		}
+	})
+
+	testBeforeStandalone = func(persist string) {
+		switch persist {
+		case pathA:
+			close(aStarted)
+			<-aHold
+		case pathB:
+			close(bStarted)
+		}
+	}
+
+	errc := make(chan error, 2)
+	go func() {
+		_, err := Client(cfgA)
+		errc <- err
+	}()
+	<-aStarted
+
+	if !mu.TryLock() {
+		t.Fatal("standaloneSession still holds the process-global mutex during NewEmbedded — one persist write serialises every workspace")
+	}
+	mu.Unlock()
+
+	go func() {
+		_, err := Client(cfgB)
+		errc <- err
+	}()
+	<-bStarted
+
+	close(aHold)
+	for i := 0; i < 2; i++ {
+		if err := <-errc; err != nil {
+			t.Fatalf("Client: %v", err)
+		}
+	}
+}

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/confluence"
@@ -100,10 +101,34 @@ type session struct {
 	wiki   *confluence.Client
 }
 
+type sessionFlight struct {
+	done chan struct{}
+	s    *session
+	err  error
+}
+
 var (
-	mu   sync.Mutex
-	live = map[string]*session{}
+	// mu guards live and flights. Contract: no IO under this lock. The
+	// critical section is a map lookup or insert; MkdirAll,
+	// issuetap.NewEmbedded (persist read/write), and Embedded.Close run
+	// with the lock released. This mutex is process-global and keyed by
+	// persist path — holding it across persist IO queues every standalone
+	// workspace behind one disk.
+	mu      sync.Mutex
+	live    = map[string]*session{}
+	flights = map[string]*sessionFlight{}
+
+	sessionInFlight   atomic.Int64
+	sessionsDiscarded atomic.Uint64
 )
+
+// SessionInFlight is how many standaloneSession constructions are running
+// outside mu. Same shape as store.WriteBusyRetries: a cheap accessor, no logs.
+func SessionInFlight() int64 { return sessionInFlight.Load() }
+
+// SessionsDiscarded is how many constructed sessions lost the publish race
+// and were closed. Same shape as store.WriteBusyRetries.
+func SessionsDiscarded() uint64 { return sessionsDiscarded.Load() }
 
 func standaloneClient(cfg *config.Config) (*jira.Client, error) {
 	s, err := standaloneSession(cfg)
@@ -137,6 +162,11 @@ func standaloneWiki(cfg *config.Config) (*confluence.Client, error) {
 	return s.wiki, nil
 }
 
+// testBeforeStandalone, if set, runs after the live-session lookup and before
+// MkdirAll / issuetap.NewEmbedded. Tests use it as a barrier to prove the
+// process-global mutex is not held across persist IO. Production is nil.
+var testBeforeStandalone func(persist string)
+
 func standaloneSession(cfg *config.Config) (*session, error) {
 	dir, err := profileDir(cfg)
 	if err != nil {
@@ -148,11 +178,54 @@ func standaloneSession(cfg *config.Config) (*session, error) {
 	persist := PersistPath(dir)
 
 	mu.Lock()
-	defer mu.Unlock()
 	if s, ok := live[persist]; ok {
+		mu.Unlock()
 		return s, nil
 	}
+	if f, ok := flights[persist]; ok {
+		mu.Unlock()
+		<-f.done
+		return f.s, f.err
+	}
+	f := &sessionFlight{done: make(chan struct{})}
+	if flights == nil {
+		flights = map[string]*sessionFlight{}
+	}
+	flights[persist] = f
+	mu.Unlock()
 
+	if testBeforeStandalone != nil {
+		testBeforeStandalone(persist)
+	}
+
+	sessionInFlight.Add(1)
+	s, err := constructStandalone(persist)
+	sessionInFlight.Add(-1)
+
+	mu.Lock()
+	delete(flights, persist)
+	if err != nil {
+		f.err = err
+		close(f.done)
+		mu.Unlock()
+		return nil, err
+	}
+	if existing, ok := live[persist]; ok {
+		sessionsDiscarded.Add(1)
+		mu.Unlock()
+		closeSession(s)
+		f.s = existing
+		close(f.done)
+		return existing, nil
+	}
+	live[persist] = s
+	f.s = s
+	close(f.done)
+	mu.Unlock()
+	return s, nil
+}
+
+func constructStandalone(persist string) (*session, error) {
 	if err := os.MkdirAll(filepath.Dir(persist), 0o700); err != nil {
 		return nil, fmt.Errorf("origin: persist dir: %w", err)
 	}
@@ -179,9 +252,13 @@ func standaloneSession(cfg *config.Config) (*session, error) {
 	}
 	w.HTTP.Transport = tr
 
-	s := &session{emb: emb, client: c, wiki: w}
-	live[persist] = s
-	return s, nil
+	return &session{emb: emb, client: c, wiki: w}, nil
+}
+
+func closeSession(s *session) {
+	if s != nil && s.emb != nil {
+		_ = s.emb.Close()
+	}
 }
 
 func profileDir(cfg *config.Config) (string, error) {
@@ -196,17 +273,32 @@ func profileDir(cfg *config.Config) (string, error) {
 // Close flushes every live standalone origin and drops the sessions.
 // Safe to call more than once. The process owner (cmd/gadak main) calls
 // this on the way out so the last PersistDebounce window is not lost.
+//
+// In-flight constructors are waited on (they publish, then this snapshots)
+// so Close never closes a half-built Embedded. There is no permanent
+// closed flag: Client after Close must open a new session (persist is
+// the origin; the process is allowed to come back).
 func Close() error {
 	mu.Lock()
-	defer mu.Unlock()
+	wait := make([]chan struct{}, 0, len(flights))
+	for _, f := range flights {
+		wait = append(wait, f.done)
+	}
+	mu.Unlock()
+	for _, done := range wait {
+		<-done
+	}
+	mu.Lock()
+	snapshot := live
+	live = map[string]*session{}
+	mu.Unlock()
 	var first error
-	for path, s := range live {
+	for _, s := range snapshot {
 		if s != nil && s.emb != nil {
 			if err := s.emb.Close(); err != nil && first == nil {
 				first = err
 			}
 		}
-		delete(live, path)
 	}
 	return first
 }

--- a/internal/server/lock_io_test.go
+++ b/internal/server/lock_io_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDerivedReleasesLockDuringRebuild is the GDK-282 recurrence gate for
+// site 1: a cache-miss rebuild must not hold s.mu across IssueLites /
+// buildView. The signal is structural (TryLock + a second construct hook
+// on a different key), not a wall-clock comparison.
+func TestDerivedReleasesLockDuringRebuild(t *testing.T) {
+	db, cfg := fixture(t)
+	h := New(db, cfg)
+	s := h.s
+	s.cached = nil
+
+	aStarted := make(chan struct{})
+	aHold := make(chan struct{})
+	bStarted := make(chan struct{})
+	t.Cleanup(func() {
+		testBeforeDerived = nil
+		select {
+		case <-aHold:
+		default:
+			close(aHold)
+		}
+	})
+
+	testBeforeDerived = func() {
+		close(aStarted)
+		<-aHold
+	}
+
+	errc := make(chan error, 2)
+	go func() {
+		_, err := s.derived(context.Background(), 1, nil)
+		errc <- err
+	}()
+	<-aStarted
+
+	if !s.mu.TryLock() {
+		t.Fatal("derived still holds s.mu during rebuild — one cache miss serialises every other derived caller")
+	}
+	s.mu.Unlock()
+
+	testBeforeDerived = func() { close(bStarted) }
+	go func() {
+		_, err := s.derived(context.Background(), 2, nil)
+		errc <- err
+	}()
+	<-bStarted
+
+	close(aHold)
+	for i := 0; i < 2; i++ {
+		if err := <-errc; err != nil {
+			t.Fatalf("derived: %v", err)
+		}
+	}
+}

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -12,10 +12,20 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/store"
 )
+
+// derivedInFlight is how many derived() rebuilds are running outside s.mu.
+// Package-level so we do not add a field on server (server.go is owned by
+// another round). Same shape as store.WriteBusyRetries.
+var derivedInFlight atomic.Int64
+
+// DerivedInFlight is how many derived() rebuilds are running outside s.mu.
+// Same shape as store.WriteBusyRetries: a cheap accessor, no logs.
+func DerivedInFlight() int64 { return derivedInFlight.Load() }
 
 /* ── response shapes ──
  * Field names follow web/src/lib/types.ts, which is what the client actually
@@ -564,16 +574,37 @@ type derivedView struct {
 	bodyAliases map[string]bool
 }
 
+// testBeforeDerived, if set, runs after the cache-miss check and before
+// IssueLites / buildView. Tests use it as a barrier to prove s.mu is not
+// held across the rebuild. Production is nil (one pointer compare on miss).
+var testBeforeDerived func()
+
 // derived returns the cached view for this sync version, rebuilding it when
 // stale. lites may be nil, in which case it scans; bootstrap passes the rows it
 // already read so the mirror is scanned once per request, not twice.
+//
+// s.mu contract: no IO under this lock. The critical section is the
+// cached-view pointer; IssueLites, EnrichmentsByKind, GroupQueryHits, and
+// buildView run with the lock released. This is the HTTP list path — one
+// cache miss must not serialise every other derived caller. (The field
+// itself lives on server in server.go; this is the only writer.)
 func (s *server) derived(ctx context.Context, version int64, lites []store.IssueLite) (*derivedView, error) {
 	key := fmt.Sprintf("%d:%d", version, s.gen.Load())
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.cached != nil && s.cached.key == key {
-		return s.cached, nil
+		v := s.cached
+		s.mu.Unlock()
+		return v, nil
 	}
+	s.mu.Unlock()
+
+	if testBeforeDerived != nil {
+		testBeforeDerived()
+	}
+
+	derivedInFlight.Add(1)
+	defer derivedInFlight.Add(-1)
+
 	if lites == nil {
 		var err error
 		if lites, err = s.db.IssueLites(ctx); err != nil {
@@ -584,7 +615,17 @@ func (s *server) derived(ctx context.Context, version int64, lites []store.Issue
 	if err != nil {
 		return nil, err
 	}
-	s.cached = v
+
+	s.mu.Lock()
+	if s.cached != nil && s.cached.key == key {
+		v = s.cached
+	} else {
+		live := fmt.Sprintf("%d:%d", version, s.gen.Load())
+		if s.cached == nil || key == live {
+			s.cached = v
+		}
+	}
+	s.mu.Unlock()
 	return v, nil
 }
 

--- a/internal/workspace/lock_io_test.go
+++ b/internal/workspace/lock_io_test.go
@@ -1,0 +1,76 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+)
+
+// TestGetReleasesLockDuringOpen is the GDK-282 recurrence gate for site 2:
+// two profiles must be able to construct at once. The signal is structural
+// (TryLock + a second construct hook), not a wall-clock comparison.
+func TestGetReleasesLockDuringOpen(t *testing.T) {
+	setupHome(t)
+	seedProfile(t, "alpha", &config.Config{
+		Site: "http://127.0.0.1:1", Email: "a@example.invalid", Token: "test-token", Projects: []string{"AAA"},
+	})
+	seedProfile(t, "beta", &config.Config{
+		Site: "http://127.0.0.1:1", Email: "b@example.invalid", Token: "test-token", Projects: []string{"BBB"},
+	})
+
+	reg := New()
+	t.Cleanup(func() { reg.Close() })
+
+	aStarted := make(chan struct{})
+	aHold := make(chan struct{})
+	bStarted := make(chan struct{})
+	t.Cleanup(func() {
+		testBeforeConstruct = nil
+		select {
+		case <-aHold:
+		default:
+			close(aHold)
+		}
+	})
+
+	testBeforeConstruct = func(name string) {
+		switch name {
+		case "alpha":
+			close(aStarted)
+			<-aHold
+		case "beta":
+			close(bStarted)
+		}
+	}
+
+	errc := make(chan error, 2)
+	go func() {
+		_, err := reg.Get("alpha")
+		errc <- err
+	}()
+	<-aStarted
+
+	// Alpha is inside construction. If r.mu is still held, this fails
+	// immediately — that is the pre-fix shape (FAIL-first, 2026-08-19).
+	if !reg.mu.TryLock() {
+		t.Fatal("Get still holds r.mu during construction — one profile's store.Open serialises every other Get/EnsureWatch/Close")
+	}
+	reg.mu.Unlock()
+
+	go func() {
+		_, err := reg.Get("beta")
+		errc <- err
+	}()
+	<-bStarted
+
+	close(aHold)
+	for i := 0; i < 2; i++ {
+		if err := <-errc; err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+	}
+
+	if _, err := reg.Get("alpha"); err != nil {
+		t.Fatalf("cached Get(alpha): %v", err)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -5,12 +5,14 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/midagedev/gadak/internal/attachcache"
@@ -19,6 +21,10 @@ import (
 	"github.com/midagedev/gadak/internal/store"
 	syncer "github.com/midagedev/gadak/internal/sync"
 )
+
+// errRegistryClosed is Get after Close. Close is process-exit; a late
+// constructor must not publish into a registry that has already snapped.
+var errRegistryClosed = errors.New("workspace: registry closed")
 
 // watchRescanInterval is how often WatchAll re-scans profiles for a credential
 // that appeared after boot (CLI `gadak init` while serve is already running).
@@ -42,8 +48,20 @@ type Entry struct {
 // Registry lazy-opens profile mirrors on first /w/<name>/ request and closes
 // them when the process exits.
 type Registry struct {
+	// mu guards entries, flights, watching, closed, and the watch-owner
+	// fields. Contract: no IO under this lock. The critical section is a
+	// map lookup or insert; construction (config.LoadFor, store.Open,
+	// attachcache.New, server.NewWorkspace) and Close of discarded or
+	// snapshotted entries run with the lock released. Holding it across
+	// disk IO serialises every other profile's Get/EnsureWatch/Close
+	// behind one migration.
 	mu      sync.Mutex
 	entries map[string]*Entry
+	flights map[string]*openFlight
+	closed  bool
+
+	openInFlight   atomic.Int64
+	opensDiscarded atomic.Uint64
 
 	// Watch ownership (D8): one loop per credentialed non-primary profile.
 	// WatchAll arms these; EnsureWatch / the rescan ticker start loops when
@@ -55,53 +73,177 @@ type Registry struct {
 	rescanStarted bool
 }
 
-// New returns an empty workspace registry.
-func New() *Registry {
-	return &Registry{entries: make(map[string]*Entry)}
+// openFlight is one in-flight construct for a profile name. Same-key racers
+// wait on done instead of calling store.Open twice (migrate is not safe
+// against one file from two Open calls at once).
+type openFlight struct {
+	done chan struct{}
+	e    *Entry
+	err  error
 }
 
+// New returns an empty workspace registry.
+func New() *Registry {
+	return &Registry{
+		entries: make(map[string]*Entry),
+		flights: make(map[string]*openFlight),
+	}
+}
+
+// OpenInFlight is how many Get/open constructions are running outside mu.
+// Same shape as store.WriteBusyRetries: a cheap accessor, no logs.
+func (r *Registry) OpenInFlight() int64 {
+	if r == nil {
+		return 0
+	}
+	return r.openInFlight.Load()
+}
+
+// OpensDiscarded is how many constructed entries lost the publish race
+// (or saw Close) and were closed. Same shape as store.WriteBusyRetries.
+func (r *Registry) OpensDiscarded() uint64 {
+	if r == nil {
+		return 0
+	}
+	return r.opensDiscarded.Load()
+}
+
+// testBeforeConstruct, if set, runs at the start of construction. Tests use
+// it as a barrier to prove the registry mutex is not held across store.Open.
+// Production is nil (one pointer compare on the miss path).
+var testBeforeConstruct func(name string)
+
 // Close closes every opened workspace DB. Safe to call once at shutdown.
+// In-flight constructors are waited on (they see closed and close their
+// own object) so this never closes a half-built entry.
 func (r *Registry) Close() {
 	if r == nil {
 		return
 	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	for name, e := range r.entries {
-		if e != nil {
-			// Stop this workspace's background sync before closing the mirror
-			// it writes to; a job that outlives the DB holds a WAL connection
-			// (GDK-270).
-			if e.Handler != nil {
-				_ = e.Handler.Close()
-			}
-			if e.DB != nil {
-				_ = e.DB.Close()
-			}
-		}
-		delete(r.entries, name)
+	r.closed = true
+	wait := make([]chan struct{}, 0, len(r.flights))
+	for _, f := range r.flights {
+		wait = append(wait, f.done)
+	}
+	r.mu.Unlock()
+	for _, done := range wait {
+		<-done
+	}
+	r.mu.Lock()
+	snapshot := r.entries
+	r.entries = make(map[string]*Entry)
+	r.mu.Unlock()
+	for _, e := range snapshot {
+		closeEntry(e)
+	}
+}
+
+func closeEntry(e *Entry) {
+	if e == nil {
+		return
+	}
+	// Stop this workspace's background sync before closing the mirror
+	// it writes to; a job that outlives the DB holds a WAL connection
+	// (GDK-270).
+	if e.Handler != nil {
+		_ = e.Handler.Close()
+	}
+	if e.DB != nil {
+		_ = e.DB.Close()
 	}
 }
 
 // Get returns a cached workspace entry, opening the profile on first use.
 func (r *Registry) Get(name string) (*Entry, error) {
+	if r == nil {
+		return nil, errRegistryClosed
+	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil, errRegistryClosed
+	}
 	if e, ok := r.entries[name]; ok {
+		r.mu.Unlock()
 		return e, nil
 	}
-	e, err := r.openLocked(name)
+	r.mu.Unlock()
+	e, err := r.open(name)
 	if err != nil {
 		return nil, err
 	}
 	// First open after CLI init: start Watch if a credential is already on disk
 	// and WatchAll has armed the owner. Per-request path after this is a map hit.
-	r.ensureWatchLocked(name)
+	r.EnsureWatch(name)
 	return e, nil
 }
 
-// openLocked creates and caches a workspace entry. Caller holds r.mu.
-func (r *Registry) openLocked(name string) (*Entry, error) {
+// open is lookup → unlock → construct → re-lock and publish. Same-name
+// racers share one store.Open (migrate is not safe twice on one file).
+func (r *Registry) open(name string) (*Entry, error) {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil, errRegistryClosed
+	}
+	if e, ok := r.entries[name]; ok {
+		r.mu.Unlock()
+		return e, nil
+	}
+	if f, ok := r.flights[name]; ok {
+		r.mu.Unlock()
+		<-f.done
+		return f.e, f.err
+	}
+	f := &openFlight{done: make(chan struct{})}
+	if r.flights == nil {
+		r.flights = map[string]*openFlight{}
+	}
+	r.flights[name] = f
+	r.mu.Unlock()
+
+	if testBeforeConstruct != nil {
+		testBeforeConstruct(name)
+	}
+
+	r.openInFlight.Add(1)
+	e, err := r.construct(name)
+	r.openInFlight.Add(-1)
+
+	r.mu.Lock()
+	delete(r.flights, name)
+	if err != nil {
+		f.err = err
+		close(f.done)
+		r.mu.Unlock()
+		return nil, err
+	}
+	if r.closed {
+		r.opensDiscarded.Add(1)
+		r.mu.Unlock()
+		closeEntry(e)
+		f.err = errRegistryClosed
+		close(f.done)
+		return nil, errRegistryClosed
+	}
+	if existing, ok := r.entries[name]; ok {
+		r.opensDiscarded.Add(1)
+		r.mu.Unlock()
+		closeEntry(e)
+		f.e = existing
+		close(f.done)
+		return existing, nil
+	}
+	r.entries[name] = e
+	f.e = e
+	close(f.done)
+	r.mu.Unlock()
+	return e, nil
+}
+
+// construct builds an Entry with no lock held. Caller publishes or closes it.
+func (r *Registry) construct(name string) (*Entry, error) {
 	cfg, err := config.LoadFor(name)
 	if err != nil {
 		return nil, err
@@ -127,9 +269,7 @@ func (r *Registry) openLocked(name string) (*Entry, error) {
 	// Same seam as the primary serve handler: first successful onboarding
 	// connect starts this profile's Watch exactly once (server-side Once).
 	h.SetSyncStarter(func() { r.EnsureWatch(profileName) })
-	e := &Entry{Handler: h, DB: db, Cfg: cfg}
-	r.entries[name] = e
-	return e, nil
+	return &Entry{Handler: h, DB: db, Cfg: cfg}, nil
 }
 
 // ProfileExists reports whether name is a directory under profiles/ (disk is
@@ -341,13 +481,75 @@ func (r *Registry) EnsureWatches() []string {
 
 // EnsureWatch starts this profile's Watch if WatchAll has armed the owner, the
 // profile now has a credential, and no loop is already running. Idempotent.
+// LoadFor and store.Open run with r.mu released.
 func (r *Registry) EnsureWatch(name string) bool {
 	if r == nil {
 		return false
 	}
 	r.mu.Lock()
+	if !r.watchReadyLocked(name) {
+		r.mu.Unlock()
+		return false
+	}
+	r.mu.Unlock()
+
+	// Credential first, mirror second. Opening the database runs migrations —
+	// a profile that will never sync should not have its file rewritten just
+	// to learn it has no token.
+	cfg, err := config.LoadFor(name)
+	if err != nil || !cfg.HasCredential() {
+		return false
+	}
+
+	e, err := r.open(name)
+	if err != nil {
+		r.mu.Lock()
+		logf := r.watchLogf
+		r.mu.Unlock()
+		if logf != nil {
+			logf("workspace " + name + ": open failed: " + err.Error())
+		}
+		return false
+	}
+	if e.DB == nil {
+		return false
+	}
+
+	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.ensureWatchLocked(name)
+	if !r.watchReadyLocked(name) {
+		return false
+	}
+	if r.watching == nil {
+		r.watching = map[string]bool{}
+	}
+	r.watching[name] = true
+	ctx, logf, db := r.watchCtx, r.watchLogf, e.DB
+	profileName := name
+	go func() {
+		opts := syncer.Options{
+			Reload: func() (*config.Config, error) {
+				return config.LoadFor(profileName)
+			},
+		}
+		if logf != nil {
+			// Prefix with profile name only — no site/email/token.
+			opts.Log = func(s string) { logf("workspace " + profileName + ": " + s) }
+		}
+		cur := cfg
+		if next, err := config.LoadFor(profileName); err == nil && next != nil {
+			cur = next
+		}
+		if err := syncer.Watch(ctx, cur, db, opts); err != nil && ctx.Err() == nil {
+			if logf != nil {
+				logf("workspace " + profileName + ": sync loop stopped: " + err.Error())
+			}
+		}
+	}()
+	if logf != nil {
+		logf("workspace " + profileName + ": watch started")
+	}
+	return true
 }
 
 // Watching returns the profile names whose Watch loop has been started.
@@ -381,8 +583,12 @@ func (r *Registry) rescanLoop(ctx context.Context) {
 	}
 }
 
-// ensureWatchLocked starts one Watch. Caller holds r.mu.
-func (r *Registry) ensureWatchLocked(name string) bool {
+// watchReadyLocked reports whether EnsureWatch may proceed past the
+// in-memory gates. Caller holds r.mu. Does not touch disk.
+func (r *Registry) watchReadyLocked(name string) bool {
+	if r.closed {
+		return false
+	}
 	if r.watchCtx == nil || r.watchCtx.Err() != nil {
 		return false
 	}
@@ -391,55 +597,6 @@ func (r *Registry) ensureWatchLocked(name string) bool {
 	}
 	if r.watching[name] {
 		return false
-	}
-	// Credential first, mirror second. Opening the database runs migrations —
-	// a profile that will never sync should not have its file rewritten just
-	// to learn it has no token.
-	cfg, err := config.LoadFor(name)
-	if err != nil || !cfg.HasCredential() {
-		return false
-	}
-	e := r.entries[name]
-	if e == nil {
-		e, err = r.openLocked(name)
-		if err != nil {
-			if r.watchLogf != nil {
-				r.watchLogf("workspace " + name + ": open failed: " + err.Error())
-			}
-			return false
-		}
-	}
-	if e.DB == nil {
-		return false
-	}
-	if r.watching == nil {
-		r.watching = map[string]bool{}
-	}
-	r.watching[name] = true
-	ctx, logf, db := r.watchCtx, r.watchLogf, e.DB
-	profileName := name
-	go func() {
-		opts := syncer.Options{
-			Reload: func() (*config.Config, error) {
-				return config.LoadFor(profileName)
-			},
-		}
-		if logf != nil {
-			// Prefix with profile name only — no site/email/token.
-			opts.Log = func(s string) { logf("workspace " + profileName + ": " + s) }
-		}
-		cur := cfg
-		if next, err := config.LoadFor(profileName); err == nil && next != nil {
-			cur = next
-		}
-		if err := syncer.Watch(ctx, cur, db, opts); err != nil && ctx.Err() == nil {
-			if logf != nil {
-				logf("workspace " + profileName + ": sync loop stopped: " + err.Error())
-			}
-		}
-	}()
-	if logf != nil {
-		logf("workspace " + profileName + ": watch started")
 	}
 	return true
 }


### PR DESCRIPTION
One class, three sites, from the v0.16 audit (axis 1, F2/F4/F5). In each, the critical section is a map insert and the lock was held across **opening a database**.

| site | held across |
|---|---|
| `server.derived` | `IssueLites`, `buildView`, two `EnrichmentsByKind`, `GroupQueryHits` — the **HTTP list path**, not a once-per-process init. One cache miss serialised every other caller. |
| `workspace.Get`/`openLocked` | `config.LoadFor`, `store.Open` (migrations + FTS repair), `attachcache.New`, `server.NewWorkspace`. Profile B's first request blocked profile A's `Get`/`EnsureWatch`/`Close` for the whole migration. |
| `origin.standaloneSession` | a **process-global** mutex across `MkdirAll` + `issuetap.NewEmbedded` — which reads and writes the persist file, i.e. a standalone workspace's real persistence. |

All three become lookup → unlock → construct → re-lock and publish.

**The answer differs per site, and that difference is the work.**

`derived` **discards the loser**: a rebuild is a read of the mirror, so a same-key double scan is wasted CPU and the discarded view owns no handle.

`workspace` and `origin` use a **keyed singleflight**, because their construction is not safe to run twice on one file:

- `store.Open`'s `migrate` reads `user_version` then writes from that snapshot — two Opens can both see `have < want` and the loser re-runs applied SQL.
- Two `NewEmbedded` on one persist path both stat, both seed or both load, and both start debounce writers: last write wins and two in-memory graphs diverge.

Different keys still construct in parallel. No process-wide `sync.Once` — that is how site 3 got a global mutex in the first place.

**The loser's object is closed, not dropped.** A leaked `*sql.DB` per lost race would be worse than the bug being fixed.

**`Close` cannot close a half-built entry**: it sets `closed`, waits on the in-flight channels, then snapshots the map and closes outside the lock. An in-flight constructor sees `closed`, closes its own object and signals. No new flight can start, because `open` checks `closed` before creating one. `Get` after `Close` now returns an error rather than reopening a mirror during shutdown.

`EnsureWatch` no longer does `LoadFor` + `store.Open` under `r.mu` either — in-memory gates, release, construct, re-check.

## Recurrence — structural, not timed

This repository has spent three rounds on flaky timing gates (GDK-303, GDK-270, GDK-290), so **no test here sleeps or compares wall clocks.** Each drives one construction to a barrier and asserts `TryLock` succeeds on the registry mutex, with a second key constructing concurrently. All three fail on the unmodified sources:

```
--- FAIL: TestGetReleasesLockDuringOpen
    Get still holds r.mu during construction — one profile's store.Open serialises every other Get/EnsureWatch/Close
--- FAIL: TestStandaloneSessionReleasesLockDuringOpen
    standaloneSession still holds the process-global mutex during NewEmbedded
--- FAIL: TestDerivedReleasesLockDuringRebuild
    derived still holds s.mu during rebuild — one cache miss serialises every other derived caller
```

## Debuggability

Lock wait was invisible. Each site gains a cheap counter in the house shape of `store.WriteBusyRetries` (GDK-305): in-flight constructions and discarded opens.

## Gates — re-run cold by the lead

`go build` / `go vet` exit 0 · `go test ./... -count=1` exit 0, 30 packages · `go test ./internal/server/ ./internal/workspace/ ./internal/origin/ -count=2 -race` **exit 0**. Timings were under contention with four other rounds and are not benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)