### PR TITLE
fix(desktop): standalone app advertises its origin (GDK-340)

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/midagedev/gadak/internal/attachcache"
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/integrations"
+	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/server"
 	"github.com/midagedev/gadak/internal/store"
 	syncer "github.com/midagedev/gadak/internal/sync"
@@ -199,6 +200,18 @@ func run() error {
 	}
 	// After db.Close above, so LIFO stops the background sync first (GDK-270).
 	defer api.Close()
+
+	// Standalone: this process owns persist. Embed (never probe our own
+	// advertise file — self-loop), and advertise a loopback origin-only
+	// listener so a concurrent CLI routes writes here instead of opening a
+	// second embedded graph over the same persist file (GDK-340). LIFO:
+	// the listener stops before api.Close.
+	if cfg.IsStandalone() {
+		origin.SetInProcess(true)
+		defer origin.SetInProcess(false)
+		stopAdvertise := startStandaloneOriginListener(cfg, api)
+		defer stopAdvertise()
+	}
 
 	ui, ok := gadak.WebUI()
 	if !ok {

--- a/desktop/originadvertise.go
+++ b/desktop/originadvertise.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+)
+
+// startStandaloneOriginListener gives a standalone desktop app the
+// advertise surface `gadak serve` has (GDK-333), so a concurrent CLI
+// routes writes here instead of opening a second embedded issuetap graph
+// over the same persist file (GDK-340). The app itself has no TCP
+// listener by design — this one is loopback-only, an OS-picked port, and
+// serves exactly two paths, both forwarded to api (which carries the
+// browser guard and the X-Gadak identity headers):
+//
+//	GET origin.ProbePath   — the port_fallback / probeMatches probe
+//	origin.RESTPrefix/...  — the origin passthrough a CLI write takes
+//
+// Everything else is 404: this is not a UI/API server ("no forced
+// server/port" invariant). Returns a cleanup that withdraws the advertise
+// file and closes the listener. Connected workspaces are a no-op.
+func startStandaloneOriginListener(cfg *config.Config, api http.Handler) func() {
+	nop := func() {}
+	if cfg == nil || !cfg.IsStandalone() || api == nil {
+		return nop
+	}
+	dir := cfg.Directory()
+	if dir == "" {
+		var err error
+		dir, err = config.Dir()
+		if err != nil || dir == "" {
+			return nop
+		}
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Printf("warning: could not open origin passthrough listener: %v", err)
+		return nop
+	}
+	mux := http.NewServeMux()
+	mux.Handle("GET "+origin.ProbePath+"{$}", api)
+	mux.Handle(origin.RESTPrefix+"/", api)
+	srv := &http.Server{Handler: mux}
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("warning: origin passthrough listener: %v", err)
+		}
+	}()
+	if err := origin.WriteAdvertise(dir, ln.Addr().String()); err != nil {
+		log.Printf("warning: could not advertise origin owner: %v", err)
+		_ = srv.Close()
+		return nop
+	}
+	return func() {
+		_ = origin.RemoveAdvertise(dir)
+		_ = srv.Close()
+	}
+}

--- a/desktop/originadvertise_test.go
+++ b/desktop/originadvertise_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/server"
+	"github.com/midagedev/gadak/internal/store"
+)
+
+func standaloneApp(t *testing.T) (*config.Config, *server.Handler) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.SetInProcess(false)
+		config.SetProfile("")
+	})
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(filepath.Join(home, "mirror.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	api := server.New(db, cfg)
+	t.Cleanup(func() { _ = api.Close() })
+	return cfg, api
+}
+
+// TestGDK340StandaloneAppAdvertisesOrigin is the desktop side of
+// route_test: an app holding a standalone workspace must advertise a
+// loopback origin passthrough, or a concurrent CLI dual-writes persist.
+// FAIL-first evidence lives in the report for GDK-340 — with the
+// pre-fix no-op wiring this fails at "advertise file missing".
+func TestGDK340StandaloneAppAdvertisesOrigin(t *testing.T) {
+	cfg, api := standaloneApp(t)
+	origin.SetInProcess(true)
+
+	stop := startStandaloneOriginListener(cfg, api)
+	defer stop()
+
+	advPath := origin.AdvertisePath(cfg.Directory())
+	data, err := os.ReadFile(advPath)
+	if err != nil {
+		t.Fatalf("FAIL-first GDK-340: advertise file missing while the app holds a standalone workspace: %v", err)
+	}
+	var adv origin.Advertise
+	if err := json.Unmarshal(data, &adv); err != nil {
+		t.Fatal(err)
+	}
+	if adv.Addr == "" || adv.PID != os.Getpid() {
+		t.Fatalf("advertise doc %+v", adv)
+	}
+
+	// The probe path answers with the identity headers port_fallback and
+	// origin.probeMatches require.
+	res, err := http.Get("http://" + adv.Addr + origin.ProbePath)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	res.Body.Close()
+	if res.Header.Get("X-Gadak") != "1" {
+		t.Fatalf("probe response lacks X-Gadak (status %d)", res.StatusCode)
+	}
+	if got := res.Header.Get("X-Gadak-Profile"); got != config.Profile() {
+		t.Fatalf("X-Gadak-Profile = %q, want %q", got, config.Profile())
+	}
+
+	// The passthrough serves real origin REST: myself on the embedded
+	// issuetap. This is the route a CLI write takes.
+	req, err := http.NewRequest(http.MethodGet, "http://"+adv.Addr+origin.RESTPrefix+"/rest/api/3/myself", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("standalone:standalone")))
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("passthrough: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("passthrough /rest/api/3/myself = %d", res.StatusCode)
+	}
+
+	// stop withdraws the advertise file.
+	stop()
+	if _, err := os.Stat(advPath); !os.IsNotExist(err) {
+		t.Fatalf("advertise file still present after stop: %v", err)
+	}
+}
+
+// The listener is origin-passthrough only — the app must not grow a full
+// loopback UI/API surface ("no forced server/port" invariant).
+func TestGDK340ListenerServesOnlyOriginPaths(t *testing.T) {
+	cfg, api := standaloneApp(t)
+	origin.SetInProcess(true)
+
+	stop := startStandaloneOriginListener(cfg, api)
+	defer stop()
+
+	data, err := os.ReadFile(origin.AdvertisePath(cfg.Directory()))
+	if err != nil {
+		t.Fatalf("advertise file: %v", err)
+	}
+	var adv origin.Advertise
+	if err := json.Unmarshal(data, &adv); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, p := range []string{
+		"/",
+		"/api/v1/bootstrap/",
+		"/api/v1/issues/",
+		"/config.json",
+		"/healthz",
+		"/api/v1/issues/sync/progress/deeper", // subtree of the probe path
+	} {
+		res, err := http.Get("http://" + adv.Addr + p)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+		res.Body.Close()
+		if res.StatusCode != http.StatusNotFound {
+			t.Fatalf("GET %s = %d, want 404", p, res.StatusCode)
+		}
+	}
+}
+
+// A connected workspace opens no listener and writes no advertise file.
+func TestGDK340ConnectedAppNoListener(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := startStandaloneOriginListener(cfg, http.NotFoundHandler())
+	stop()
+	if _, err := os.Stat(origin.AdvertisePath(home)); !os.IsNotExist(err) {
+		t.Fatalf("connected workspace wrote advertise: %v", err)
+	}
+}

--- a/internal/origin/advertise.go
+++ b/internal/origin/advertise.go
@@ -24,14 +24,15 @@ const AdvertiseRel = "serve-origin.json"
 // /rest/api/3/issue is sent to <serve> + RESTPrefix + /rest/api/3/issue.
 const RESTPrefix = "/api/v1/origin"
 
-const (
-	// probePath and probeTimeout match cmd/gadak/port_fallback.go. Origin
-	// cannot import cmd, so the values and the header contract (X-Gadak,
-	// X-Gadak-Profile) are copied here including the 700ms bound — a
-	// longer timeout would stall every CLI write when no serve is up.
-	probePath    = "/api/v1/issues/sync/progress/"
-	probeTimeout = 700 * time.Millisecond
-)
+// ProbePath and probeTimeout match cmd/gadak/port_fallback.go. Origin
+// cannot import cmd, so the values and the header contract (X-Gadak,
+// X-Gadak-Profile) are copied here including the 700ms bound — a
+// longer timeout would stall every CLI write when no serve is up.
+// Exported so the desktop app's origin-only listener (GDK-340) can serve
+// exactly the path the probe hits.
+const ProbePath = "/api/v1/issues/sync/progress/"
+
+const probeTimeout = 700 * time.Millisecond
 
 // Advertise is the JSON document in AdvertiseRel.
 type Advertise struct {
@@ -214,7 +215,7 @@ func probeGadakOnPort(port string, timeout time.Duration) gadakProbe {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	url := "http://" + net.JoinHostPort("127.0.0.1", port) + probePath
+	url := "http://" + net.JoinHostPort("127.0.0.1", port) + ProbePath
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return gadakProbe{}


### PR DESCRIPTION
GDK-333 closed the `gadak serve`+CLI double-writer; this closes the remaining half. A standalone desktop app has no TCP listener by design, so it had no address to advertise — a concurrent CLI write opened a second embedded issuetap graph over the same persist file.

Now, standalone-only, the app opens a loopback origin-passthrough listener (port 0), serves exactly `origin.ProbePath` and `origin.RESTPrefix/` (all else 404), advertises via the GDK-333 infrastructure, and withdraws on exit.

- FAIL-first evidence and a 6-path 404 whitelist test in `desktop/originadvertise_test.go`
- Local gates green (root + desktop: build/test/vet); this PR exists for the Windows/Linux desktop CI jobs that cannot run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwZjv2m5jMZ77X2LgSmXRN