### PR TITLE
docs(desktop): seven claims that 0.16 made false (GDK-296)

### DIFF
--- a/cmd/gadak/views.go
+++ b/cmd/gadak/views.go
@@ -576,7 +576,9 @@ func composeServeURL(base, prefix, hash string) string {
 // has to be told which port to name. This is a pure function of the profile
 // and the hash, so an agent that built a view always has something to hand
 // over. What it does not promise is that anything will answer — that needs
-// the desktop app installed, which is macOS-only today.
+// the desktop app installed. The platforms that ship, and which of them
+// receive the deep-link event, live in the table in desktop/README.md;
+// focusDesktopApp raises on darwin and windows.
 //
 // Built from the same prefix the serve URL uses, so the two links describe
 // the same view; desktop/deeplink.go reverses exactly this.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -6,13 +6,21 @@ listener at all**. The Wails asset server calls straight into the
 conflicts stop existing as UX. A second launch focuses the running window
 (single-instance lock) instead of hunting for a free port.
 
-Status: **macOS app bundle + signed/notarized dmg on tag releases** (arm64), on
-`wails/v3` (beta). Linux is a from-source AppImage pack (`desktop/build-linux.sh`);
-Windows is a from-source portable directory (`desktop/build-windows.ps1`).
-This tree's tag workflow does not upload the Linux or Windows packs. The module
-stays a nested Go module so the wails dependency tree and its CGO requirement
+The pack scripts on disk are the ship-shape owner; `coldStartDecisionFor` in
+`main.go` is the deep-link delivery owner (GDK-293). This table summarises
+both so the rest of the tree can point here instead of restating either.
+
+| GOOS | Pack | Shipped on tag | `ApplicationLaunchedWithUrl` |
+| --- | --- | --- | --- |
+| darwin | `desktop/build-app.sh` → `Gadak-<ver>-arm64.dmg` (signed/notarized) | yes | yes (Apple Event; argv is not applied) |
+| windows | `desktop/build-windows.ps1` → `Gadak-<ver>-windows-<x64\|arm64>.zip` (unsigned; GDK-211) | yes (from 0.16) | yes when argv is exactly one `://` argument (wails `pkg/application/application_windows.go`); otherwise argv |
+| linux | `desktop/build-linux.sh` → AppDir / AppImage | no — from-source only | no (GTK4 never emits it; argv is applied) |
+
+The in-app Jira/Confluence browse pane is still darwin-only (`embed_darwin.go`; other GOOS use the stub in `embed_other.go`).
+
+The module stays a nested Go module so the wails dependency tree and its CGO requirement
 never touch the CLI build or the non-macOS CI matrix. No `wails3` CLI: plain
-`go build`, no bindings, HTTP only.
+`go build`, no bindings, HTTP only. On `wails/v3` (beta).
 
 ## Build
 
@@ -29,7 +37,7 @@ desktop/build-linux.sh              # → desktop/build/Gadak.AppDir
 desktop/build-linux.sh --appimage   # → desktop/build/Gadak-<version>-x86_64.AppImage as well
 ```
 
-Windows (must run on Windows; see WebView2 below):
+Windows (cross-compile with `CGO_ENABLED=0`; Authenticode and a missing-WebView2 check still need a Windows host — see WebView2 below):
 
 ```powershell
 desktop/build-windows.ps1   # → desktop/build/Gadak-<version>-x64/
@@ -126,8 +134,11 @@ machine without WebView2** (that has not been done):
   (`internal/webview2/webviewloader/find_dll.go`).
 - `Chromium.errorCallback` logs the error and calls `os.Exit(1)`
   (`internal/webview2/pkg/edge/chromium.go`).
-- `gadak-desktop` does not set an `ErrorHandler`, so there is no in-app
-  download dialog — the process exits.
+- `gadak-desktop` sets `ErrorHandler: handleDesktopFatal` (`main.go`),
+  which shows a `MessageBoxW` on Windows (`fatal_windows.go`) and writes
+  stderr. wails still `os.Exit(1)` after the handler returns, so there is
+  still no download dialog — the process exits. The silent half is
+  handled; the exit is not.
 
 Install the Evergreen runtime from
 <https://developer.microsoft.com/en-us/microsoft-edge/webview2/>.
@@ -227,14 +238,14 @@ would try to self-swap.
 
 ## Known limits
 
-- No workspace switcher (`/w/<profile>/` mounts) — single profile per window.
+- Workspace switcher: `/w/<profile>/` is served from `fallbackHandler` in
+  `main.go`, and `/config.json` on that mount is stamped `desktop=true`.
+  The sidebar lists profiles when more than one exists (see `docs/DESKTOP.md`).
 - Onboarding for a machine with no credential is a separate track; until that
   lands, `gadak init` (or the bundled CLI) remains the setup path.
-- macOS is the shipped desktop artifact (signed/notarized dmg). Linux is a
-  from-source AppImage pack; Windows is a from-source unsigned portable
-  directory. This repository's tag workflow does not upload the Linux or
-  Windows packs. The in-app Jira/Confluence pane (`embed_darwin.go`) is still
-  macOS-only — other platforms get the stub in `embed_other.go`.
+- Ship shape and deep-link delivery are the platform table above. The
+  in-app Jira/Confluence pane (`embed_darwin.go`) is still macOS-only —
+  other platforms get the stub in `embed_other.go`.
 - macOS builds still need the Xcode command line tools. (The
   `UniformTypeIdentifiers` link flag `build-app.sh` used to pass by hand is
   gone — wails v3 declares that framework itself.)

--- a/desktop/build-windows.ps1
+++ b/desktop/build-windows.ps1
@@ -30,9 +30,11 @@
 #   machines already have it via Edge.
 #   Missing runtime (from wails v3.0.0-beta.6 source, not launched here):
 #   webviewloader returns "no webview2 found"; Chromium.errorCallback logs
-#   and os.Exit(1). gadak-desktop sets no ErrorHandler, so there is no
-#   download dialog — the process exits. Unverified on a real Windows
-#   machine. Runtime: https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+#   and os.Exit(1). gadak-desktop sets ErrorHandler to handleDesktopFatal
+#   (desktop/main.go), which shows a MessageBoxW (fatal_windows.go) and
+#   writes stderr; wails still os.Exit(1) after the handler returns, so
+#   there is no download dialog — the process exits. Unverified on a real
+#   Windows machine. Runtime: https://developer.microsoft.com/en-us/microsoft-edge/webview2/
 #
 # Signing is out of scope (GDK-211). The unsigned exe is expected to hit
 # SmartScreen on first download; that is documented in desktop/README.md,

--- a/desktop/deeplink.go
+++ b/desktop/deeplink.go
@@ -30,8 +30,12 @@ import (
 //     to SecondInstanceData.Args before exiting, so it arrives in the
 //     OnSecondInstanceLaunch callback of the instance that was already up.
 //
-// Nothing here is macOS-specific in Go terms; on other platforms the events
-// simply never fire, because only the .app bundle registers a scheme.
+// Nothing here is macOS-specific in Go terms. Which GOOS emits
+// ApplicationLaunchedWithUrl is owned by coldStartDecisionFor in main.go
+// (GDK-293): Windows does, when wails sees a single "://" argument
+// (pkg/application/application_windows.go in the pinned wails module);
+// GTK4 Linux never does, so argv is applied instead. The same split is
+// in the platform table in README.md.
 
 // errUnsupportedAction reports a well-formed link naming something this build
 // does not implement. It is deliberately distinct from a malformed link: the

--- a/desktop/embed_other.go
+++ b/desktop/embed_other.go
@@ -7,9 +7,10 @@ import (
 	"unsafe"
 )
 
-// The desktop app ships for macOS only today; this stub keeps the module
-// compiling elsewhere (same arrangement as install_cli). Every call reports
-// the pane as unavailable.
+// The in-app browse pane is darwin-only (embed_darwin.go). This stub keeps
+// the module compiling on the other pack targets (Linux AppImage, Windows
+// portable zip — platform table in README.md). Every call reports the pane
+// as unavailable.
 type stubEmbedder struct{}
 
 func newPlatformEmbedder(func() unsafe.Pointer) embedder {

--- a/desktop/fatal_windows.go
+++ b/desktop/fatal_windows.go
@@ -7,9 +7,12 @@ import (
 	"unsafe"
 )
 
-// windowsMessageBox is user32 MessageBoxW. wails has no dialog helper for
-// a missing-runtime path (the webview is what failed).
-// MB_OK | MB_ICONERROR | MB_SETFOREGROUND.
+// windowsMessageBox is user32 MessageBoxW. wails' Dialog.Error() is also
+// a MessageBox on Windows (pkg/application/dialogs_windows.go), but it is
+// reached through application.Get(); nobody has demonstrated that Get() is
+// safe to call from inside Chromium's errorCallback, which is exactly when
+// handleDesktopFatal runs. This syscall is that isolation, not a missing
+// helper. MB_OK | MB_ICONERROR | MB_SETFOREGROUND.
 func windowsMessageBox(title, text string) {
 	user32 := syscall.NewLazyDLL("user32.dll")
 	proc := user32.NewProc("MessageBoxW")

--- a/desktop/platforms_test.go
+++ b/desktop/platforms_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// desktopPlatform is one row of the platform contract: what this module
+// packs, and how a first-launch gadak:// URL reaches the window.
+//
+// Two owners already exist and this table must not become a third:
+//
+//   - pack scripts on disk are the ship-shape owner
+//     (build-app.sh / build-linux.sh / build-windows.ps1)
+//   - coldStartDecisionFor in main.go is the deep-link delivery owner (GDK-293)
+//
+// The table exists so a reader (and this file) can answer both questions in
+// one place, and so comments can point at it / at those owners instead of
+// restating either. EventOnURLArg / ArgvOnURLArg are the one-argument
+// gadak:// shape the CLI launcher uses (len(args)==2, args[1] contains "://").
+type desktopPlatform struct {
+	GOOS          string
+	PackScript    string
+	EventOnURLArg bool
+	ArgvOnURLArg  bool
+}
+
+var desktopPlatforms = []desktopPlatform{
+	{GOOS: "darwin", PackScript: "build-app.sh", EventOnURLArg: true, ArgvOnURLArg: false},
+	{GOOS: "windows", PackScript: "build-windows.ps1", EventOnURLArg: true, ArgvOnURLArg: false},
+	{GOOS: "linux", PackScript: "build-linux.sh", EventOnURLArg: false, ArgvOnURLArg: true},
+}
+
+func TestDesktopPackScriptsExist(t *testing.T) {
+	for _, p := range desktopPlatforms {
+		if _, err := os.Stat(p.PackScript); err != nil {
+			t.Errorf("pack script for GOOS %s missing: %s: %v", p.GOOS, p.PackScript, err)
+		}
+	}
+}
+
+func TestDesktopPlatformsMatchColdStartOwner(t *testing.T) {
+	urlArgs := []string{"gadak-desktop", "gadak://view?issue=NMB-1"}
+	for _, p := range desktopPlatforms {
+		got := coldStartDecisionFor(p.GOOS, urlArgs)
+		if got.DeferToEvent != p.EventOnURLArg {
+			t.Errorf("coldStartDecisionFor(%s, urlArg).DeferToEvent = %v, table EventOnURLArg = %v",
+				p.GOOS, got.DeferToEvent, p.EventOnURLArg)
+		}
+		if got.ApplyArgv != p.ArgvOnURLArg {
+			t.Errorf("coldStartDecisionFor(%s, urlArg).ApplyArgv = %v, table ArgvOnURLArg = %v",
+				p.GOOS, got.ApplyArgv, p.ArgvOnURLArg)
+		}
+	}
+}
+
+func TestDesktopREADMENamesPlatformOwners(t *testing.T) {
+	body, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	needles := []string{
+		"coldStartDecisionFor",
+		"ApplicationLaunchedWithUrl",
+	}
+	for _, p := range desktopPlatforms {
+		needles = append(needles, p.PackScript)
+	}
+	for _, n := range needles {
+		if !strings.Contains(text, n) {
+			t.Errorf("desktop/README.md does not mention %q (platform table / owners)", n)
+		}
+	}
+}
+
+// Phrases that were true before 0.16 and are false now. A comment that
+// restates any of these reintroduces a bug that was already fixed (GDK-293
+// was caused by a comment asserting the wrong platform split).
+func TestDesktopCommentsDoNotRestateStalePlatformFacts(t *testing.T) {
+	cases := []struct {
+		path    string
+		phrases []string
+	}{
+		{"deeplink.go", []string{"on other platforms the events", "simply never fire"}},
+		{"embed_other.go", []string{"The desktop app ships for macOS only today"}},
+		{"fatal_windows.go", []string{"wails has no dialog helper"}},
+		{"README.md", []string{"does not set an `ErrorHandler`", "No workspace switcher"}},
+		{"build-windows.ps1", []string{"sets no ErrorHandler"}},
+		{"../docs/DESKTOP.md", []string{"Intel Macs and Linux use the"}},
+		{"../cmd/gadak/views.go", []string{"which is macOS-only today"}},
+	}
+	for _, tc := range cases {
+		body, err := os.ReadFile(tc.path)
+		if err != nil {
+			t.Errorf("%s: %v", tc.path, err)
+			continue
+		}
+		text := string(body)
+		for _, p := range tc.phrases {
+			if strings.Contains(text, p) {
+				t.Errorf("%s still contains stale platform claim %q", tc.path, p)
+			}
+		}
+	}
+}

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -33,7 +33,12 @@ exe, use the CLI zip and `gadak serve`. Do not turn Smart App Control off.
 The wording and the CLI fallback live in
 [INSTALL.md](INSTALL.md#desktop-app-windows).
 
-Intel Macs and Linux use the [CLI](../README.md#install).
+Intel Macs have no shipped dmg (tag releases are arm64 only;
+`desktop/build-app.sh` packs the host arch). Linux is a from-source
+AppDir/AppImage (`desktop/build-linux.sh`); the tag workflow does not
+upload it. Either build that pack or use the [CLI](../README.md#install).
+The platforms that ship, and which of them receive the `gadak://` event,
+are the table in [`desktop/README.md`](../desktop/README.md).
 
 First launch walks you through setup in the window — Jira site, email, API
 token (from <https://id.atlassian.com/manage-profile/security/api-tokens>),


### PR DESCRIPTION
All seven were true before 0.16 and are not now. One commit because they are one class — *a comment that contradicts the code* — and because `desktop/main.go` was just corrected for exactly that reason: the GDK-293 bug was **caused** by a comment asserting the wrong platform split.

| where | said | true |
|---|---|---|
| `deeplink.go` | the event never fires off macOS | Windows fires it; GTK4 does not. Now points at `coldStartDecisionFor`, which owns that. |
| `README.md`, `build-windows.ps1` | no `ErrorHandler` → missing WebView2 exits silently | `main.go` installs `handleDesktopFatal`. **Half survived**: the dialog appears, and wails still exits after, so there is still no download prompt. Both halves are now said. |
| `embed_other.go` | the app ships macOS-only | what is macOS-only is the in-app browse pane — the file's actual subject |
| `docs/DESKTOP.md` | Intel Macs and Linux use the CLI | Linux has a pack script; Intel Macs have no shipped dmg. Different statement. |
| `cmd/gadak/views.go` | the desktop app is macOS-only | `focusDesktopApp` has had a Windows branch. **Comment only — no logic changed.** |
| `README.md` | no workspace switcher | `main.go` serves `/w/` and stamps `desktop=true`; `docs/DESKTOP.md` already documents the sidebar list |
| `fatal_windows.go` | wails has no dialog helper | `Dialog.Error()` is a MessageBox on Windows — **but** it goes through `application.Get()`, and nobody has shown `Get()` is safe inside Chromium's `errorCallback`, which is precisely when this runs. The syscall stays; the comment now records that reason instead of implying an oversight. |

## Not seven corrected sentences — an owner

`README.md` gains one table of GOOS × pack script × ships-on-tag × receives-the-event, and the comments point at it rather than restating it.

It is **not a third source of truth**: the pack scripts on disk and `coldStartDecisionFor` remain the owners, and `desktop/platforms_test.go` asserts the table against **both** — every pack script exists, and every row's event/argv expectation matches what `coldStartDecisionFor` returns for the one-argument `gadak://` shape the CLI launcher produces. A runnable test, not a described one.

## Verified rather than transcribed (lead)

- the tag workflow really does attach `Gadak-<ver>-windows-<x64|arm64>.zip` (`desktop-release.yml` job `desktop-windows`, step "Attach zip to GitHub Release")
- Linux really has no release job
- `docs/DESKTOP.md:175-177` really documents the sidebar **Workspaces** list

## Filed separately, not edited

`docs/STATE_OF_PLAY.md` is stamped v0.15.0 and is stale about the desktop in the same ways.

## Gates — re-run cold by the lead

`cd desktop && go build/vet/test` all exit 0 (`ok github.com/midagedev/gadak/desktop`) · root `go build`/`go vet` exit 0 · `tools/doc-checks.sh` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)