### PR TITLE
deps(desktop): wails v3.0.0-beta.6 → v3.0.0-beta.9 (GDK-294)

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -82,11 +82,13 @@ registration (`HKCU\SOFTWARE\Classes\gadak`) is not part of this pack.
 
 ### Linux build prerequisites
 
-wails v3 (`v3.0.0-beta.6`, `desktop/go.mod`) compiles the Linux host with
+wails v3 (`v3.0.0-beta.9`, `desktop/go.mod`) compiles the Linux host with
 `#cgo pkg-config: gtk4 webkitgtk-6.0`. `CGO_ENABLED=0` does not compile (see
 the comment on the desktop job in `.github/workflows/ci.yml`). Do not pass
 `-tags gtk3`: that is the webkit2gtk 4.1 legacy stack, and wails plans to
-remove it in v3.1.
+remove it in v3.1. GTK4 `gtk_application_new` uses `G_APPLICATION_NON_UNIQUE`
+(`pkg/application/linux_cgo.h`); second-launch focusing is wails
+`SingleInstanceOptions` (session-bus name on Linux), not GTK uniqueness.
 
 Development packages as listed by that wails release's doctor (not installed
 or compiled against in this repository's CI):
@@ -109,7 +111,7 @@ only the directory tree for the same reason.
 
 ### Windows build prerequisites
 
-wails v3 (`v3.0.0-beta.6`, `desktop/go.mod`) talks to WebView2 over COM. The
+wails v3 (`v3.0.0-beta.9`, `desktop/go.mod`) talks to WebView2 over COM. The
 pack script sets `CGO_ENABLED=0`. This script has not been executed on a
 Windows machine in this repository (the authoring runner is darwin).
 
@@ -126,13 +128,17 @@ includes the Evergreen runtime and that many Windows 10 machines already
 have it via Edge; **this repository has not checked either claim on a
 Windows machine.**
 
-What happens if the runtime is missing is taken from the wails v3.0.0-beta.6
+What happens if the runtime is missing is taken from the wails v3.0.0-beta.9
 source this module links, **not from launching `gadak-desktop.exe` on a
 machine without WebView2** (that has not been done):
 
 - `webviewloader` reports `no webview2 found`
   (`internal/webview2/webviewloader/find_dll.go`).
-- `Chromium.errorCallback` logs the error and calls `os.Exit(1)`
+- `Chromium.Embed` waits at most 30s for the controller (`embedTimeout` /
+  `pumpUntilInited` in `internal/webview2/pkg/edge/chromium.go`). A
+  controller that never becomes ready calls `errorCallback` with a timeout
+  instead of blocking forever on `GetMessageW`.
+- `Chromium.errorCallback` still calls `os.Exit(1)` after the handler
   (`internal/webview2/pkg/edge/chromium.go`).
 - `gadak-desktop` sets `ErrorHandler: handleDesktopFatal` (`main.go`),
   which shows a `MessageBoxW` on Windows (`fatal_windows.go`) and writes

--- a/desktop/build-windows.ps1
+++ b/desktop/build-windows.ps1
@@ -28,9 +28,10 @@
 #   hundreds of MB and this pack is a directory, not an installer that
 #   could update it. Windows 11 ships the Evergreen runtime; many Windows 10
 #   machines already have it via Edge.
-#   Missing runtime (from wails v3.0.0-beta.6 source, not launched here):
-#   webviewloader returns "no webview2 found"; Chromium.errorCallback logs
-#   and os.Exit(1). gadak-desktop sets ErrorHandler to handleDesktopFatal
+#   Missing runtime (from wails v3.0.0-beta.9 source, not launched here):
+#   webviewloader returns "no webview2 found"; Chromium.Embed waits at most
+#   30s for the controller, then Chromium.errorCallback logs and os.Exit(1).
+#   gadak-desktop sets ErrorHandler to handleDesktopFatal
 #   (desktop/main.go), which shows a MessageBoxW (fatal_windows.go) and
 #   writes stderr; wails still os.Exit(1) after the handler returns, so
 #   there is no download dialog — the process exits. Unverified on a real

--- a/desktop/coldstart_test.go
+++ b/desktop/coldstart_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 // The launcher that broke (cmd/gadak/views.go startWindowsDesktopImpl) starts
-// the exe with exactly one argument — the gadak:// URL. wails v3.0.0-beta.6
+// the exe with exactly one argument — the gadak:// URL. wails v3.0.0-beta.9
 // treats that shape as ApplicationLaunchedWithUrl on Windows.
 const launcherURL = "gadak://view?issue=NMB-1"
 

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -6,7 +6,7 @@ replace github.com/midagedev/gadak => ../
 
 require (
 	github.com/midagedev/gadak v0.0.0
-	github.com/wailsapp/wails/v3 v3.0.0-beta.6
+	github.com/wailsapp/wails/v3 v3.0.0-beta.9
 )
 
 require (

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -38,8 +38,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wailsapp/wails/v3 v3.0.0-beta.6 h1:k9FHF/T39EyTZNCHweRrLt1c6dwV3R3A+r1oCNiPB8I=
-github.com/wailsapp/wails/v3 v3.0.0-beta.6/go.mod h1:A/OaL1mXOnwWynTJv4rZU89Wbk5q3rtq3C3qkx4rRN0=
+github.com/wailsapp/wails/v3 v3.0.0-beta.9 h1:mcxa5KW199nPBcBf5DQioRC2p9Z1Fv8/XKqhptqdBbc=
+github.com/wailsapp/wails/v3 v3.0.0-beta.9/go.mod h1:zKZYhB3WjrN5LhJWbnOAVMN0Xf8qTozbw2nf5micKl4=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"unsafe"
@@ -75,7 +76,7 @@ type coldStartDecision struct {
 //   - darwin: event only. LaunchServices delivers the URL as an Apple Event;
 //     applying argv as well would navigate twice.
 //   - windows: event when wails will emit ApplicationLaunchedWithUrl — that
-//     is len(args)==2 and args[1] contains "://" (wails v3.0.0-beta.6
+//     is len(args)==2 and args[1] contains "://" (wails v3.0.0-beta.9
 //     pkg/application/application_windows.go:159-162). Every other argv
 //     shape is ignored by wails, so argv is the fallback.
 //   - linux (and anything else): argv. GTK4 run() in the same wails pin
@@ -94,11 +95,33 @@ func coldStartDecisionFor(goos string, args []string) coldStartDecision {
 	}
 }
 
-// wailsEmitsLaunchURL is the argv shape wails v3.0.0-beta.6 special-cases
+// wailsEmitsLaunchURL is the argv shape wails v3.0.0-beta.9 special-cases
 // on Windows (application_windows.go:159-162). GTK3 has the same check;
 // GTK4, which this pin compiles, does not.
 func wailsEmitsLaunchURL(args []string) bool {
 	return len(args) == 2 && strings.Contains(args[1], "://")
+}
+
+// wailsModuleVersion is the version of github.com/wailsapp/wails/v3 linked
+// into this binary (debug.ReadBuildInfo). "unknown" if build info is missing
+// or the module is not a dependency — neither happens for a normal build.
+func wailsModuleVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, m := range info.Deps {
+		if m.Path != "github.com/wailsapp/wails/v3" {
+			continue
+		}
+		if m.Replace != nil && m.Replace.Version != "" {
+			return m.Replace.Version
+		}
+		if m.Version != "" {
+			return m.Version
+		}
+	}
+	return "unknown"
 }
 
 // coldStartGate applies a cold-start URL only after WindowRuntimeReady.
@@ -312,6 +335,13 @@ func run() error {
 	app.Menu.Set(appMenu)
 
 	decision := coldStartDecisionFor(runtime.GOOS, os.Args)
+	// One line answers "which wails, and does this process defer to the
+	// launch event" without opening go.mod or upstream source.
+	coldStart := "argv"
+	if decision.DeferToEvent {
+		coldStart = "event"
+	}
+	log.Printf("gadak-desktop version=%s wails=%s cold_start=%s", appVersion, wailsModuleVersion(), coldStart)
 	var gate coldStartGate
 	gate.apply = func(raw, source string) {
 		if applyDeepLink == nil {

--- a/desktop/platforms_test.go
+++ b/desktop/platforms_test.go
@@ -55,6 +55,54 @@ func TestDesktopPlatformsMatchColdStartOwner(t *testing.T) {
 	}
 }
 
+// pinnedWailsVersion is the require line in this module's go.mod. A bump
+// that forgets to re-check the comments that name the pin fails
+// TestPinnedWailsVersionIsNamed, which is the point: those comments are
+// beliefs about upstream, and they rot the way GDK-296 already closed.
+func pinnedWailsVersion(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const prefix = "github.com/wailsapp/wails/v3 "
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 2 {
+			return fields[1]
+		}
+	}
+	t.Fatal("go.mod has no github.com/wailsapp/wails/v3 require")
+	return ""
+}
+
+func TestPinnedWailsVersionIsNamed(t *testing.T) {
+	ver := pinnedWailsVersion(t)
+	// Every tracked file in desktop/ that states a belief about upstream
+	// behaviour. build-windows.ps1 was left naming beta.6 by the beta.9
+	// bump — the same rot GDK-296 closed, so it is in the list.
+	for _, path := range []string{"main.go", "README.md", "build-windows.ps1"} {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), ver) {
+			t.Errorf("%s does not name the pinned wails version %q — re-read the pin's launch-event and lock behaviour before landing a bump", path, ver)
+		}
+	}
+}
+
+func TestWailsModuleVersionMatchesGoMod(t *testing.T) {
+	want := pinnedWailsVersion(t)
+	if got := wailsModuleVersion(); got != want {
+		t.Fatalf("wailsModuleVersion() = %q, go.mod has %q", got, want)
+	}
+}
+
 func TestDesktopREADMENamesPlatformOwners(t *testing.T) {
 	body, err := os.ReadFile("README.md")
 	if err != nil {


### PR DESCRIPTION
Bumps the wails v3 pin the desktop module deferred at v0.14.

**Why a PR and not a direct push:** it touches `desktop/` and its `go.mod`, so the verdict that matters comes from `Desktop Linux build` (GTK4 + WebKitGTK + AppImage, ubuntu) and `Desktop Windows build` (windows-latest) — neither runs on this machine.

## What actually changed upstream

- **WebView2 init is now bounded.** beta.6 pumped `GetMessageW` until the controller reported ready, with no deadline. beta.9 bounds it at 30s and calls `errorCallback` with a timeout (`internal/webview2/pkg/edge/chromium.go`). `os.Exit(1)` after our `ErrorHandler` is unchanged.
- **GTK4 uses `G_APPLICATION_NON_UNIQUE`** (`pkg/application/linux_cgo.h`, upstream PR 5971). Our second-instance behaviour is `SingleInstanceOptions` keyed per profile (`desktop/main.go:223-226`), and GTK's app id is the global `org.wails.gadak` — so GTK uniqueness would have threatened a *second profile*, and turning it off is a fix for us, not a conflict.
- **#5963's asset-request cancel is macOS/iOS only.** `request_linux.go` is byte-identical between the pins and still calls `newRequestFinalizer`, not the native-cancel wrapper. The release note reads as a GTK fix; it is not one.

No transitive requirement moved — the `go.mod`/`go.sum` delta is the wails module alone.

`coldStartDecisionFor`'s two premises were re-read against the new source: Windows still emits `ApplicationLaunchedWithUrl` iff `len(args)==2 && strings.Contains(args[1], "://")` (`application_windows.go:159-167`), GTK4 `run()` still never emits it (`application_linux.go:89-99`).

## Recurrence

`TestPinnedWailsVersionIsNamed` fails when `go.mod`'s version is absent from `main.go`, `README.md` or `build-windows.ps1`. That is not hypothetical — the bump left `build-windows.ps1:31` naming beta.6, and extending the check to the pack script is what caught it (FAIL-first captured). `TestWailsModuleVersionMatchesGoMod` ties `debug.ReadBuildInfo()` to the require line.

## Gates (lead-run, cold)

`go build ./...` 0 · `go vet ./...` 0 · `go test ./... -count=1` ok · `GOOS=windows GOARCH=amd64` 0 · `GOOS=windows GOARCH=arm64` 0. Linux/darwin `CGO_ENABLED=0` still fails as before the bump — documented at `.github/workflows/ci.yml:266-268`, not introduced here.

## Not verified — no GUI in this environment

The 30s WebView2 deadline against a real missing runtime; a second-profile launch under `NON_UNIQUE`; Darwin's asset-cancel path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)