### PR TITLE
fix(desktop): the Close Tab accelerator exists only where the pane does (GDK-351)

### DIFF
--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -156,6 +156,10 @@
   관례 `~/.local/bin` 대신 `%LOCALAPPDATA%\Programs\gadak`가 되고, 권한
   힌트가 sudo를 권하지 않으며, 설치 시 `gadak-desktop.exe` 위치를 기록해
   복사된 CLI에서도 `views open`이 앱을 찾습니다.
+- **Ctrl+W가 못 하는 일을 약속하지 않습니다** ([GDK-351]). Close Tab
+  액셀러레이터는 macOS 전용인 인앱 브라우즈 페인에만 작동하므로, 페인이
+  없는 빌드에서는 메뉴 항목 자체를 만들지 않습니다 — 항목의 존재가 페인과
+  같은 사실에서 파생됩니다.
 - **Windows에서 `gadak://` 링크가 동작합니다** ([GDK-350]). 데스크톱 앱이
   첫 실행 시 `HKCU\SOFTWARE\Classes\gadak`에 스킴을 등록하고, 자기 경로가
   바뀌면 항목을 다시 씁니다 — 브라우저·슬랙에서 링크를 클릭하면 앱이
@@ -1650,6 +1654,7 @@ gadak의 백로그를 gadak으로 하루 도그푸딩하고, 착륙하는 대로
 [GDK-341]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-341
 [GDK-349]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-349
 [GDK-350]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-350
+[GDK-351]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-351
 [GDK-255]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-255
 [GDK-316]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-316
 [GDK-353]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-353

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,10 @@ the fixes are all here.
   permission hint stops recommending sudo, and installing records where
   `gadak-desktop.exe` lives so `views open` from the copied CLI can still
   find the app.
+- **Ctrl+W stops promising what it cannot do** ([GDK-351]). The Close Tab
+  accelerator only acts on the in-app browse pane, which is macOS-only, so
+  builds without the pane no longer create the menu item at all — its
+  presence now derives from the same fact as the pane itself.
 - **A `gadak://` link works on Windows** ([GDK-350]). The desktop app now
   registers the scheme in `HKCU\SOFTWARE\Classes\gadak` on first launch and
   rewrites the entry whenever its own path changes, so clicking a link in a
@@ -1648,6 +1652,7 @@ measured numbers instead of adjectives.
 [GDK-341]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-341
 [GDK-349]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-349
 [GDK-350]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-350
+[GDK-351]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-351
 [GDK-255]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-255
 [GDK-316]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-316
 [GDK-353]: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-353

--- a/desktop/embed_darwin.go
+++ b/desktop/embed_darwin.go
@@ -234,6 +234,11 @@ func newPlatformEmbedder(window func() unsafe.Pointer) embedder {
 	return &macEmbedder{window: window}
 }
 
+// paneSupported is the one fact "does this build have an in-app browse
+// pane". UI that only acts on the pane (the Close Tab menu item) derives
+// from it, so a platform without the pane never grows dead chrome (GDK-351).
+const paneSupported = true
+
 // installEscapeRelay is darwin's answer to GDK-78; other platforms have no
 // embedded webviews to steal keystrokes in the first place.
 func installEscapeRelay() {

--- a/desktop/embed_other.go
+++ b/desktop/embed_other.go
@@ -20,6 +20,11 @@ func newPlatformEmbedder(func() unsafe.Pointer) embedder {
 // No embedded webviews off darwin, so there is nothing to relay Escape past.
 func installEscapeRelay() {}
 
+// paneSupported mirrors embed_darwin.go: no pane on this build, so
+// pane-only UI (the Close Tab accelerator) must not be created — a
+// CmdOrCtrl+W that visibly does nothing was os-audit F-2 (GDK-351).
+const paneSupported = false
+
 func (stubEmbedder) Create(string, frameRect) (unsafe.Pointer, error) {
 	return nil, errors.New("in-app browser pane is macOS-only")
 }

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -355,8 +355,12 @@ func run() error {
 	// ⌘W closes the visible in-app browser tab and nothing else. It has to be
 	// a menu accelerator: with focus inside the embedded page the SPA never
 	// sees the keystroke. Deliberately not the stock CloseWindow role — that
-	// closes the focused window, and here that is the app.
-	if item := appMenu.FindByLabel("Window"); item != nil && item.IsSubmenu() {
+	// closes the focused window, and here that is the app. On a build without
+	// the pane the item is not created at all: browse.CloseActive() would be
+	// a no-op there, and a Ctrl+W that visibly does nothing was os-audit F-2
+	// (GDK-351). Falling back to closing the window was considered and
+	// rejected — it would discard an open comment draft on a reflex keystroke.
+	if item := appMenu.FindByLabel("Window"); paneSupported && item != nil && item.IsSubmenu() {
 		win := item.GetSubmenu()
 		win.AddSeparator()
 		win.Add("Close Tab").


### PR DESCRIPTION
os-audit F-2: the Window menu's Close Tab (CmdOrCtrl+W) called `browse.CloseActive()` on every platform, but the in-app browse pane is darwin-only (`embed_other.go` stubs) — on Windows and Linux the accelerator visibly did nothing.

The fix makes the menu item's existence derive from the same fact as the pane: `paneSupported` is a build-tag constant owned by the embed files (`true` in `embed_darwin.go`, `false` in `embed_other.go`), and the Close Tab item is only created when it holds. The alternative — falling back to closing the window — was rejected because a reflex Ctrl+W would discard an open comment draft; that reasoning is in the code comment.

Gates: desktop build/vet/test green on darwin, `GOOS=windows` build+vet green. Linux compiles only in CI (GTK4 cgo), which is what this PR's run verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)