### PR TITLE
fix(desktop): mailto links reach the mail client from the webview (GDK-339)

### DIFF
--- a/desktop/handler_test.go
+++ b/desktop/handler_test.go
@@ -121,7 +121,13 @@ func TestFallbackHandler(t *testing.T) {
 		if len(openedURLs) != 1 || openedURLs[0] != "https://example.atlassian.net/wiki/x" {
 			t.Fatalf("opened = %v", openedURLs)
 		}
+		// mailto rides the same system-open path (GDK-339, About tab contact).
+		if rec := post(`{"url":"mailto:midagedev@gmail.com"}`); rec.Code != 204 {
+			t.Fatalf("mailto: got %d body %s", rec.Code, rec.Body.String())
+		}
+		openedURLs = openedURLs[:1]
 		for _, bad := range []string{
+			`{"url":"mailto:"}`,
 			`{"url":"file:///etc/passwd"}`,
 			`{"url":"javascript:alert(1)"}`,
 			`{"url":"/api/v1/issues/"}`,

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -712,10 +712,13 @@ func fallbackHandler(api http.Handler, ui fs.FS, reg *workspace.Registry, openUR
 			http.Error(w, `{"error":"bad_request"}`, http.StatusBadRequest)
 			return
 		}
-		// http(s) only: the mirror's URLs are web URLs, and nothing else
-		// (file:, javascript:, custom schemes) has any business here.
+		// http(s) plus mailto (GDK-339, the About tab's contact link) only:
+		// nothing else (file:, javascript:, custom schemes) has any business
+		// here. openURL is `open <url>` on darwin, which handles both.
 		u, err := url.Parse(body.URL)
-		if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		webURL := err == nil && (u.Scheme == "https" || u.Scheme == "http") && u.Host != ""
+		mailURL := err == nil && u.Scheme == "mailto" && u.Opaque != ""
+		if !webURL && !mailURL {
 			http.Error(w, `{"error":"bad_url"}`, http.StatusBadRequest)
 			return
 		}

--- a/web/src/lib/desktop-links.ts
+++ b/web/src/lib/desktop-links.ts
@@ -98,6 +98,13 @@ export function installDesktopLinkOpener(): () => void {
     const anchor = (e.target as Element | null)?.closest?.('a[href]')
     if (!anchor) return
     const href = anchor.getAttribute('href') ?? ''
+    // mailto dies silently in the webview too (GDK-339) — hand it to the
+    // system, which opens the mail client.
+    if (/^mailto:./i.test(href)) {
+      e.preventDefault()
+      openSystemBrowser(href)
+      return
+    }
     if (!/^https?:\/\//i.test(href)) return
     e.preventDefault()
     const base = config().jiraBaseUrl || null


### PR DESCRIPTION
About 탭의 Contact by Email(mailto:)이 데스크톱 웹뷰에서 무동작이던 결함. /desktop/open 허용 스킴에 mailto 추가(opaque 주소 필수; file:/javascript:/커스텀 스킴은 계속 400), desktop-links.ts 인터셉터가 mailto 클릭을 시스템 오픈으로 전달.

로컬 게이트: go build/vet/test(root+desktop 모듈), typecheck 0 에러, vitest 440, Playwright 279 전부 초록. PR인 이유: desktop/ 변경 — Windows/Linux 데스크톱 빌드 잡은 로컬에서 못 돈다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwZjv2m5jMZ77X2LgSmXRN