### PR TITLE
fix(standalone): persist flock makes the embed owner exclusive (GDK-343)

### DIFF
--- a/cmd/gadak/serve.go
+++ b/cmd/gadak/serve.go
@@ -209,7 +209,10 @@ func runServeHTTP(ctx context.Context, mux http.Handler, preferred string, addrP
 	defer ln.Close()
 	// Advertise the final listen address (after port fallback) so other
 	// processes route origin writes here. Connected workspaces skip.
-	unpublish := publishStandaloneOrigin(cfg, bound)
+	unpublish, err := publishStandaloneOrigin(cfg, bound)
+	if err != nil {
+		return err
+	}
 	defer unpublish()
 
 	srv := &http.Server{
@@ -259,6 +262,12 @@ func cmdServe(args []string) error {
 	if cfg.IsStandalone() {
 		origin.SetInProcess(true)
 		defer origin.SetInProcess(false)
+		// Take the persist lock now (GDK-343): a second owner must fail at
+		// startup — before its advertise write could steal routing from the
+		// live owner — not at the first write.
+		if _, err := origin.StandaloneHandler(cfg); err != nil {
+			return err
+		}
 	}
 	db, err := openStore()
 	if err != nil {
@@ -299,24 +308,28 @@ func cmdServe(args []string) error {
 // publishStandaloneOrigin writes serve-origin.json for a standalone
 // workspace and returns a cleanup that removes it. Connected workspaces
 // and a missing profile dir are no-ops.
-func publishStandaloneOrigin(cfg *config.Config, bound string) func() {
+//
+// A write failure is fatal (GDK-343 / F6): this process holds the persist
+// lock, so without the advertise file every concurrent CLI write becomes a
+// hard "workspace busy" error instead of routing here. Failing loud at
+// startup beats a warning nobody reads.
+func publishStandaloneOrigin(cfg *config.Config, bound string) (func(), error) {
 	nop := func() {}
 	if cfg == nil || !cfg.IsStandalone() || bound == "" {
-		return nop
+		return nop, nil
 	}
 	dir := cfg.Directory()
 	if dir == "" {
 		var err error
 		dir, err = config.Dir()
 		if err != nil || dir == "" {
-			return nop
+			return nop, nil
 		}
 	}
 	if err := origin.WriteAdvertise(dir, bound); err != nil {
-		log.Printf("warning: could not advertise origin owner: %v", err)
-		return nop
+		return nop, fmt.Errorf("could not advertise origin owner: %w", err)
 	}
-	return func() { _ = origin.RemoveAdvertise(dir) }
+	return func() { _ = origin.RemoveAdvertise(dir) }, nil
 }
 
 // openOnceUp opens the browser as soon as the server answers /healthz, so the

--- a/cmd/gadak/serve_test.go
+++ b/cmd/gadak/serve_test.go
@@ -119,7 +119,10 @@ func TestPublishStandaloneOriginWritesAndRemoves(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unpublish := publishStandaloneOrigin(cfg, "127.0.0.1:7998")
+	unpublish, err := publishStandaloneOrigin(cfg, "127.0.0.1:7998")
+	if err != nil {
+		t.Fatal(err)
+	}
 	p := origin.AdvertisePath(cfg.Directory())
 	raw, err := os.ReadFile(p)
 	if err != nil {
@@ -142,7 +145,10 @@ func TestPublishStandaloneOriginSkipsConnected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("GADAK_HOME", home)
 	cfg := &config.Config{Kind: config.KindConnected}
-	unpublish := publishStandaloneOrigin(cfg, "127.0.0.1:7998")
+	unpublish, err := publishStandaloneOrigin(cfg, "127.0.0.1:7998")
+	if err != nil {
+		t.Fatal(err)
+	}
 	unpublish()
 	if _, err := os.Stat(filepath.Join(home, origin.AdvertiseRel)); !os.IsNotExist(err) {
 		t.Fatal("connected workspace must not write serve-origin.json")

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -209,7 +209,10 @@ func run() error {
 	if cfg.IsStandalone() {
 		origin.SetInProcess(true)
 		defer origin.SetInProcess(false)
-		stopAdvertise := startStandaloneOriginListener(cfg, api)
+		stopAdvertise, err := startStandaloneOriginListener(cfg, api)
+		if err != nil {
+			return err
+		}
 		defer stopAdvertise()
 		// The CLI flushes the standalone persist on the way out
 		// (cmd/gadak/main.go); the app must too, or quitting inside the

--- a/desktop/originadvertise.go
+++ b/desktop/originadvertise.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -23,23 +24,32 @@ import (
 // Everything else is 404: this is not a UI/API server ("no forced
 // server/port" invariant). Returns a cleanup that withdraws the advertise
 // file and closes the listener. Connected workspaces are a no-op.
-func startStandaloneOriginListener(cfg *config.Config, api http.Handler) func() {
+//
+// Failure is fatal (GDK-343): the persist lock is taken here — before the
+// advertise write — so a second owner dies at startup instead of stealing
+// routing; and once this process holds the lock, a missing advertise file
+// would turn every concurrent CLI write into a hard "workspace busy" error
+// instead of a route, so a failed listener or advertise write aborts too.
+func startStandaloneOriginListener(cfg *config.Config, api http.Handler) (func(), error) {
 	nop := func() {}
 	if cfg == nil || !cfg.IsStandalone() || api == nil {
-		return nop
+		return nop, nil
 	}
 	dir := cfg.Directory()
 	if dir == "" {
 		var err error
 		dir, err = config.Dir()
 		if err != nil || dir == "" {
-			return nop
+			return nop, nil
 		}
+	}
+	// Eager persist lock: fail before advertising, not at the first write.
+	if _, err := origin.StandaloneHandler(cfg); err != nil {
+		return nop, err
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		log.Printf("warning: could not open origin passthrough listener: %v", err)
-		return nop
+		return nop, fmt.Errorf("could not open origin passthrough listener: %w", err)
 	}
 	mux := http.NewServeMux()
 	mux.Handle("GET "+origin.ProbePath+"{$}", api)
@@ -51,12 +61,11 @@ func startStandaloneOriginListener(cfg *config.Config, api http.Handler) func() 
 		}
 	}()
 	if err := origin.WriteAdvertise(dir, ln.Addr().String()); err != nil {
-		log.Printf("warning: could not advertise origin owner: %v", err)
 		_ = srv.Close()
-		return nop
+		return nop, fmt.Errorf("could not advertise origin owner: %w", err)
 	}
 	return func() {
 		_ = origin.RemoveAdvertise(dir)
 		_ = srv.Close()
-	}
+	}, nil
 }

--- a/desktop/originadvertise_test.go
+++ b/desktop/originadvertise_test.go
@@ -55,7 +55,10 @@ func TestGDK340StandaloneAppAdvertisesOrigin(t *testing.T) {
 	cfg, api := standaloneApp(t)
 	origin.SetInProcess(true)
 
-	stop := startStandaloneOriginListener(cfg, api)
+	stop, err := startStandaloneOriginListener(cfg, api)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	advPath := origin.AdvertisePath(cfg.Directory())
@@ -114,7 +117,10 @@ func TestGDK340ListenerServesOnlyOriginPaths(t *testing.T) {
 	cfg, api := standaloneApp(t)
 	origin.SetInProcess(true)
 
-	stop := startStandaloneOriginListener(cfg, api)
+	stop, err := startStandaloneOriginListener(cfg, api)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer stop()
 
 	data, err := os.ReadFile(origin.AdvertisePath(cfg.Directory()))
@@ -155,7 +161,10 @@ func TestGDK340ConnectedAppNoListener(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stop := startStandaloneOriginListener(cfg, http.NotFoundHandler())
+	stop, err := startStandaloneOriginListener(cfg, http.NotFoundHandler())
+	if err != nil {
+		t.Fatal(err)
+	}
 	stop()
 	if _, err := os.Stat(origin.AdvertisePath(home)); !os.IsNotExist(err) {
 		t.Fatalf("connected workspace wrote advertise: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/midagedev/issuetap v0.0.0-20260819171819-ad4162bf3e58
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.56.0
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/origin/gdk333_failfirst_test.go
+++ b/internal/origin/gdk333_failfirst_test.go
@@ -2,6 +2,7 @@ package origin
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,12 +10,13 @@ import (
 	"github.com/midagedev/gadak/internal/jira"
 )
 
-// TestGDK333FailFirstTwoSessionsInvisible is the pre-fix shape of the
-// defect: two constructStandalone graphs on the same persist path do not
-// share memory. A create on A is invisible on B. After the routing fix
-// this remains true of two embeddings — the fix is that the CLI no longer
-// constructs B when a live serve owns A. The assertion is the inverse of
-// what we want from a routed Client (visibility); it documents the hazard.
+// TestGDK333FailFirstTwoSessionsInvisible documented the pre-fix defect:
+// two constructStandalone graphs on the same persist path did not share
+// memory — a create on A was invisible on B, and the last Close silently
+// won. GDK-333 closed the happy path by routing; GDK-343 closes the rest:
+// the persist lock now makes the second construction impossible at all, so
+// the assertion is that B fails with ErrWorkspaceBusy instead of opening
+// an invisible sibling graph.
 func TestGDK333FailFirstTwoSessionsInvisible(t *testing.T) {
 	persist := filepath.Join(t.TempDir(), "origin", "issuetap.yaml")
 	a, err := constructStandalone(persist)
@@ -22,11 +24,6 @@ func TestGDK333FailFirstTwoSessionsInvisible(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { closeSession(a) })
-	b, err := constructStandalone(persist)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { closeSession(b) })
 
 	ctx := context.Background()
 	key, err := a.client.CreateIssue(ctx, map[string]any{
@@ -41,13 +38,21 @@ func TestGDK333FailFirstTwoSessionsInvisible(t *testing.T) {
 		t.Fatalf("key %q", key)
 	}
 
-	found := searchKey(t, b.client, key)
-	if found {
-		t.Fatalf("session B unexpectedly sees %s — two embeddings now share memory; the routing fix needs revisit", key)
+	// FAIL-first (2026-08-19, unmodified constructStandalone): this second
+	// construction succeeded and B could not see A's issue — two embedded
+	// graphs over one file. Since GDK-343 it must fail on the persist lock.
+	b, err := constructStandalone(persist)
+	if err == nil {
+		closeSession(b)
+		t.Fatal("second constructStandalone succeeded — the GDK-333/343 double-graph hazard is back")
 	}
-	// FAIL-first (2026-08-19, unmodified constructStandalone):
-	// "FAIL-first GDK-333: issue STD-1 created on session A is invisible on session B (two embedded graphs)"
-	t.Logf("GDK-333 hazard still holds: %s created on A is invisible on B", key)
+	if !errors.Is(err, ErrWorkspaceBusy) {
+		t.Fatalf("second constructStandalone error = %v, want ErrWorkspaceBusy", err)
+	}
+
+	if !searchKey(t, a.client, key) {
+		t.Fatalf("issue %s missing on its own session", key)
+	}
 }
 
 func searchKey(t *testing.T, c *jira.Client, key string) bool {

--- a/internal/origin/gdk343_lock_test.go
+++ b/internal/origin/gdk343_lock_test.go
@@ -1,0 +1,73 @@
+package origin
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+)
+
+// TestGDK343SecondProcessCannotEmbed: two processes (simulated with
+// ForgetLive — origin.go's existing technique) open the same persist.
+// Before the flock fix both embedded and the last Close won (silent
+// last-writer-wins loss). After the fix the second Client must not embed:
+// with no advertise to route to, it fails with ErrWorkspaceBusy.
+//
+// FAIL-first (2026-08-20, pre-fix): the second Client succeeded, both
+// sessions wrote STD-1/STD-2 into their own graphs, and
+// SessionsConstructed rose by 2 — the double-embed hazard was live.
+func TestGDK343SecondProcessCannotEmbed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() {
+		_ = Close()
+		config.SetProfile("")
+	})
+	cfg := &config.Config{Kind: config.KindStandalone}
+
+	a, err := Client(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.CreateIssue(context.Background(), map[string]any{
+		"project":   map[string]any{"key": DefaultProjectKey},
+		"summary":   "gdk-343 first owner",
+		"issuetype": map[string]any{"name": "Task"},
+	}); err != nil {
+		t.Fatalf("CreateIssue on first owner: %v", err)
+	}
+
+	// Simulate a second process: the first session still holds the graph
+	// (and the lock), but this "process" no longer finds it in live.
+	ForgetLive()
+
+	_, err = Client(cfg)
+	if err == nil {
+		t.Fatal("second process embedded the same persist — double-owner hazard (GDK-343)")
+	}
+	if !errors.Is(err, ErrWorkspaceBusy) {
+		t.Fatalf("second Client error = %v, want ErrWorkspaceBusy", err)
+	}
+	if _, err := Wiki(cfg); !errors.Is(err, ErrWorkspaceBusy) {
+		t.Fatalf("second Wiki error = %v, want ErrWorkspaceBusy", err)
+	}
+}
+
+// TestGDK343LockReleasedOnClose: Close releases the persist lock, so the
+// process is allowed to come back (origin.Close contract).
+func TestGDK343LockReleasedOnClose(t *testing.T) {
+	persist := filepath.Join(t.TempDir(), "origin", "issuetap.yaml")
+	a, err := constructStandalone(persist)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeSession(a)
+	b, err := constructStandalone(persist)
+	if err != nil {
+		t.Fatalf("construct after close: %v", err)
+	}
+	closeSession(b)
+}

--- a/internal/origin/lock_other.go
+++ b/internal/origin/lock_other.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package origin
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// lockPersist takes the exclusive cross-process lock for a persist path.
+// The lock lives on a sidecar (persist + ".lock") because issuetap replaces
+// the persist file itself by temp+rename — a lock on that inode would not
+// survive the first write. flock is released by the kernel when the process
+// dies, so a crashed owner never leaves the workspace stuck (the stale
+// advertise file, F6's leftover, is thereby harmless too).
+//
+// A held lock returns ErrWorkspaceBusy; any other failure is its own error.
+func lockPersist(persist string) (func(), error) {
+	f, err := os.OpenFile(persist+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("origin: persist lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+			return nil, ErrWorkspaceBusy
+		}
+		return nil, fmt.Errorf("origin: persist lock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/origin/lock_windows.go
+++ b/internal/origin/lock_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package origin
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockPersist takes the exclusive cross-process lock for a persist path via
+// LockFileEx on a sidecar (persist + ".lock" — issuetap replaces the persist
+// file itself by temp+rename). Windows releases the lock when the process
+// exits, matching the flock behavior on the other platforms.
+func lockPersist(persist string) (func(), error) {
+	f, err := os.OpenFile(persist+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("origin: persist lock: %w", err)
+	}
+	ol := new(windows.Overlapped)
+	err = windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, ol)
+	if err != nil {
+		_ = f.Close()
+		if err == windows.ERROR_LOCK_VIOLATION {
+			return nil, ErrWorkspaceBusy
+		}
+		return nil, fmt.Errorf("origin: persist lock: %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -49,6 +49,12 @@ const (
 // existing sync/init gates so a missing token still reads the same.
 var errNeedCredential = errors.New("origin: site, email and token are required")
 
+// ErrWorkspaceBusy means another process holds the persist lock for this
+// workspace and did not advertise a routable origin. Embedding anyway would
+// open a second graph over the same file (GDK-343: last Close wins, silent
+// loss), so the caller gets this instead.
+var ErrWorkspaceBusy = errors.New("origin: another process is using this workspace (persist is locked); write through its serve, or close it and retry")
+
 // PersistPath is the absolute issuetap snapshot path inside a profile directory.
 func PersistPath(dir string) string {
 	if dir == "" {
@@ -101,6 +107,7 @@ type session struct {
 	emb    *issuetap.Embedded
 	client *jira.Client
 	wiki   *confluence.Client
+	unlock func() // releases the persist lock; runs after emb.Close
 }
 
 type sessionFlight struct {
@@ -159,6 +166,14 @@ func standaloneClient(cfg *config.Config) (*jira.Client, error) {
 		return c, nil
 	}
 	s, err := standaloneSession(cfg)
+	if errors.Is(err, ErrWorkspaceBusy) {
+		// The lock holder may have advertised between our probe and now, or
+		// the first probe was a 700ms false negative (F5). One more chance
+		// to route before surfacing the busy error.
+		if c, ok := routedJira(cfg); ok {
+			return c, nil
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -201,6 +216,12 @@ func standaloneWiki(cfg *config.Config) (*confluence.Client, error) {
 		return w, nil
 	}
 	s, err := standaloneSession(cfg)
+	if errors.Is(err, ErrWorkspaceBusy) {
+		// Same second-chance route as standaloneClient (F5 false negative).
+		if w, ok := routedWiki(cfg); ok {
+			return w, nil
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -276,6 +297,15 @@ func constructStandalone(persist string) (*session, error) {
 		return nil, fmt.Errorf("origin: persist dir: %w", err)
 	}
 
+	// The persist lock is the single truth for "who may embed" (GDK-343).
+	// Held for the session's lifetime; the kernel releases it if the
+	// process dies. A second process gets ErrWorkspaceBusy here instead of
+	// a second graph whose last Close would silently win.
+	unlock, err := lockPersist(persist)
+	if err != nil {
+		return nil, err
+	}
+
 	emb, err := issuetap.NewEmbedded(issuetap.EmbeddedConfig{
 		PersistPath:  persist,
 		FixtureBytes: defaultStandaloneFixture,
@@ -286,6 +316,7 @@ func constructStandalone(persist string) (*session, error) {
 		PersistDebounce: -1,
 	})
 	if err != nil {
+		unlock()
 		return nil, fmt.Errorf("origin: issuetap: %w", err)
 	}
 
@@ -303,12 +334,18 @@ func constructStandalone(persist string) (*session, error) {
 	}
 	w.HTTP.Transport = tr
 
-	return &session{emb: emb, client: c, wiki: w}, nil
+	return &session{emb: emb, client: c, wiki: w, unlock: unlock}, nil
 }
 
 func closeSession(s *session) {
-	if s != nil && s.emb != nil {
+	if s == nil {
+		return
+	}
+	if s.emb != nil {
 		_ = s.emb.Close()
+	}
+	if s.unlock != nil {
+		s.unlock()
 	}
 }
 
@@ -345,10 +382,16 @@ func Close() error {
 	mu.Unlock()
 	var first error
 	for _, s := range snapshot {
-		if s != nil && s.emb != nil {
+		if s == nil {
+			continue
+		}
+		if s.emb != nil {
 			if err := s.emb.Close(); err != nil && first == nil {
 				first = err
 			}
+		}
+		if s.unlock != nil {
+			s.unlock()
 		}
 	}
 	return first

--- a/internal/origin/route_test.go
+++ b/internal/origin/route_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -187,39 +188,32 @@ func TestClientFallsBackWhenProbeFails(t *testing.T) {
 	}
 }
 
-func TestClientFallsBackOnProfileMismatch(t *testing.T) {
+// Pre-GDK-343 this fell back to a second embedded graph over the live
+// owner's persist (the F5 double-write hazard). The persist lock now makes
+// that fallback fail loud instead: the owner is alive, so busy.
+func TestClientFailsBusyOnProfileMismatch(t *testing.T) {
 	cfg, _, _, _ := liveStandaloneServe(t)
 	config.SetProfile("other")
 	t.Cleanup(func() { config.SetProfile("") })
 
-	before := origin.SessionsConstructed()
-	c, err := origin.Client(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !origin.TransportIsEmbedded(c.HTTP.Transport) {
-		t.Fatalf("Transport type %T after profile mismatch, want embedded", c.HTTP.Transport)
-	}
-	if got := origin.SessionsConstructed(); got != before+1 {
-		t.Fatalf("profile mismatch should embed; constructed %d → %d", before, got)
+	_, err := origin.Client(cfg)
+	if !errors.Is(err, origin.ErrWorkspaceBusy) {
+		t.Fatalf("profile mismatch with a live owner: err = %v, want ErrWorkspaceBusy (embedding would double-write the persist)", err)
 	}
 }
 
+// In-process (this process is the serve owner) must never route to its own
+// advertise file. With the live owner's lock held by the still-open forgotten
+// session, the proof is the busy error: routing would have returned a serve
+// transport, and embedding would have opened a second graph (GDK-343).
 func TestSetInProcessSkipsRouting(t *testing.T) {
 	cfg, _, _, _ := liveStandaloneServe(t)
 	origin.SetInProcess(true)
 	t.Cleanup(func() { origin.SetInProcess(false) })
 
-	before := origin.SessionsConstructed()
-	c, err := origin.Client(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !origin.TransportIsEmbedded(c.HTTP.Transport) {
-		t.Fatalf("in-process Client Transport %T, want embedded", c.HTTP.Transport)
-	}
-	if got := origin.SessionsConstructed(); got != before+1 {
-		t.Fatalf("in-process should embed; constructed %d → %d", before, got)
+	_, err := origin.Client(cfg)
+	if !errors.Is(err, origin.ErrWorkspaceBusy) {
+		t.Fatalf("in-process Client err = %v, want ErrWorkspaceBusy (routing to self is the bug this guards)", err)
 	}
 }
 


### PR DESCRIPTION
Every advertise/probe failure path could open a second embedded issuetap graph over one persist file (last Close silently wins). An exclusive sidecar flock (LockFileEx on Windows) now decides who may embed: second process gets ErrWorkspaceBusy after one route retry; serve/desktop take the lock eagerly and fail loud on advertise errors; Watch busy-skips per tick.

Local gates green (root+desktop, plus GOOS=windows builds); PR for the desktop CI jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwZjv2m5jMZ77X2LgSmXRN