### PR TITLE
fix(create): the shared resolver spoke CLI flag names and REST handed them to HTTP clients (GDK-283)

### DIFF
--- a/cmd/gadak/create.go
+++ b/cmd/gadak/create.go
@@ -226,7 +226,7 @@ func createOne(ctx context.Context, cfg *config.Config, c *jira.Client, projectW
 	}
 	projRes, err := create.Project(projectWant, cfg)
 	if err != nil {
-		return "", nil, err
+		return "", nil, formatCreateError(err)
 	}
 	meta, err := c.CreateMeta(ctx, []string{projRes.Value})
 	if err != nil {
@@ -238,7 +238,7 @@ func createOne(ctx context.Context, cfg *config.Config, c *jira.Client, projectW
 	}
 	typeRes, err := create.Type(typeWant, types, cfg, projRes.Value)
 	if err != nil {
-		return "", nil, err
+		return "", nil, formatCreateError(err)
 	}
 
 	fields := map[string]any{
@@ -259,7 +259,7 @@ func createOne(ctx context.Context, cfg *config.Config, c *jira.Client, projectW
 		}
 		id, err := create.Priority(p, list)
 		if err != nil {
-			return "", nil, err
+			return "", nil, formatCreateError(err)
 		}
 		fields["priority"] = create.PriorityField(id)
 	}
@@ -293,6 +293,27 @@ func createOne(ctx context.Context, cfg *config.Config, c *jira.Client, projectW
 		extra["attached"] = attached
 	}
 	return key, extra, nil
+}
+
+// formatCreateError turns shared Need* catalogue data into the CLI flag +
+// catalog sentences. The shared package must not compose those flags itself.
+func formatCreateError(err error) error {
+	var np *create.NeedProjectError
+	if errors.As(err, &np) {
+		if len(np.Configured) == 0 {
+			return fmt.Errorf("pass --project")
+		}
+		return fmt.Errorf("pass --project, configured: %s", strings.Join(np.Configured, ", "))
+	}
+	var nt *create.NeedTypeError
+	if errors.As(err, &nt) {
+		return fmt.Errorf("pass --type, available: %s", create.FormatTypes(nt.Available))
+	}
+	var npri *create.NeedPriorityError
+	if errors.As(err, &npri) {
+		return fmt.Errorf("pass --priority, available: %s", create.FormatTypes(npri.Available))
+	}
+	return err
 }
 
 // emitBatchLine refreshes the new key the same way emitAfterWrite does.

--- a/cmd/gadak/create_test.go
+++ b/cmd/gadak/create_test.go
@@ -293,6 +293,23 @@ func TestCreateTypeOmittedListsAvailable(t *testing.T) {
 	}
 }
 
+func TestFormatCreateErrorKeepsFlagAndCatalog(t *testing.T) {
+	if got := formatCreateError(&create.NeedProjectError{}).Error(); got != "pass --project" {
+		t.Fatalf("empty projects: %q", got)
+	}
+	if got := formatCreateError(&create.NeedProjectError{Configured: []string{"NMA", "NMB", "NMS"}}).Error(); got != "pass --project, configured: NMA, NMB, NMS" {
+		t.Fatalf("configured: %q", got)
+	}
+	types := []jira.NamedID{{ID: "10001", Name: "Task"}, {ID: "10002", Name: "작업"}, {ID: "10004", Name: "Bug"}}
+	if got := formatCreateError(&create.NeedTypeError{Available: types}).Error(); got != "pass --type, available: Task (id 10001); 작업 (id 10002); Bug (id 10004)" {
+		t.Fatalf("type: %q", got)
+	}
+	pris := []jira.NamedID{{ID: "1", Name: "Highest"}, {ID: "2", Name: "High"}, {ID: "3", Name: "Medium"}}
+	if got := formatCreateError(&create.NeedPriorityError{Available: pris}).Error(); got != "pass --priority, available: Highest (id 1); High (id 2); Medium (id 3)" {
+		t.Fatalf("priority: %q", got)
+	}
+}
+
 func TestCreateTypeMatchesCaseAndID(t *testing.T) {
 	f := newFakeJira(t)
 	mirror(t, f.URL)
@@ -1784,7 +1801,7 @@ func TestCreateResolveTypeTable(t *testing.T) {
 		{"flag korean", "작업", "NMB", many, nil, "10002", create.SourceFlag, ""},
 		{"config", "", "NMB", many, cfg("10001"), "10001", create.SourceConfig, ""},
 		{"sole", "", "GDK", one, nil, "10001", create.SourceSole, ""},
-		{"omitted no evidence", "", "NMB", many, nil, "", "", "pass --type"},
+		{"omitted no evidence", "", "NMB", many, nil, "", "", "issue type required"},
 		{"stale default", "", "NMB", many, cfg("99999"), "", "", "99999"},
 		{"stale does not fall to sole", "", "GDK", one, cfg("99999"), "", "", "99999"},
 		{"flag beats config", "Bug", "NMB", many, cfg("10001"), "10004", create.SourceFlag, ""},
@@ -1819,8 +1836,8 @@ func TestCreateResolveProjectTable(t *testing.T) {
 		{"flag", "NMB", &config.Config{Projects: []string{"NMA", "NMB"}, DefaultProject: "NMA"}, "NMB", create.SourceFlag, ""},
 		{"config", "", &config.Config{Projects: []string{"NMA", "NMB"}, DefaultProject: "NMB"}, "NMB", create.SourceConfig, ""},
 		{"sole", "", &config.Config{Projects: []string{"NMB"}}, "NMB", create.SourceSole, ""},
-		{"ambiguous", "", &config.Config{Projects: []string{"NMA", "NMB"}}, "", "", "pass --project"},
-		{"none", "", &config.Config{}, "", "", "pass --project"},
+		{"ambiguous", "", &config.Config{Projects: []string{"NMA", "NMB"}}, "", "", "project required"},
+		{"none", "", &config.Config{}, "", "", "project required"},
 		{"flag beats config", "GDK", &config.Config{DefaultProject: "NMB", Projects: []string{"NMB", "GDK"}}, "GDK", create.SourceFlag, ""},
 	}
 	for _, tc := range cases {

--- a/cmd/gadak/edit.go
+++ b/cmd/gadak/edit.go
@@ -135,7 +135,7 @@ func cmdEdit(args []string) error {
 			}
 			id, err := create.Priority(*priority, list)
 			if err != nil {
-				return nil, err
+				return nil, formatCreateError(err)
 			}
 			fields["priority"] = map[string]string{"id": id}
 		}

--- a/internal/create/resolve.go
+++ b/internal/create/resolve.go
@@ -1,6 +1,9 @@
 // Package create is the single owner of project, issue-type, and priority
 // resolution for gadak create (CLI and REST). Both surfaces must call these
 // functions so a default cannot exist on one path and not the other.
+//
+// Need* errors carry catalogue data only. The CLI formats flag names;
+// REST maps them to stable wire codes. This package does not name CLI flags.
 package create
 
 import (
@@ -47,9 +50,9 @@ func Project(want string, cfg *config.Config) (Resolved, error) {
 		return Resolved{Value: configured[0], Source: SourceSole}, nil
 	}
 	if len(configured) == 0 {
-		return Resolved{}, fmt.Errorf("pass --project")
+		return Resolved{}, &NeedProjectError{}
 	}
-	return Resolved{}, fmt.Errorf("pass --project, configured: %s", strings.Join(configured, ", "))
+	return Resolved{}, &NeedProjectError{Configured: copyStrings(configured)}
 }
 
 // Type resolves the create issue type:
@@ -87,7 +90,7 @@ func Type(want string, types []jira.NamedID, cfg *config.Config, project string)
 	if len(types) == 1 && strings.TrimSpace(types[0].ID) != "" {
 		return Resolved{Value: types[0].ID, Source: SourceSole}, nil
 	}
-	return Resolved{}, fmt.Errorf("pass --type, available: %s", FormatTypes(types))
+	return Resolved{}, &NeedTypeError{Available: copyNamed(types)}
 }
 
 func matchType(want string, types []jira.NamedID) (string, error) {
@@ -123,7 +126,7 @@ func FormatTypes(types []jira.NamedID) string {
 func Priority(want string, list []jira.NamedID) (id string, err error) {
 	want = strings.TrimSpace(want)
 	if want == "" {
-		return "", fmt.Errorf("pass --priority, available: %s", FormatTypes(list))
+		return "", &NeedPriorityError{Available: copyNamed(list)}
 	}
 	for _, p := range list {
 		if p.ID == want || strings.EqualFold(p.Name, want) {
@@ -137,4 +140,61 @@ func Priority(want string, list []jira.NamedID) (id string, err error) {
 // localized name. Create and edit both send this shape.
 func PriorityField(id string) map[string]string {
 	return map[string]string{"id": id}
+}
+
+// NeedProjectError is returned when create cannot resolve a project.
+// Configured is the profile project list (may be empty). Surfaces format this.
+type NeedProjectError struct {
+	Configured []string
+}
+
+func (e *NeedProjectError) Error() string {
+	if e == nil || len(e.Configured) == 0 {
+		return "project required"
+	}
+	return "project required, configured: " + strings.Join(e.Configured, ", ")
+}
+
+// NeedTypeError is returned when create cannot resolve an issue type.
+// Available is the createmeta catalog. Surfaces format this.
+type NeedTypeError struct {
+	Available []jira.NamedID
+}
+
+func (e *NeedTypeError) Error() string {
+	if e == nil {
+		return "issue type required"
+	}
+	return "issue type required, available: " + FormatTypes(e.Available)
+}
+
+// NeedPriorityError is returned when a priority name or id was required but empty.
+// Available is the site catalog. Surfaces format this.
+type NeedPriorityError struct {
+	Available []jira.NamedID
+}
+
+func (e *NeedPriorityError) Error() string {
+	if e == nil {
+		return "priority required"
+	}
+	return "priority required, available: " + FormatTypes(e.Available)
+}
+
+func copyStrings(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func copyNamed(in []jira.NamedID) []jira.NamedID {
+	if in == nil {
+		return nil
+	}
+	out := make([]jira.NamedID, len(in))
+	copy(out, in)
+	return out
 }

--- a/internal/create/resolve_test.go
+++ b/internal/create/resolve_test.go
@@ -1,9 +1,11 @@
 package create
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/jira"
 )
 
@@ -49,8 +51,41 @@ func TestPriorityMatchesLocalizedName(t *testing.T) {
 
 func TestPriorityEmptyListsCatalog(t *testing.T) {
 	_, err := Priority("", priList())
-	if err == nil || !strings.Contains(err.Error(), "pass --priority") || !strings.Contains(err.Error(), "Highest (id 1)") {
-		t.Fatalf("empty: %v", err)
+	var need *NeedPriorityError
+	if !errors.As(err, &need) {
+		t.Fatalf("empty: %v (want NeedPriorityError)", err)
+	}
+	if !strings.Contains(FormatTypes(need.Available), "Highest (id 1)") {
+		t.Fatalf("catalog: %+v", need.Available)
+	}
+	if strings.Contains(err.Error(), "--") {
+		t.Fatalf("shared error named a flag: %v", err)
+	}
+}
+
+func TestNeedErrorsDoNotNameCLIFlags(t *testing.T) {
+	errs := []error{
+		func() error { _, e := Project("", &config.Config{}); return e }(),
+		func() error { _, e := Project("", &config.Config{Projects: []string{"NMA", "NMB"}}); return e }(),
+		func() error { _, e := Type("", priList(), nil, "NMB"); return e }(),
+		func() error { _, e := Priority("", priList()); return e }(),
+	}
+	for i, err := range errs {
+		if err == nil {
+			t.Errorf("%d: nil error", i)
+			continue
+		}
+		if strings.Contains(err.Error(), "--") {
+			t.Errorf("%d: shared error named a flag: %v", i, err)
+		}
+	}
+	var np *NeedProjectError
+	if _, err := Project("", &config.Config{Projects: []string{"NMA", "NMB"}}); !errors.As(err, &np) || strings.Join(np.Configured, ",") != "NMA,NMB" {
+		t.Fatalf("NeedProjectError: %v", err)
+	}
+	var nt *NeedTypeError
+	if _, err := Type("", priList(), nil, "NMB"); !errors.As(err, &nt) || len(nt.Available) != 3 {
+		t.Fatalf("NeedTypeError: %v", err)
 	}
 }
 

--- a/internal/server/write.go
+++ b/internal/server/write.go
@@ -644,6 +644,27 @@ func (s *server) handleFields(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// failCreate maps shared create-resolution errors onto stable wire codes.
+// Need* errors are surface-neutral; CLI flag names stay in cmd/gadak.
+func failCreate(w http.ResponseWriter, err error) {
+	var np *create.NeedProjectError
+	if errors.As(err, &np) {
+		fail(w, http.StatusBadRequest, "project_required")
+		return
+	}
+	var nt *create.NeedTypeError
+	if errors.As(err, &nt) {
+		fail(w, http.StatusBadRequest, "issue_type_required")
+		return
+	}
+	var npri *create.NeedPriorityError
+	if errors.As(err, &npri) {
+		fail(w, http.StatusBadRequest, "priority_required")
+		return
+	}
+	writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+}
+
 /* ── create ── */
 
 func (s *server) handleCreate(w http.ResponseWriter, r *http.Request) {
@@ -675,7 +696,7 @@ func (s *server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	proj, err := create.Project(p.ProjectKey, cfg)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		failCreate(w, err)
 		return
 	}
 	// An issue filed outside the mirrored projects would never come back from the
@@ -691,12 +712,12 @@ func (s *server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	metaProj, types, err := create.MetaFor(meta, proj.Value)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		failCreate(w, err)
 		return
 	}
 	typ, err := create.Type(p.IssueType, types, cfg, proj.Value)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		failCreate(w, err)
 		return
 	}
 

--- a/internal/server/write_test.go
+++ b/internal/server/write_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/create"
+	"github.com/midagedev/gadak/internal/jira"
 	"github.com/midagedev/gadak/internal/sync"
 )
 
@@ -516,11 +519,92 @@ func TestCreateIssueOmitsTypeFailsWhenMany(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("create → %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "pass --type") {
-		t.Errorf("error %s", rec.Body.String())
+	// 2026-08-19: retargeted from the CLI prose "pass --type" to the stable
+	// wire code. That assertion froze the F6 leak (internal/create composed
+	// CLI flag names; REST copied err.Error() into the JSON body). Same 400
+	// and no-Jira-call contract; the body now keys on the house-style code
+	// the way project_not_mirrored does (fail() in server.go), not on a
+	// surface sentence.
+	if got := decode[map[string]string](t, rec)["error"]; got != "issue_type_required" {
+		t.Errorf("error %q", got)
 	}
 	if f.called("POST /issue") {
 		t.Fatalf("omitted type reached Jira: %v", f.calls)
+	}
+}
+
+func TestCreateIssueOmitsProjectFailsWhenAmbiguous(t *testing.T) {
+	f, h, _ := writable(t)
+
+	rec := send(t, h, http.MethodPost, apiBase+"create/",
+		`{"summary":"needs a project","issue_type":"10004"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("create → %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decode[map[string]string](t, rec)["error"]; got != "project_required" {
+		t.Errorf("error %q", got)
+	}
+	if f.called("POST /issue") {
+		t.Fatalf("omitted project reached Jira: %v", f.calls)
+	}
+}
+
+// cliFlagToken matches a GNU-style long option in a REST body. The class is
+// "any token starting with --", not today's three create cases: a future
+// shared-package error that names a flag must fail here too.
+var cliFlagToken = regexp.MustCompile(`--[A-Za-z][A-Za-z0-9_-]*`)
+
+func TestCreateRESTErrorBodiesHaveNoCLIFlagTokens(t *testing.T) {
+	f, h, cfg := writable(t)
+	f.createMetaJSON = manyCreateTypes
+	cfg.DefaultProject = ""
+	cfg.DefaultIssueTypeID = ""
+
+	cases := []struct {
+		name, body string
+	}{
+		{"omitted project", `{"summary":"x","issue_type":"10004"}`},
+		{"omitted type", `{"project_key":"NMB","summary":"needs a type"}`},
+		{"unmatched type", `{"project_key":"NMB","issue_type":"Nope","summary":"x"}`},
+		{"unmirrored project", `{"project_key":"ZZZ","issue_type":"10004","summary":"x"}`},
+		{"empty summary", `{"project_key":"NMB","issue_type":"10004"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := send(t, h, http.MethodPost, apiBase+"create/", tc.body)
+			if rec.Code < 400 {
+				t.Fatalf("want 4xx, got %d %s", rec.Code, rec.Body.String())
+			}
+			if hits := cliFlagToken.FindAllString(rec.Body.String(), -1); len(hits) > 0 {
+				t.Errorf("REST body contains CLI flag token(s) %v: %s", hits, rec.Body.String())
+			}
+		})
+	}
+
+	// Stale configured default is another create 400; include it so a future
+	// rewrite of that path cannot sneak a -- token in.
+	cfg.DefaultIssueTypeID = "99999"
+	rec := send(t, h, http.MethodPost, apiBase+"create/", `{"project_key":"NMB","summary":"stale"}`)
+	if rec.Code < 400 {
+		t.Fatalf("stale default → %d %s", rec.Code, rec.Body.String())
+	}
+	if hits := cliFlagToken.FindAllString(rec.Body.String(), -1); len(hits) > 0 {
+		t.Errorf("stale-default REST body contains CLI flag token(s) %v: %s", hits, rec.Body.String())
+	}
+
+	// REST create does not call create.Priority today (priority_id is an id).
+	// failCreate still owns that Need* type so a future caller cannot dump
+	// "--priority" onto the wire.
+	recP := httptest.NewRecorder()
+	failCreate(recP, &create.NeedPriorityError{Available: []jira.NamedID{{ID: "1", Name: "Highest"}}})
+	if recP.Code < 400 {
+		t.Fatalf("need priority → %d %s", recP.Code, recP.Body.String())
+	}
+	if hits := cliFlagToken.FindAllString(recP.Body.String(), -1); len(hits) > 0 {
+		t.Errorf("need-priority body contains CLI flag token(s) %v: %s", hits, recP.Body.String())
+	}
+	if got := decode[map[string]string](t, recP)["error"]; got != "priority_required" {
+		t.Errorf("need-priority code %q", got)
 	}
 }
 


### PR DESCRIPTION
`internal/create`'s own doc comment declares it the single owner shared by the CLI and REST. It was composing `pass --project`, `pass --type, available: …`, `pass --priority, available: …` — sentences for a surface it cannot see.

`internal/server/write.go` copied `err.Error()` straight into the HTTP JSON body, so **a client that never had a command line was told to pass `--project`**. And `write_test.go:519` asserted the 400 body contains `pass --type` — a test holding the leak in place.

The same `write.go` already used stable wire codes elsewhere (`project_not_mirrored`), so the house shape existed and this path missed it.

## The fix

`Need*` errors now carry **catalogue data and nothing else** — the configured project list, the createmeta types, the priority list, defensively copied.

- **CLI** formats the flag sentences in `cmd/gadak`. Output is **byte-identical to before**: the user still learns both the flag and what values exist. `edit.go` turned out to be a second caller and gets the same formatter.
- **REST** maps the three onto `project_required` / `issue_type_required` / `priority_required` through one `failCreate`, in the existing `fail()` style.

## Recurrence — a class scan, not today's three cases

A regexp for any GNU-style long option in a REST error body, run over five create failure paths plus the stale-default path — so a *future* error added to the shared package is caught too.

Plus `failCreate` driven directly with a `NeedPriorityError`: REST create does not reach `create.Priority` today, and a future caller must not be able to dump `--priority` onto the wire.

## The retargeted assertion

`write_test.go` carries an attribution comment with the date and reason. It is a **change of target, not a weakening** — the same 400 and the same "did not reach Jira" contract still hold — and the new assertion fails against the unmodified source.

## Debuggability

A wire code lets a log tell "the user did not name a project" apart from "the project is not mirrored". `err.Error()` prose could not.

## Gates — re-run cold by the lead

`go build` exit 0 · `go vet` exit 0 · `go test ./... -count=1` exit 0, 30 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)