### PR TITLE
refactor(clitool): the npm fallback table existed twice, and the second copy said so in its own comment (GDK-286)

### DIFF
--- a/cmd/gadak/raycast.go
+++ b/cmd/gadak/raycast.go
@@ -19,7 +19,6 @@ import (
 
 	raycastext "github.com/midagedev/gadak/contrib/raycast"
 	"github.com/midagedev/gadak/internal/clitool"
-	"github.com/midagedev/gadak/internal/config"
 )
 
 func init() {
@@ -36,20 +35,11 @@ func init() {
 }
 
 const (
-	raycastExtDirName      = "raycast-extension"
 	developSuccessMarker   = "built extension successfully"
 	developTimeoutDefault  = 90 * time.Second
 	developSettleDefault   = 3 * time.Second
 	developStopWaitDefault = 10 * time.Second
 )
-
-// npmFallbackPaths is LookPath("npm") then these, first existing+executable
-// wins. Same brew locations as contrib/raycast/src/gadak.ts GADAK_CANDIDATES,
-// opposite direction (we are finding npm, not gadak).
-var npmFallbackPaths = []string{
-	"/opt/homebrew/bin/npm",
-	"/usr/local/bin/npm",
-}
 
 // lookPath is exec.LookPath; tests inject a stub.
 var lookPath = exec.LookPath
@@ -77,7 +67,7 @@ func cmdRaycastInstall(args []string) error {
 		return usageError("raycast", "usage: gadak raycast install")
 	}
 
-	dest, err := raycastExtDir()
+	dest, err := clitool.RaycastExtDir()
 	if err != nil {
 		return err
 	}
@@ -85,7 +75,7 @@ func cmdRaycastInstall(args []string) error {
 		return err
 	}
 
-	npm, ok := resolveNPM(lookPath, fileIsExec)
+	npm, ok := clitool.ResolveNPM(lookPath, fileIsExec)
 	if !ok {
 		return fmt.Errorf("%s", strings.TrimRight(npmMissingMessage(), "\n"))
 	}
@@ -107,16 +97,6 @@ func cmdRaycastInstall(args []string) error {
 	fmt.Println("Raycast에서 'Search Jira & Confluence'를 실행하세요")
 	fmt.Println("스토어 심사가 끝나면 Raycast Store 설치로 교체할 수 있습니다.")
 	return nil
-}
-
-// raycastExtDir is ~/.gadak/raycast-extension, or $GADAK_HOME/raycast-extension.
-// Profile is ignored: the extension is one copy per gadak home.
-func raycastExtDir() (string, error) {
-	base, err := config.DirFor("")
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(base, raycastExtDirName), nil
 }
 
 func deployRaycastExt(dst string, src fs.FS) error {
@@ -174,25 +154,6 @@ func extractEmbedFS(dst string, src fs.FS) error {
 	})
 }
 
-// resolveNPM tries PATH, then npmFallbackPaths. look and present are injected
-// so tests can assert the candidate order without touching the host.
-func resolveNPM(look func(string) (string, error), present func(string) bool) (string, bool) {
-	if look != nil {
-		if p, err := look("npm"); err == nil && p != "" {
-			return p, true
-		}
-	}
-	if present == nil {
-		present = isExecutable
-	}
-	for _, c := range npmFallbackPaths {
-		if present(c) {
-			return c, true
-		}
-	}
-	return "", false
-}
-
 func isExecutable(path string) bool {
 	fi, err := os.Stat(path)
 	if err != nil || fi.IsDir() {
@@ -202,12 +163,12 @@ func isExecutable(path string) bool {
 }
 
 func npmMissingMessage() string {
-	return `Node.js (npm) is required to install the Raycast extension.
-The extension is under review at https://github.com/raycast/extensions/pull/30297
-Until it is in the store, you can install from source:
-  git clone https://github.com/midagedev/gadak && cd gadak/contrib/raycast
-  npm ci && npm run dev
-`
+	return "Node.js (npm) is required to install the Raycast extension.\n" +
+		"Looked for npm on " + clitool.NPMNotFoundDetail() + ".\n" +
+		"The extension is under review at https://github.com/raycast/extensions/pull/30297\n" +
+		"Until it is in the store, you can install from source:\n" +
+		"  git clone https://github.com/midagedev/gadak && cd gadak/contrib/raycast\n" +
+		"  npm ci && npm run dev\n"
 }
 
 func runNPMCi(npm, dir string) error {

--- a/cmd/gadak/raycast_test.go
+++ b/cmd/gadak/raycast_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	raycastext "github.com/midagedev/gadak/contrib/raycast"
+	"github.com/midagedev/gadak/internal/clitool"
 	"github.com/midagedev/gadak/internal/config"
 )
 
@@ -88,10 +89,10 @@ func TestResolveNPMLookupOrder(t *testing.T) {
 		order = append(order, p)
 		return false
 	}
-	if got, ok := resolveNPM(look, present); ok {
+	if got, ok := clitool.ResolveNPM(look, present); ok {
 		t.Fatalf("expected miss, got %q", got)
 	}
-	want := append([]string{"path:npm"}, npmFallbackPaths...)
+	want := append([]string{"path:npm"}, clitool.NPMFallbackPaths...)
 	if strings.Join(order, ",") != strings.Join(want, ",") {
 		t.Errorf("order %v, want %v", order, want)
 	}
@@ -108,7 +109,7 @@ func TestResolveNPMPathWins(t *testing.T) {
 		t.Errorf("fallback should not run after PATH hit; present(%s)", p)
 		return false
 	}
-	got, ok := resolveNPM(look, present)
+	got, ok := clitool.ResolveNPM(look, present)
 	if !ok || got != "/custom/bin/npm" {
 		t.Fatalf("got %q ok=%v", got, ok)
 	}
@@ -117,7 +118,7 @@ func TestResolveNPMPathWins(t *testing.T) {
 func TestResolveNPMSecondFallback(t *testing.T) {
 	look := func(string) (string, error) { return "", errors.New("no") }
 	present := func(p string) bool { return p == "/usr/local/bin/npm" }
-	got, ok := resolveNPM(look, present)
+	got, ok := clitool.ResolveNPM(look, present)
 	if !ok || got != "/usr/local/bin/npm" {
 		t.Fatalf("got %q ok=%v, want /usr/local/bin/npm", got, ok)
 	}
@@ -158,13 +159,13 @@ func TestRaycastExtDirHonorsGADAKHome(t *testing.T) {
 	t.Cleanup(func() { config.SetProfile("") })
 	config.SetProfile("work")
 
-	got, err := raycastExtDir()
+	got, err := clitool.RaycastExtDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := filepath.Join(home, raycastExtDirName)
+	want := filepath.Join(home, clitool.RaycastExtDirName)
 	if got != want {
-		t.Errorf("raycastExtDir() = %q, want %q (profile must not nest it)", got, want)
+		t.Errorf("RaycastExtDir() = %q, want %q (profile must not nest it)", got, want)
 	}
 }
 
@@ -183,5 +184,18 @@ func TestCmdRaycastUsage(t *testing.T) {
 	}
 	if err := cmdRaycastInstall([]string{"extra"}); err == nil || !strings.Contains(err.Error(), "usage: gadak raycast install") {
 		t.Fatalf("extra args: %v", err)
+	}
+}
+
+func TestNPMMissingMessageListsTried(t *testing.T) {
+	msg := npmMissingMessage()
+	detail := clitool.NPMNotFoundDetail()
+	if !strings.Contains(msg, detail) {
+		t.Errorf("npm-missing text must include %q; got:\n%s", detail, msg)
+	}
+	for _, p := range clitool.NPMFallbackPaths {
+		if !strings.Contains(msg, p) {
+			t.Errorf("npm-missing text must name tried path %s; got:\n%s", p, msg)
+		}
 	}
 }

--- a/internal/clitool/clitool.go
+++ b/internal/clitool/clitool.go
@@ -3,6 +3,9 @@
 // Mode or elevation, so the default path fails). Shared by
 // `gadak install-cli` and the desktop "Install Command Line Tool…" menu
 // so both surfaces use the same resolve / install / PATH-advice logic.
+//
+// LookPathThen / ResolveNPM / RaycastExtDir live here too: the CLI install
+// verb and the desktop catalog must try the same candidates.
 package clitool
 
 import (

--- a/internal/clitool/lookpath.go
+++ b/internal/clitool/lookpath.go
@@ -1,0 +1,78 @@
+package clitool
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/midagedev/gadak/internal/config"
+)
+
+// NPMFallbackPaths is LookPath("npm") then these, first existing+executable
+// wins. Same brew locations as contrib/raycast/src/gadak.ts GADAK_CANDIDATES,
+// opposite direction (we are finding npm, not gadak).
+//
+// Owned here so `gadak raycast install` and the desktop catalog cannot drift.
+var NPMFallbackPaths = []string{
+	"/opt/homebrew/bin/npm",
+	"/usr/local/bin/npm",
+}
+
+// RaycastExtDirName is the directory under the gadak home that holds the
+// unpacked Raycast extension. Profile is ignored: one copy per home.
+const RaycastExtDirName = "raycast-extension"
+
+// LookPathThen is LookPath(name), then the first fallback that present
+// reports. look and present are injected so tests can assert order without
+// touching the host. A nil present falls back to an execute-bit check
+// (on Windows, any regular file).
+func LookPathThen(name string, fallbacks []string, look func(string) (string, error), present func(string) bool) (string, bool) {
+	if look != nil {
+		if p, err := look(name); err == nil && p != "" {
+			return p, true
+		}
+	}
+	if present == nil {
+		present = executable
+	}
+	for _, c := range fallbacks {
+		if present(c) {
+			return c, true
+		}
+	}
+	return "", false
+}
+
+// ResolveNPM is LookPath("npm"), then NPMFallbackPaths.
+func ResolveNPM(look func(string) (string, error), present func(string) bool) (string, bool) {
+	return LookPathThen("npm", NPMFallbackPaths, look, present)
+}
+
+// NPMNotFoundDetail names every place ResolveNPM looks. Generated from
+// NPMFallbackPaths so the wording cannot drift from the table.
+func NPMNotFoundDetail() string {
+	return "PATH, then " + strings.Join(NPMFallbackPaths, ", ")
+}
+
+// RaycastExtDir is $GADAK_HOME/raycast-extension (profile ignored).
+// A DirFor error is returned: the install verb must not write to a guessed
+// path. Catalog display that cannot fail should fall back at the call site.
+func RaycastExtDir() (string, error) {
+	base, err := config.DirFor("")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, RaycastExtDirName), nil
+}
+
+func executable(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return fi.Mode()&0o111 != 0
+}

--- a/internal/clitool/lookpath_test.go
+++ b/internal/clitool/lookpath_test.go
@@ -1,0 +1,115 @@
+package clitool
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+)
+
+func TestResolveNPMLookupOrder(t *testing.T) {
+	var order []string
+	look := func(name string) (string, error) {
+		order = append(order, "path:"+name)
+		return "", errors.New("not on PATH")
+	}
+	present := func(p string) bool {
+		order = append(order, p)
+		return false
+	}
+	if got, ok := ResolveNPM(look, present); ok {
+		t.Fatalf("expected miss, got %q", got)
+	}
+	want := append([]string{"path:npm"}, NPMFallbackPaths...)
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Errorf("order %v, want %v", order, want)
+	}
+}
+
+func TestResolveNPMPathWins(t *testing.T) {
+	look := func(name string) (string, error) {
+		if name != "npm" {
+			t.Errorf("LookPath(%q)", name)
+		}
+		return "/custom/bin/npm", nil
+	}
+	present := func(p string) bool {
+		t.Errorf("fallback should not run after PATH hit; present(%s)", p)
+		return false
+	}
+	got, ok := ResolveNPM(look, present)
+	if !ok || got != "/custom/bin/npm" {
+		t.Fatalf("got %q ok=%v", got, ok)
+	}
+}
+
+func TestResolveNPMSecondFallback(t *testing.T) {
+	look := func(string) (string, error) { return "", errors.New("no") }
+	present := func(p string) bool { return p == "/usr/local/bin/npm" }
+	got, ok := ResolveNPM(look, present)
+	if !ok || got != "/usr/local/bin/npm" {
+		t.Fatalf("got %q ok=%v, want /usr/local/bin/npm", got, ok)
+	}
+}
+
+func TestNPMNotFoundDetailListsTable(t *testing.T) {
+	detail := NPMNotFoundDetail()
+	if !strings.HasPrefix(detail, "PATH, then ") {
+		t.Fatalf("detail %q must start with PATH, then", detail)
+	}
+	for _, p := range NPMFallbackPaths {
+		if !strings.Contains(detail, p) {
+			t.Errorf("detail %q missing table entry %s", detail, p)
+		}
+	}
+}
+
+func TestRaycastExtDirHonorsGADAKHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	t.Cleanup(func() { config.SetProfile("") })
+	config.SetProfile("work")
+
+	got, err := RaycastExtDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, RaycastExtDirName)
+	if got != want {
+		t.Errorf("RaycastExtDir() = %q, want %q (profile must not nest it)", got, want)
+	}
+}
+
+func TestLookPathThenEmptyLookIsMiss(t *testing.T) {
+	look := func(string) (string, error) { return "", nil }
+	got, ok := LookPathThen("gadak", []string{"/usr/local/bin/gadak"}, look, func(p string) bool {
+		return p == "/usr/local/bin/gadak"
+	})
+	if !ok || got != "/usr/local/bin/gadak" {
+		t.Fatalf("empty LookPath must fall through: got %q ok=%v", got, ok)
+	}
+}
+
+func TestExecutableRegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows treats a regular file as executable")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "tool")
+	if err := os.WriteFile(bin, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if executable(bin) {
+		t.Fatal("0644 regular file must not count as executable on unix")
+	}
+	if err := os.Chmod(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !executable(bin) {
+		t.Fatal("0755 regular file must count as executable")
+	}
+}

--- a/internal/integrations/integrations.go
+++ b/internal/integrations/integrations.go
@@ -36,13 +36,6 @@ var lookPath = exec.LookPath
 // fileIsExec reports a path exists and has an execute bit. Tests inject a stub.
 var fileIsExec = isExecutable
 
-// npmFallbackPaths mirrors cmd/gadak/raycast.go npmFallbackPaths:
-// LookPath("npm") then these, first existing+executable wins.
-var npmFallbackPaths = []string{
-	"/opt/homebrew/bin/npm",
-	"/usr/local/bin/npm",
-}
-
 // gadakFallbackPaths: LookPath("gadak") then these, first existing+executable wins.
 var gadakFallbackPaths = []string{
 	"/opt/homebrew/bin/gadak",
@@ -141,10 +134,10 @@ func commandLineToolItem() Item {
 func raycastItem() Item {
 	dir := raycastExtDir()
 	prereq := &Prerequisite{}
-	if _, ok := resolveNPM(lookPath, fileIsExec); ok {
+	if _, ok := clitool.ResolveNPM(lookPath, fileIsExec); ok {
 		prereq.OK = true
 	} else {
-		prereq.Message = "npm is required (not found on PATH)"
+		prereq.Message = "npm is required (not found on " + clitool.NPMNotFoundDetail() + ")"
 	}
 	installed := fileExists(filepath.Join(dir, "package.json"))
 	detail := clitool.TildeHome(dir)
@@ -210,18 +203,19 @@ func mcpClaudeItem() Item {
 	}
 }
 
-// raycastExtDir mirrors cmd/gadak/raycast.go raycastExtDir:
-// $GADAK_HOME/raycast-extension, default ~/.gadak/raycast-extension.
+// raycastExtDir is clitool.RaycastExtDir (same path the CLI install writes).
+// List cannot return an error, so a DirFor failure falls back to a display
+// path — the install verb still fails closed if the home cannot be resolved.
 func raycastExtDir() string {
-	base, err := config.DirFor("")
+	dir, err := clitool.RaycastExtDir()
 	if err != nil {
 		home, homeErr := os.UserHomeDir()
 		if homeErr != nil {
-			return filepath.Join(".gadak", "raycast-extension")
+			return filepath.Join(config.DirName, clitool.RaycastExtDirName)
 		}
-		return filepath.Join(home, config.DirName, "raycast-extension")
+		return filepath.Join(home, config.DirName, clitool.RaycastExtDirName)
 	}
-	return filepath.Join(base, "raycast-extension")
+	return dir
 }
 
 // skillPath mirrors cmd/gadak/skill.go resolveSkillDest default:
@@ -238,31 +232,9 @@ func skillPath() string {
 	return filepath.Join(home, ".claude", "skills", "gadak", "SKILL.md")
 }
 
-// resolveNPM mirrors cmd/gadak/raycast.go resolveNPM: PATH, then npmFallbackPaths.
-func resolveNPM(look func(string) (string, error), present func(string) bool) (string, bool) {
-	return resolveNamed("npm", npmFallbackPaths, look, present)
-}
-
 // resolveGadak is LookPath("gadak"), then gadakFallbackPaths.
 func resolveGadak(look func(string) (string, error), present func(string) bool) (string, bool) {
-	return resolveNamed("gadak", gadakFallbackPaths, look, present)
-}
-
-func resolveNamed(name string, fallbacks []string, look func(string) (string, error), present func(string) bool) (string, bool) {
-	if look != nil {
-		if p, err := look(name); err == nil && p != "" {
-			return p, true
-		}
-	}
-	if present == nil {
-		present = isExecutable
-	}
-	for _, c := range fallbacks {
-		if present(c) {
-			return c, true
-		}
-	}
-	return "", false
+	return clitool.LookPathThen("gadak", gadakFallbackPaths, look, present)
 }
 
 // mcpNotRegisteredMarker is claude CLI's wording for a definitive negative

--- a/internal/integrations/integrations_test.go
+++ b/internal/integrations/integrations_test.go
@@ -189,20 +189,44 @@ func TestItemJSONKeepsNulls(t *testing.T) {
 
 func TestResolveNPMOrder(t *testing.T) {
 	look := func(string) (string, error) { return "", os.ErrNotExist }
-	if _, ok := resolveNPM(look, func(string) bool { return false }); ok {
+	if _, ok := clitool.ResolveNPM(look, func(string) bool { return false }); ok {
 		t.Fatal("no candidate should miss")
 	}
-	got, ok := resolveNPM(func(string) (string, error) { return "/tmp/path-npm", nil }, func(string) bool { return false })
+	got, ok := clitool.ResolveNPM(func(string) (string, error) { return "/tmp/path-npm", nil }, func(string) bool { return false })
 	if !ok || got != "/tmp/path-npm" {
 		t.Fatalf("PATH win: %q ok=%v", got, ok)
 	}
-	got, ok = resolveNPM(look, func(p string) bool { return p == "/opt/homebrew/bin/npm" })
+	got, ok = clitool.ResolveNPM(look, func(p string) bool { return p == "/opt/homebrew/bin/npm" })
 	if !ok || got != "/opt/homebrew/bin/npm" {
 		t.Fatalf("brew fallback: %q ok=%v", got, ok)
 	}
-	got, ok = resolveNPM(look, func(p string) bool { return p == "/usr/local/bin/npm" })
+	got, ok = clitool.ResolveNPM(look, func(p string) bool { return p == "/usr/local/bin/npm" })
 	if !ok || got != "/usr/local/bin/npm" {
 		t.Fatalf("usr/local fallback: %q ok=%v", got, ok)
+	}
+}
+
+func TestRaycastPrerequisiteListsTriedNPM(t *testing.T) {
+	prevLook, prevExec := lookPath, fileIsExec
+	lookPath = func(string) (string, error) { return "", os.ErrNotExist }
+	fileIsExec = func(string) bool { return false }
+	t.Cleanup(func() {
+		lookPath = prevLook
+		fileIsExec = prevExec
+	})
+	item := raycastItem()
+	if item.Prerequisite == nil || item.Prerequisite.OK {
+		t.Fatalf("missing npm: prerequisite=%+v", item.Prerequisite)
+	}
+	msg := item.Prerequisite.Message
+	detail := clitool.NPMNotFoundDetail()
+	if !strings.Contains(msg, detail) {
+		t.Errorf("raycast prerequisite must include %q; got %q", detail, msg)
+	}
+	for _, p := range clitool.NPMFallbackPaths {
+		if !strings.Contains(msg, p) {
+			t.Errorf("raycast prerequisite must name tried path %s; got %q", p, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
`cmd/gadak/raycast.go` and `internal/integrations/integrations.go` each held `/opt/homebrew/bin/npm` and `/usr/local/bin/npm`, and the integrations comment stated outright that it *mirrored* the CLI file. `resolveNPM` and `raycastExtDir` were mirrored the same way.

A comment that says "this mirrors that file" is a promise nothing enforces. It matters because decision 0008 makes the desktop catalog row a wrapper that streams the CLI verb — **a catalog that finds npm the CLI cannot, or the reverse, is an Install button that lies.**

## The behavioural diff was done before merging anything, and it found drift the audit had not recorded

| | tables | resolve algorithm | `raycastExtDir` |
|---|---|---|---|
| drifted? | no — byte-identical | no | **yes** |

The CLI returns a `DirFor` error so an install cannot write to a guessed path; the catalog falls back to `$HOME/.gadak/raycast-extension` because `List` cannot fail. That is a **genuine API difference**, so it stays at the catalog call site. Only the happy-path location becomes one function.

## One owner

`internal/clitool` already owned PATH-adjacent install logic and was already imported by both callers, so it takes `NPMFallbackPaths`, `ResolveNPM`, `LookPathThen`, `RaycastExtDir`, `RaycastExtDirName`.

**Import direction checked**: both callers point down into `clitool`, `clitool` points down into `config`, nothing points back. `resolveGadak` in the catalog now uses `LookPathThen` too, so the algorithm is not left behind as a second copy.

## Recurrence — declined, with the argument

Once the duplication is gone there is nothing left to assert, and a check that passes forever is worse than none. Same argument GDK-288 made.

What replaces it: **"npm not found" now names what was tried**, generated from the table so the wording cannot drift from it. That is the one thing a user hitting this could not previously find out.

## Gates — re-run cold by the lead

`go build` exit 0 · `go vet` exit 0 · `go test ./... -count=1` exit 0, 30 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)