### PR TITLE
fix(desktop): the app itself registers gadak:// on Windows, and heals a moved path (GDK-350)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,10 @@ jobs:
           Write-Host "windows pack tree — ok"
           exit 0
 
+      - name: Protocol handler tests
+        working-directory: desktop
+        run: go test ./... -run 'Protocol' -count=1
+
       # In a child process, not in this step's own runspace: a non-zero
       # $LASTEXITCODE left behind at the end of a pwsh step is what the runner
       # reads as the step's result, so checking it in place fails the job even

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -143,6 +143,11 @@
 - **첫 실행이 에픽 분해 뷰로 열립니다** ([GDK-100]). 저장된 뷰가 없는 새
   워크스페이스는 all-open 복제본 대신 빌트인 Epics 뷰로 열리고, 두 번째
   실행부터는 마지막 뷰가, 팀 그룹 프리셋이 있으면 그것이 우선합니다.
+- **Windows에서 `gadak://` 링크가 동작합니다** ([GDK-350]). 데스크톱 앱이
+  첫 실행 시 `HKCU\SOFTWARE\Classes\gadak`에 스킴을 등록하고, 자기 경로가
+  바뀌면 항목을 다시 씁니다 — 브라우저·슬랙에서 링크를 클릭하면 앱이
+  열립니다. 포터블 팩 자체는 여전히 레지스트리를 건드리지 않고,
+  `--unregister-gadak-protocol`로 키를 제거할 수 있습니다.
 - **Windows가 알린 척을 멈춥니다** ([GDK-349]). OS 데스크톱 알림의 능력
   판정에 단일 소유자가 생겨, 알림을 못 쏘는 플랫폼에서는 watch 루프가
   대기 이벤트를 소비하지 않고, 설정 카피의 "항상 동작" 주장이 사라지며,
@@ -1631,6 +1636,7 @@ gadak의 백로그를 gadak으로 하루 도그푸딩하고, 착륙하는 대로
 [GDK-100]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-100
 [GDK-341]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-341
 [GDK-349]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-349
+[GDK-350]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-350
 [GDK-352]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-352
 [GDK-369]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-369
 [GDK-389]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-389

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,11 @@ the fixes are all here.
   workspace with no saved view opens on the built-in Epics view instead of
   a bare all-open replica; from the second run the last-used view wins, and
   a configured team-group preset still beats the generic default.
+- **A `gadak://` link works on Windows** ([GDK-350]). The desktop app now
+  registers the scheme in `HKCU\SOFTWARE\Classes\gadak` on first launch and
+  rewrites the entry whenever its own path changes, so clicking a link in a
+  browser or Slack opens the app — the portable pack itself still never
+  touches the registry, and `--unregister-gadak-protocol` removes the key.
 - **Windows stops pretending it notified you** ([GDK-349]). OS desktop
   notifications have one capability owner; on a platform that cannot fire
   them the watch loop no longer consumes pending events, the settings copy
@@ -1626,6 +1631,7 @@ measured numbers instead of adjectives.
 [GDK-100]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-100
 [GDK-341]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-341
 [GDK-349]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-349
+[GDK-350]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-350
 [GDK-352]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-352
 [GDK-369]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-369
 [GDK-389]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-389

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -78,7 +78,9 @@ with the host.
 The Windows portable directory includes the same two binaries at the root
 (`gadak-desktop.exe` and `gadak.exe`). `gadak.exe install-cli` copies
 `gadak.exe` onto PATH (Windows has no default symlink right). Protocol-handler
-registration (`HKCU\SOFTWARE\Classes\gadak`) is not part of this pack.
+registration (`HKCU\SOFTWARE\Classes\gadak`) is not part of this pack:
+`gadak-desktop.exe` writes that key on first launch and rewrites it when the
+exe path changes. To remove it: `gadak-desktop.exe --unregister-gadak-protocol`.
 
 ### Linux build prerequisites
 

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -7,6 +7,7 @@ replace github.com/midagedev/gadak => ../
 require (
 	github.com/midagedev/gadak v0.0.0
 	github.com/wailsapp/wails/v3 v3.0.0-beta.9
+	golang.org/x/sys v0.47.0
 )
 
 require (
@@ -22,7 +23,6 @@ require (
 	github.com/midagedev/issuetap v0.0.0-20260821112832-959fc515db7c // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -46,6 +46,9 @@ import (
 var appVersion = "dev"
 
 func main() {
+	if unregisterGadakProtocolIfRequested(os.Args[1:]) {
+		return
+	}
 	if printWindowChromeIfRequested(os.Args[1:]) {
 		return
 	}
@@ -391,6 +394,16 @@ func run() error {
 		coldStart = "event"
 	}
 	log.Printf("gadak-desktop version=%s wails=%s cold_start=%s", appVersion, wailsModuleVersion(), coldStart)
+	if protocolRegistersFor(runtime.GOOS) {
+		exe, err := os.Executable()
+		if err != nil {
+			log.Printf("gadak:// registration: %v", err)
+		} else if status, err := registerGadakProtocol(exe); err != nil {
+			log.Printf("gadak:// registration: %v", err)
+		} else {
+			log.Printf("gadak:// registration: %s", status)
+		}
+	}
 	var gate coldStartGate
 	gate.apply = func(raw, source string) {
 		if applyDeepLink == nil {

--- a/desktop/protocol.go
+++ b/desktop/protocol.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// protocolCommand is the HKCU shell\open\command default: quoted exe + "%1".
+func protocolCommand(exePath string) string {
+	return `"` + exePath + `" "%1"`
+}
+
+// protocolDefaultIcon is the DefaultIcon default: quoted exe + ",0".
+func protocolDefaultIcon(exePath string) string {
+	return `"` + exePath + `",0`
+}
+
+func protocolNeedsRewrite(current, want string) bool {
+	return current != want
+}
+
+// protocolRegistersFor reports whether this GOOS registers gadak:// in HKCU.
+// macOS uses Info.plist (build-app.sh); Linux xdg-mime is a separate track.
+func protocolRegistersFor(goos string) bool {
+	return goos == "windows"
+}
+
+func hasUnregisterGadakProtocolFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--unregister-gadak-protocol" {
+			return true
+		}
+	}
+	return false
+}
+
+// unregisterGadakProtocolIfRequested handles --unregister-gadak-protocol
+// before the wails app is created. Always returns true when the flag is
+// present so main exits 0 without opening a window. A missing key is not
+// an error; a real registry error is written to stderr and still returns.
+func unregisterGadakProtocolIfRequested(args []string) bool {
+	if !hasUnregisterGadakProtocolFlag(args) {
+		return false
+	}
+	if err := unregisterGadakProtocol(); err != nil {
+		fmt.Fprintf(os.Stderr, "gadak:// unregister: %v\n", err)
+	}
+	fmt.Println("unregistered gadak:// protocol handler")
+	return true
+}

--- a/desktop/protocol_other.go
+++ b/desktop/protocol_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+// gadak:// registration is Windows HKCU only. macOS uses Info.plist
+// (build-app.sh); Linux xdg-mime is a separate track.
+func registerGadakProtocol(string) (string, error) { return "", nil }
+
+func unregisterGadakProtocol() error { return nil }

--- a/desktop/protocol_test.go
+++ b/desktop/protocol_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+func TestProtocolCommand(t *testing.T) {
+	exe := `C:\Program Files\Gadak\gadak-desktop.exe`
+	got := protocolCommand(exe)
+	want := `"C:\Program Files\Gadak\gadak-desktop.exe" "%1"`
+	if got != want {
+		t.Fatalf("protocolCommand = %q, want %q", got, want)
+	}
+}
+
+func TestProtocolNeedsRewrite(t *testing.T) {
+	want := protocolCommand(`C:\Gadak\gadak-desktop.exe`)
+	if protocolNeedsRewrite(want, want) {
+		t.Fatal("identical command needs rewrite")
+	}
+	if !protocolNeedsRewrite("", want) {
+		t.Fatal("empty current skipped rewrite")
+	}
+	moved := protocolCommand(`D:\Gadak\gadak-desktop.exe`)
+	if !protocolNeedsRewrite(moved, want) {
+		t.Fatal("path change skipped rewrite")
+	}
+}
+
+func TestProtocolRegistersFor(t *testing.T) {
+	table := []struct {
+		goos string
+		want bool
+	}{
+		{"windows", true},
+		{"darwin", false},
+		{"linux", false},
+		{"freebsd", false},
+		{"js", false},
+		{"", false},
+	}
+	for _, tc := range table {
+		if got := protocolRegistersFor(tc.goos); got != tc.want {
+			t.Errorf("protocolRegistersFor(%q) = %v, want %v", tc.goos, got, tc.want)
+		}
+	}
+}
+
+func TestUnregisterGadakProtocolFlag(t *testing.T) {
+	if hasUnregisterGadakProtocolFlag(nil) {
+		t.Fatal("empty args should not unregister")
+	}
+	if hasUnregisterGadakProtocolFlag([]string{"gadak://view"}) {
+		t.Fatal("deeplink is not the unregister flag")
+	}
+	if hasUnregisterGadakProtocolFlag([]string{"--print-window-chrome"}) {
+		t.Fatal("chrome flag is not the unregister flag")
+	}
+	if !hasUnregisterGadakProtocolFlag([]string{"--unregister-gadak-protocol"}) {
+		t.Fatal("flag not recognized")
+	}
+}

--- a/desktop/protocol_windows.go
+++ b/desktop/protocol_windows.go
@@ -1,0 +1,164 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const gadakProtocolScheme = "gadak"
+
+func protocolClassPath(scheme string) string {
+	return `SOFTWARE\Classes\` + scheme
+}
+
+func protocolCommandPath(scheme string) string {
+	return protocolClassPath(scheme) + `\shell\open\command`
+}
+
+func protocolIconPath(scheme string) string {
+	return protocolClassPath(scheme) + `\DefaultIcon`
+}
+
+func registryMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, registry.ErrNotExist) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ERROR_FILE_NOT_FOUND || errno == syscall.ERROR_PATH_NOT_FOUND
+	}
+	return false
+}
+
+func readProtocolCommand(scheme string) (string, error) {
+	k, err := registry.OpenKey(registry.CURRENT_USER, protocolCommandPath(scheme), registry.QUERY_VALUE)
+	if registryMissing(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	defer k.Close()
+	val, _, err := k.GetStringValue("")
+	if registryMissing(err) {
+		return "", nil
+	}
+	return val, err
+}
+
+func writeProtocolScheme(scheme, exePath string) error {
+	classPath := protocolClassPath(scheme)
+	k, _, err := registry.CreateKey(registry.CURRENT_USER, classPath, registry.WRITE)
+	if err != nil {
+		return fmt.Errorf("HKCU\\%s: %w", classPath, err)
+	}
+	if err := k.SetStringValue("", "URL:"+scheme); err != nil {
+		k.Close()
+		return err
+	}
+	if err := k.SetStringValue("URL Protocol", ""); err != nil {
+		k.Close()
+		return err
+	}
+	k.Close()
+
+	iconPath := protocolIconPath(scheme)
+	icon, _, err := registry.CreateKey(registry.CURRENT_USER, iconPath, registry.WRITE)
+	if err != nil {
+		return fmt.Errorf("HKCU\\%s: %w", iconPath, err)
+	}
+	if err := icon.SetStringValue("", protocolDefaultIcon(exePath)); err != nil {
+		icon.Close()
+		return err
+	}
+	icon.Close()
+
+	cmdPath := protocolCommandPath(scheme)
+	cmd, _, err := registry.CreateKey(registry.CURRENT_USER, cmdPath, registry.WRITE)
+	if err != nil {
+		return fmt.Errorf("HKCU\\%s: %w", cmdPath, err)
+	}
+	if err := cmd.SetStringValue("", protocolCommand(exePath)); err != nil {
+		cmd.Close()
+		return err
+	}
+	return cmd.Close()
+}
+
+func deleteKeyTree(root registry.Key, path string) error {
+	k, err := registry.OpenKey(root, path, registry.ENUMERATE_SUB_KEYS)
+	if registryMissing(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	names, err := k.ReadSubKeyNames(-1)
+	k.Close()
+	if err != nil && err != io.EOF {
+		return err
+	}
+	for _, name := range names {
+		if err := deleteKeyTree(root, path+`\`+name); err != nil {
+			return err
+		}
+	}
+	err = registry.DeleteKey(root, path)
+	if registryMissing(err) {
+		return nil
+	}
+	return err
+}
+
+func registerProtocolScheme(scheme, exePath string) (rewrote bool, err error) {
+	if scheme == "" || strings.ContainsAny(scheme, `\/`) {
+		return false, fmt.Errorf("invalid protocol scheme %q", scheme)
+	}
+	want := protocolCommand(exePath)
+	current, err := readProtocolCommand(scheme)
+	if err != nil {
+		return false, err
+	}
+	if !protocolNeedsRewrite(current, want) {
+		return false, nil
+	}
+	if err := writeProtocolScheme(scheme, exePath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func unregisterProtocolScheme(scheme string) error {
+	if scheme == "" || strings.ContainsAny(scheme, `\/`) {
+		return fmt.Errorf("invalid protocol scheme %q", scheme)
+	}
+	return deleteKeyTree(registry.CURRENT_USER, protocolClassPath(scheme))
+}
+
+// registerGadakProtocol writes HKCU\SOFTWARE\Classes\gadak when the open
+// command does not already name exePath. Status is "registered" or
+// "already current". Never fatal for the caller.
+func registerGadakProtocol(exePath string) (string, error) {
+	rewrote, err := registerProtocolScheme(gadakProtocolScheme, exePath)
+	if err != nil {
+		return "", err
+	}
+	if rewrote {
+		return "registered", nil
+	}
+	return "already current", nil
+}
+
+func unregisterGadakProtocol() error {
+	return unregisterProtocolScheme(gadakProtocolScheme)
+}

--- a/desktop/protocol_windows_test.go
+++ b/desktop/protocol_windows_test.go
@@ -1,0 +1,91 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func testProtocolScheme(t *testing.T) string {
+	t.Helper()
+	name := strings.ToLower(t.Name())
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, `\`, "-")
+	scheme := "gadak-test-" + name
+	if scheme == gadakProtocolScheme {
+		t.Fatal("test must not use the live gadak scheme")
+	}
+	return scheme
+}
+
+func TestProtocolWindowsRoundTrip(t *testing.T) {
+	scheme := testProtocolScheme(t)
+	exe := `C:\Temp\gadak-desktop.exe`
+	want := protocolCommand(exe)
+
+	t.Cleanup(func() {
+		if err := unregisterProtocolScheme(scheme); err != nil {
+			t.Errorf("cleanup unregister: %v", err)
+		}
+	})
+
+	rewrote, err := registerProtocolScheme(scheme, exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rewrote {
+		t.Fatal("first register reported already current")
+	}
+	got, err := readProtocolCommand(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("command %q, want %q", got, want)
+	}
+
+	rewrote, err = registerProtocolScheme(scheme, exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rewrote {
+		t.Fatal("second register rewrote identical command")
+	}
+
+	moved := `D:\Other\gadak-desktop.exe`
+	rewrote, err = registerProtocolScheme(scheme, moved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rewrote {
+		t.Fatal("path change did not rewrite")
+	}
+	got, err = readProtocolCommand(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != protocolCommand(moved) {
+		t.Fatalf("after move command %q, want %q", got, protocolCommand(moved))
+	}
+
+	if err := unregisterProtocolScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	got, err = readProtocolCommand(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("command still present after unregister: %q", got)
+	}
+	_, err = registry.OpenKey(registry.CURRENT_USER, protocolClassPath(scheme), registry.QUERY_VALUE)
+	if err == nil {
+		t.Fatal("scheme key still exists after unregister")
+	}
+	if !registryMissing(err) {
+		t.Fatalf("open after unregister: %v", err)
+	}
+}

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -162,9 +162,11 @@ plain name, try to traverse a path, or exceed the size limits
 (`internal/deeplink`). Actions that submit or write will not be added.
 
 macOS registers the scheme from the bundle's `Info.plist`. The Windows
-portable zip does not write `HKCU\SOFTWARE\Classes\gadak` (that registration
-is not part of the pack). On Linux, and on Windows when you are using
-`gadak serve` instead of the exe, the `web` field from
+portable zip does not write `HKCU\SOFTWARE\Classes\gadak` — the pack never
+touches the registry. `gadak-desktop.exe` registers that key on first launch
+and rewrites it when its path changes. Unregister with
+`gadak-desktop.exe --unregister-gadak-protocol`. On Linux, and on Windows
+when you are using `gadak serve` instead of the exe, the `web` field from
 `gadak views open --json` is the link to hand over — it needs a running
 `serve`.
 


### PR DESCRIPTION
os-audit F-10: clicking a `gadak://view?...` link in a browser or Slack did nothing on Windows — the handler was never registered with the OS. The receiving side (wails `ApplicationLaunchedWithUrl` / second-instance argv → `desktop/deeplink.go`) was already complete; only the registration was missing.

**Owner: the app, not the pack.** The desktop-windows CI job asserts the portable pack writes no HKCU key, and that assertion is untouched. Instead `gadak-desktop.exe` registers `HKCU\SOFTWARE\Classes\gadak` at startup: read the current open command, compare against its own path, rewrite only on mismatch — which also heals a moved or upgraded install. Registration failure is logged, never fatal. `--unregister-gadak-protocol` deletes the key tree for portable removal.

**Verification.** Pure logic (command string, rewrite decision, GOOS table, flag parse) is tested on every host. The real registry round-trip runs on the Windows CI runner via a new `go test -run Protocol` step, against a throwaway `gadak-test-*` scheme so the live key is never touched, placed after the pack's HKCU-absence assertion. Local gates green (desktop + root build/vet/test, `GOOS=windows` cross build/vet, doc-checks). Not verified here: an actual browser click on a real Windows machine — that stays on the GDK-355 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)