### PR TITLE
ci: gofmt joins the gate (GDK-607)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      # AGENTS.md documents `gofmt -l .` as a pre-gate; without CI enforcement
+      # unformatted files reached main twice (GDK-607). Empty output or fail.
+      - name: gofmt
+        run: |
+          out=$(gofmt -l .)
+          if [ -n "$out" ]; then echo "gofmt -l flagged:"; echo "$out"; exit 1; fi
+
       # Store/source firewall (docs/ARCHITECTURE.md:79). Not path-scoped: any
       # import-graph edit can break it.
       - name: Store dependency firewall

--- a/cmd/gadak/agent_test.go
+++ b/cmd/gadak/agent_test.go
@@ -171,7 +171,8 @@ func (f *fakeJira) route(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(`{"errorMessages":["no claim route on this origin"]}`))
-	case path == "/user/search":		q := r.URL.Query().Get("query")
+	case path == "/user/search":
+		q := r.URL.Query().Get("query")
 		f.searchQueries = append(f.searchQueries, q)
 		if f.searchUsers != nil {
 			body := f.searchUsers(q)

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -294,14 +294,14 @@ func etagMatches(header string, version int64) bool {
 /* ── detail ── */
 
 type detailComment struct {
-	CommentID       string          `json:"comment_id"`
-	Author          *string         `json:"author"`
-	AuthorEmail     *string         `json:"author_email"`
-	AuthorAccountID *string         `json:"author_account_id"`
-	AuthorAccountType *string       `json:"author_account_type,omitempty"`
-	Body            string          `json:"body"`
-	RawBody         json.RawMessage `json:"raw_body"`
-	CreatedAt       *string         `json:"created_at"`
+	CommentID         string          `json:"comment_id"`
+	Author            *string         `json:"author"`
+	AuthorEmail       *string         `json:"author_email"`
+	AuthorAccountID   *string         `json:"author_account_id"`
+	AuthorAccountType *string         `json:"author_account_type,omitempty"`
+	Body              string          `json:"body"`
+	RawBody           json.RawMessage `json:"raw_body"`
+	CreatedAt         *string         `json:"created_at"`
 }
 
 type detailAttachment struct {
@@ -703,13 +703,13 @@ type derivedView struct {
 	// which account ids touched each issue — comment, changelog entry, or
 	// dev-panel link. Rows serialize it as `actor_ids`; the client's actor
 	// filter narrows on it with no extra round trip.
-	actorsByIssue map[string][]string
-	categories    map[string]string
-	groupByEmail         map[string]string
-	groupByAccount       map[string]string
-	rules                []config.GroupRule
-	queryGroup           map[string]string
-	groupsEnabled        bool
+	actorsByIssue  map[string][]string
+	categories     map[string]string
+	groupByEmail   map[string]string
+	groupByAccount map[string]string
+	rules          []config.GroupRule
+	queryGroup     map[string]string
+	groupsEnabled  bool
 	// Plugin enrichments the list rows carry, by issue key. They are cached with
 	// everything else here, which is exactly as fresh as the ETag: a plugin that
 	// forgets to bump sync_state.version gets no refetch either way (docs/PLUGINS.md).

--- a/internal/store/durations_test.go
+++ b/internal/store/durations_test.go
@@ -175,7 +175,7 @@ func TestDurationsLegacyStampsAndClamp(t *testing.T) {
 
 func TestFormatDuration(t *testing.T) {
 	cases := []struct {
-		d   time.Duration
+		d    time.Duration
 		want string
 	}{
 		{0, "0s"},

--- a/internal/store/people.go
+++ b/internal/store/people.go
@@ -136,11 +136,11 @@ func (db *DB) UserCatalog(ctx context.Context) ([]UserAccount, error) {
 // the issue_actors view, so `gadak sql` and documented recipes see the same
 // axis the server builds members from.
 type IssueActor struct {
-	IssueKey   string
-	SourceID   string
-	ActorID    string
-	ActorName  string
-	Via        string // "comment" | "changelog" | "dev_link"
+	IssueKey  string
+	SourceID  string
+	ActorID   string
+	ActorName string
+	Via       string // "comment" | "changelog" | "dev_link"
 }
 
 // QueryIssueActors returns every (issue, actor) touch, unordered. The set is


### PR DESCRIPTION
AGENTS.md documents `gofmt -l .` as a pre-gate, but CI never enforced it — struct-alignment drift reached main twice. This PR formats the four drifted files and adds a CI step that fails on any `gofmt -l` output.

FAIL-first: on main before this PR, `gofmt -l .` lists `cmd/gadak/agent_test.go internal/server/read.go internal/store/durations_test.go internal/store/people.go` — the new step would have failed exactly there.

PR (not direct push) because `.github/workflows/` only proves itself on a branch run.

Backlog: https://midagedev.github.io/gadak/backlog/#/?ks=GDK-607

🤖 Generated with [Claude Code](https://claude.com/claude-code)