### PR TITLE
docs(desktop): point the GTK4 launch-event workaround at wailsapp/wails#6000 (GDK-295)

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -14,7 +14,7 @@ both so the rest of the tree can point here instead of restating either.
 | --- | --- | --- | --- |
 | darwin | `desktop/build-app.sh` → `Gadak-<ver>-arm64.dmg` (signed/notarized) | yes | yes (Apple Event; argv is not applied) |
 | windows | `desktop/build-windows.ps1` → `Gadak-<ver>-windows-<x64\|arm64>.zip` (unsigned; GDK-211) | yes (from 0.16) | yes when argv is exactly one `://` argument (wails `pkg/application/application_windows.go`); otherwise argv |
-| linux | `desktop/build-linux.sh` → AppDir / AppImage | no — from-source only | no (GTK4 never emits it; argv is applied) |
+| linux | `desktop/build-linux.sh` → AppDir / AppImage | no — from-source only | no (GTK4 never emits it — fix sent upstream, wailsapp/wails#6000; argv is applied) |
 
 The in-app Jira/Confluence browse pane is still darwin-only (`embed_darwin.go`; other GOOS use the stub in `embed_other.go`).
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -80,7 +80,9 @@ type coldStartDecision struct {
 //     pkg/application/application_windows.go:159-162). Every other argv
 //     shape is ignored by wails, so argv is the fallback.
 //   - linux (and anything else): argv. GTK4 run() in the same wails pin
-//     (application_linux.go:89-99) does not emit the event.
+//     (application_linux.go:89-99) does not emit the event. Fix sent
+//     upstream as wailsapp/wails#6000 (GDK-295); when a pin containing it
+//     lands, Linux can move to DeferToEvent like Windows.
 func coldStartDecisionFor(goos string, args []string) coldStartDecision {
 	switch goos {
 	case "darwin":
@@ -97,7 +99,7 @@ func coldStartDecisionFor(goos string, args []string) coldStartDecision {
 
 // wailsEmitsLaunchURL is the argv shape wails v3.0.0-beta.9 special-cases
 // on Windows (application_windows.go:159-162). GTK3 has the same check;
-// GTK4, which this pin compiles, does not.
+// GTK4, which this pin compiles, does not (upstream fix: wailsapp/wails#6000).
 func wailsEmitsLaunchURL(args []string) bool {
 	return len(args) == 2 && strings.Contains(args[1], "://")
 }
@@ -355,7 +357,8 @@ func run() error {
 	window.OnWindowEvent(events.Common.WindowRuntimeReady, func(*application.WindowEvent) {
 		log.Print("wails runtime ready — --wails-draggable listeners are attached")
 		// Cold-start URL source is coldStartDecisionFor, not "!= darwin".
-		// Linux always reads argv (GTK4 does not emit ApplicationLaunchedWithUrl).
+		// Linux always reads argv (GTK4 does not emit ApplicationLaunchedWithUrl;
+		// fix sent upstream as wailsapp/wails#6000).
 		// Windows reads argv only when wails will not emit the event
 		// (len(os.Args) != 2 or the single arg has no "://"). macOS never
 		// reads argv. Nothing is handed to the webview until this event:


### PR DESCRIPTION
Comment-only. desktop/ hits the two CI jobs that cannot run locally, so this goes through a PR per the merge rule.

- `desktop/main.go`: the three comments that state "GTK4 does not emit the event" now carry the upstream fix's address (wailsapp/wails#6000) and the follow-up (move Linux to DeferToEvent when a pin containing it lands).
- `desktop/README.md`: the platform table row for linux points at the same PR.

Local gates: `go build ./...` 0, `go vet` 0 (both modules), `desktop go test ./... -count=1` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)