### PR TITLE
fix(standalone): acknowledged writes are durable before the response (GDK-342)

### DIFF
--- a/cmd/gadak/main.go
+++ b/cmd/gadak/main.go
@@ -188,8 +188,14 @@ Profiles keep separate credentials and mirrors (e.g. work and demo):
 func main() {
 	log.SetFlags(0)
 	// origin.Close flushes a standalone issuetap PersistPath. os.Exit
-	// below skips defers, so Close is also called on the error path.
-	defer func() { _ = origin.Close() }()
+	// below skips defers, so Close is also called on the error path. A
+	// flush failure must not exit 0 alongside a success line (GDK-342).
+	defer func() {
+		if err := origin.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "gadak: standalone persist flush on exit: %v\n", err)
+			os.Exit(1)
+		}
+	}()
 	server.Version = version
 	if base := filepath.Base(os.Args[0]); base == config.LegacyName || base == config.LegacyName+".exe" {
 		fmt.Fprintf(os.Stderr, "gadak: the `%s` command was renamed to `gadak`.\n", config.LegacyName)
@@ -226,7 +232,9 @@ func main() {
 	}
 	if err := run(args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "gadak: %v\n", err)
-		_ = origin.Close()
+		if cerr := origin.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "gadak: standalone persist flush on exit: %v\n", cerr)
+		}
 		os.Exit(exitStatus(err))
 	}
 }

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jchv/go-winloader v0.0.0-20250406163304-c1995be93bd1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37 // indirect
+	github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -28,8 +28,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
-github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37 h1:d01b41L8tmiTWclUNEoS/nAYPNHpyngdtl+QJasnQoc=
-github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37/go.mod h1:4d/iws7L/mIVY5uxd3Ui8eysZMDnou334uFfxZxWSUs=
+github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58 h1:YnlckLB1V1STwZ6HwlZMufD2tJUW4pcrEX40NHfSNu4=
+github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58/go.mod h1:4d/iws7L/mIVY5uxd3Ui8eysZMDnou334uFfxZxWSUs=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -211,6 +211,15 @@ func run() error {
 		defer origin.SetInProcess(false)
 		stopAdvertise := startStandaloneOriginListener(cfg, api)
 		defer stopAdvertise()
+		// The CLI flushes the standalone persist on the way out
+		// (cmd/gadak/main.go); the app must too, or quitting inside the
+		// debounce window silently drops the last write (GDK-342). LIFO:
+		// runs after the listener stops, so nothing new arrives mid-flush.
+		defer func() {
+			if err := origin.Close(); err != nil {
+				log.Printf("warning: standalone persist flush on exit: %v", err)
+			}
+		}()
 	}
 
 	ui, ok := gadak.WebUI()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/mattn/go-runewidth v0.0.19
-	github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37
+	github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58
 	modernc.org/sqlite v1.56.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
-github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37 h1:d01b41L8tmiTWclUNEoS/nAYPNHpyngdtl+QJasnQoc=
-github.com/midagedev/issuetap v0.0.0-20260819163823-2f94333b1d37/go.mod h1:4d/iws7L/mIVY5uxd3Ui8eysZMDnou334uFfxZxWSUs=
+github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58 h1:YnlckLB1V1STwZ6HwlZMufD2tJUW4pcrEX40NHfSNu4=
+github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58/go.mod h1:4d/iws7L/mIVY5uxd3Ui8eysZMDnou334uFfxZxWSUs=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -279,6 +279,11 @@ func constructStandalone(persist string) (*session, error) {
 	emb, err := issuetap.NewEmbedded(issuetap.EmbeddedConfig{
 		PersistPath:  persist,
 		FixtureBytes: defaultStandaloneFixture,
+		// The persist file is the origin — a write we acknowledged must be
+		// on disk before the response, not a debounce window later. A
+		// negative debounce is issuetap's durable-before-return mode
+		// (GDK-342); the mirror keeps its own transactionality either way.
+		PersistDebounce: -1,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("origin: issuetap: %w", err)


### PR DESCRIPTION
issuetap ad4162b (backoff retry + negative-debounce durable mode) + gadak wiring: embedded origin runs durable-before-return, the desktop app flushes persist on exit like the CLI, and a CLI exit-flush failure exits 1 instead of hiding behind a success line.

Local gates green (root+desktop build/test/vet, doc-checks); PR exists for the Windows/Linux desktop CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwZjv2m5jMZ77X2LgSmXRN