### PR TITLE
fix(hosted): one Vite bundle for /demo/ and /backlog/ (GDK-673)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,12 +60,15 @@ jobs:
       # fetches detail/<KEY>.json, so the exploded tree must exist at deploy.
       # build.mjs unpacks too (local hosted-demo); this step is the Pages
       # source of truth and overwrites JSON onto the Vite backlog bundle.
+      # The snapshot still carries a pre-GDK-676 /gadak/ apiBase; rewrite it
+      # onto the runtime mount so hosted-fetch and config().apiBase agree.
       - name: Materialize public backlog snapshot
         run: |
           set -euo pipefail
           mkdir -p dist/hosted/backlog
           bash tools/backlog-snapshot.sh --unpack dist/hosted/backlog
           rm -f dist/hosted/backlog/MANIFEST
+          node tools/hosted-demo/build.mjs --rewrite-backlog-config dist/hosted/backlog/config.json /backlog/
 
       # GDK-52: the hosted browser gate runs in CI now, not only locally — a
       # false-state regression on the snapshot (feature entry points that 404)

--- a/e2e/hosted/bundle-once.spec.ts
+++ b/e2e/hosted/bundle-once.spec.ts
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto'
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test'
+import { dismissHostedFirstFrame } from './helpers'
+
+/**
+ * GDK-673 — one Vite bundle at /demo/ and /backlog/. The gate is the
+ * artifact (same hashed bytes at both paths), not the build log.
+ */
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..')
+const hosted = join(root, 'dist/hosted')
+
+function sha256(file: string): string {
+  return createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
+function hashedAssets(app: 'demo' | 'backlog'): string[] {
+  return readdirSync(join(hosted, app, 'assets')).filter((n) => n.startsWith('index-')).sort()
+}
+
+function readIndex(app: 'demo' | 'backlog'): string {
+  return readFileSync(join(hosted, app, 'index.html'), 'utf8')
+}
+
+test.describe('GDK-673 one Vite bundle', () => {
+  test('demo and backlog serve the same hashed JS/CSS bytes', () => {
+    const demo = hashedAssets('demo')
+    const backlog = hashedAssets('backlog')
+    expect(demo, 'each app must emit hashed index-* assets').not.toEqual([])
+    expect(backlog, 'copied bundle must keep the same asset names').toEqual(demo)
+    for (const name of demo) {
+      expect(
+        sha256(join(hosted, 'backlog', 'assets', name)),
+        `${name} must be the same bytes under /demo/ and /backlog/ — two Vite builds inlined different BASE_URL values`,
+      ).toBe(sha256(join(hosted, 'demo', 'assets', name)))
+    }
+  })
+
+  test('each app HTML names its own <base href> and keeps relative asset URLs', () => {
+    const demo = readIndex('demo')
+    const backlog = readIndex('backlog')
+    expect(demo).toMatch(/<base\s+href="\/demo\/"\s*\/?>/i)
+    expect(backlog).toMatch(/<base\s+href="\/backlog\/"\s*\/?>/i)
+    expect(demo).toContain('src="./assets/')
+    expect(backlog).toContain('src="./assets/')
+    expect(demo).toContain('href="./assets/')
+    expect(backlog).toContain('href="./assets/')
+  })
+
+  test('backlog config.json apiBase is the runtime mount, not a compile-time leftover', () => {
+    const demoCfg = JSON.parse(readFileSync(join(hosted, 'demo', 'config.json'), 'utf8')) as {
+      apiBase: string
+    }
+    const backlogCfg = JSON.parse(
+      readFileSync(join(hosted, 'backlog', 'config.json'), 'utf8'),
+    ) as { apiBase: string }
+    expect(demoCfg.apiBase).toBe('/demo/api/v1/issues/')
+    expect(backlogCfg.apiBase).toBe('/backlog/api/v1/issues/')
+  })
+})
+
+function isBundle404(line: string): boolean {
+  if (/favicon/i.test(line)) return false
+  if (/\/api\/v1\/workspaces/.test(line)) return false
+  if (line.startsWith('console:')) {
+    return !/Failed to load resource|service.?worker/i.test(line)
+  }
+  return /\/(assets\/|config\.json|bootstrap\.json)/.test(line)
+}
+
+test.describe('GDK-673 each mount draws its own snapshot', () => {
+  test('demo paints NMB issues; backlog paints GDK issues', async ({ page }) => {
+    let bucket: 'demo' | 'backlog' = 'demo'
+    const demoHits: string[] = []
+    const backlogHits: string[] = []
+    page.on('response', (res) => {
+      if (res.status() !== 404) return
+      ;(bucket === 'demo' ? demoHits : backlogHits).push(`${res.status()} ${res.url()}`)
+    })
+    page.on('console', (msg: ConsoleMessage) => {
+      if (msg.type() !== 'error') return
+      ;(bucket === 'demo' ? demoHits : backlogHits).push(`console: ${msg.text()}`)
+    })
+
+    await page.goto('/demo/')
+    await dismissHostedFirstFrame(page)
+    await expect(page.locator('html')).toHaveAttribute('data-base-path', '/demo/')
+    // Visible rows are virtualized; the demo fixture is NMA/NMB/NMS, not GDK.
+    await expect(page.getByText(/NM[ABS]-\d+/).first()).toBeVisible({ timeout: 60_000 })
+    await expect(page.getByText(/GDK-\d+/)).toHaveCount(0)
+    const seriousDemo = demoHits.filter(isBundle404)
+    expect(seriousDemo, `demo 404/console:\n${seriousDemo.join('\n')}`).toEqual([])
+
+    bucket = 'backlog'
+    await page.goto('/backlog/')
+    await expect(page.getByTestId('issue-layout')).toBeVisible({ timeout: 60_000 })
+    await expect(page.locator('html')).toHaveAttribute('data-base-path', '/backlog/')
+    await expect(page.getByText(/GDK-\d+/).first()).toBeVisible({ timeout: 60_000 })
+    await expect(page.getByText(/NMB-\d+/)).toHaveCount(0)
+    const seriousBacklog = backlogHits.filter(isBundle404)
+    expect(seriousBacklog, `backlog 404/console:\n${seriousBacklog.join('\n')}`).toEqual([])
+  })
+})

--- a/tools/hosted-demo/build.mjs
+++ b/tools/hosted-demo/build.mjs
@@ -3,8 +3,8 @@
  * Build the public site into dist/hosted.
  *
  *   /         landing page (static, authored here)
- *   /demo/    the zero-install live demo (Vite build + frozen examples/demo.db)
- *   /backlog/ the public backlog viewer (Vite build + committed snapshot)
+ *   /demo/    the zero-install live demo (one Vite build + frozen examples/demo.db)
+ *   /backlog/ the public backlog viewer (same bundle + committed snapshot)
  *
  * The site is served at the apex of gadak.dev, so the base path is `/`
  * (GDK-676). It used to be `/gadak/` for midagedev.github.io/gadak/; that
@@ -18,7 +18,7 @@
  *   ./tools/hosted-demo/preview.sh   # serve dist/hosted at :4173/
  */
 import { spawnSync } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { copyFileSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -27,14 +27,98 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const outDir = join(root, 'dist', 'hosted')
 const basePath = process.env.GADAK_BASE_PATH || '/'
 const withSlash = basePath.endsWith('/') ? basePath : `${basePath}/`
-// Each app owns a subpath because basePath() is a compile-time BASE_URL: two
-// bundles under one base would fetch each other's config.json.
+// Site layout: /demo/ and /backlog/. One Vite bundle (relative `./` assets);
+// each index.html gets a <base href> so basePath() can read the mount at
+// runtime (GDK-673). GADAK_BASE_PATH still prefixes a subpath deployment.
 const demoBase = `${withSlash}demo/`
 const backlogBase = `${withSlash}backlog/`
 const demoOut = join(outDir, 'demo')
 const apiBase = `${demoBase}api/v1/issues/`
 const authBase = `${demoBase}api/v1/auth/`
 const siteOrigin = process.env.GADAK_SITE_ORIGIN || 'https://gadak.dev'
+
+function withTrailingSlash(p) {
+  return p.endsWith('/') ? p : `${p}/`
+}
+
+function injectBaseHref(html, href) {
+  const tag = `    <base href="${href}" />\n`
+  if (/<base\b/i.test(html)) {
+    return html.replace(/<base\b[^>]*>\s*/i, tag)
+  }
+  if (!html.includes('<head>')) {
+    console.error('hosted-demo: no <head> in index.html — cannot inject <base>')
+    process.exit(1)
+  }
+  const next = html.replace('<head>', `<head>\n${tag}`)
+  if (next === html) {
+    console.error('hosted-demo: could not inject <base> — <head> tag changed shape')
+    process.exit(1)
+  }
+  return next
+}
+
+function copyViteShell(src, dest) {
+  mkdirSync(dest, { recursive: true })
+  for (const name of readdirSync(src)) {
+    cpSync(join(src, name), join(dest, name), { recursive: true })
+  }
+}
+
+function rewriteSnapshotConfig(configPath, appBase) {
+  if (!existsSync(configPath)) {
+    console.error(`hosted-demo: missing ${configPath}`)
+    process.exit(1)
+  }
+  const doc = JSON.parse(readFileSync(configPath, 'utf8'))
+  const base = withTrailingSlash(appBase)
+  doc.apiBase = `${base}api/v1/issues/`
+  doc.authBase = `${base}api/v1/auth/`
+  writeFileSync(configPath, `${JSON.stringify(doc, null, 2)}\n`)
+}
+
+function assertSharedBundle(demoDir, backlogDir) {
+  const demoAssetsDir = join(demoDir, 'assets')
+  const backlogAssetsDir = join(backlogDir, 'assets')
+  const demoAssets = readdirSync(demoAssetsDir).sort()
+  const backlogAssets = readdirSync(backlogAssetsDir).sort()
+  if (JSON.stringify(demoAssets) !== JSON.stringify(backlogAssets)) {
+    console.error(
+      `hosted-demo: demo/assets [${demoAssets}] != backlog/assets [${backlogAssets}] — the SPA was built twice`,
+    )
+    process.exit(1)
+  }
+  for (const name of demoAssets) {
+    const a = readFileSync(join(demoAssetsDir, name))
+    const b = readFileSync(join(backlogAssetsDir, name))
+    if (!a.equals(b)) {
+      console.error(`hosted-demo: ${name} bytes differ between demo and backlog — the SPA was built twice`)
+      process.exit(1)
+    }
+  }
+  for (const [dir, href] of [
+    [demoDir, demoBase],
+    [backlogDir, backlogBase],
+  ]) {
+    const html = readFileSync(join(dir, 'index.html'), 'utf8')
+    if (!html.includes(`<base href="${href}"`)) {
+      console.error(`hosted-demo: ${dir}/index.html missing <base href="${href}">`)
+      process.exit(1)
+    }
+    if (!html.includes('src="./assets/')) {
+      console.error(`hosted-demo: ${dir}/index.html does not use relative Vite assets`)
+      process.exit(1)
+    }
+  }
+}
+
+if (process.argv[2] === '--rewrite-backlog-config') {
+  const configPath = process.argv[3] || join(root, 'dist/hosted/backlog/config.json')
+  const appBase = process.argv[4] || '/backlog/'
+  rewriteSnapshotConfig(configPath, appBase)
+  console.log(`hosted-demo: rewrote apiBase/authBase on ${configPath} for ${withTrailingSlash(appBase)}`)
+  process.exit(0)
+}
 
 function run(cmd, args, env = {}) {
   console.log(`+ ${cmd} ${args.join(' ')}`)
@@ -79,7 +163,9 @@ if (!existsSync(viteBin)) {
 }
 run(viteBin, ['build'], {
   VITE_HOSTED_DEMO: '1',
-  GADAK_BASE_PATH: demoBase,
+  // Relative emit so one HTML works under /demo/ and /backlog/ (GDK-673).
+  // Do not pass demoBase here: that is the site mount, not Vite's asset base.
+  GADAK_BASE_PATH: './',
   HOSTED_OUT: demoOut,
 })
 
@@ -89,10 +175,14 @@ if (!existsSync(indexPath)) {
   process.exit(1)
 }
 
+const backlogOut = join(outDir, 'backlog')
+// Copy the Vite shell before export-static pollutes demo/ with snapshot JSON.
+copyViteShell(demoOut, backlogOut)
+
 // The tab title is the one label a visitor sees before the app paints, and it
 // follows a bookmark or a shared link anywhere. Say "demo" there too.
 // Social meta is hosted-only: injected here, never in web/index.html.
-const indexHtml = readFileSync(indexPath, 'utf8')
+const indexHtml = injectBaseHref(readFileSync(indexPath, 'utf8'), demoBase)
 const titled = indexHtml.replace('<title>gadak</title>', '<title>gadak — live demo</title>')
 if (titled === indexHtml) {
   console.error('hosted-demo: could not retitle index.html — the <title> tag changed shape')
@@ -165,9 +255,7 @@ run(bin, [
   authBase,
   demoOut,
 ])
-// ── 3b. Public backlog (GDK-389) — committed scrubbed snapshot, own bundle ──
-// A third Vite build because basePath() is compile-time BASE_URL: the same
-// bundle under /backlog/ would fetch /demo/config.json.
+// ── 3b. Public backlog (GDK-389) — same Vite shell, committed snapshot ──
 // Git tracks examples/backlog-snapshot.tar.gz. The viewer still fetches
 // detail/<KEY>.json, so unpack to a temp tree and copy as before.
 let backlogSnapshot = join(root, 'examples', 'backlog-snapshot')
@@ -177,14 +265,8 @@ if (!existsSync(join(backlogSnapshot, 'bootstrap.json')) && existsSync(backlogAr
   run('bash', ['tools/backlog-snapshot.sh', '--unpack', backlogSnapshot])
 }
 if (existsSync(join(backlogSnapshot, 'bootstrap.json'))) {
-  const backlogOut = join(outDir, 'backlog')
-  run(viteBin, ['build'], {
-    VITE_HOSTED_DEMO: '1',
-    GADAK_BASE_PATH: backlogBase,
-    HOSTED_OUT: backlogOut,
-  })
   const backlogIndex = join(backlogOut, 'index.html')
-  const backlogHtml = readFileSync(backlogIndex, 'utf8')
+  const backlogHtml = injectBaseHref(readFileSync(backlogIndex, 'utf8'), backlogBase)
   const backlogTitled = backlogHtml.replace('<title>gadak</title>', '<title>gadak — public backlog</title>')
   if (backlogTitled === backlogHtml) {
     console.error('hosted-demo: could not retitle backlog index.html')
@@ -203,8 +285,11 @@ if (existsSync(join(backlogSnapshot, 'bootstrap.json'))) {
   for (const f of readdirSync(detailSrc)) {
     copyFileSync(join(detailSrc, f), join(backlogOut, 'detail', f))
   }
+  rewriteSnapshotConfig(join(backlogOut, 'config.json'), backlogBase)
+  assertSharedBundle(demoOut, backlogOut)
   console.log(`hosted-demo: public backlog at ${backlogOut} (base ${backlogBase})`)
 } else {
+  rmSync(backlogOut, { recursive: true, force: true })
   console.log('hosted-demo: public backlog snapshot missing — skipping backlog page')
 }
 

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -279,10 +279,85 @@ export function jiraFilterUrl(filterId: string, jql?: string): string | null {
   return null
 }
 
-/** Vite `base` at runtime, always with a trailing slash. */
+/**
+ * App URL prefix, always with a trailing slash.
+ *
+ * Hosted /demo/ and /backlog/ share one Vite bundle (GDK-673), so this cannot
+ * be compile-time `import.meta.env.BASE_URL` — that value is only the asset
+ * emit (often `./`). The prefix is, in order:
+ *   1. the document `<base href>` (injected per mount by the hosted build)
+ *   2. this module's own URL, when Vite emitted a relative base — the JS
+ *      lives at `{prefix}assets/…`, which is not `/w/<name>/` (gadak serve
+ *      still ships assets at `/assets/` even on a workspace mount)
+ *   3. compile-time BASE_URL for `gadak serve` / desktop (`/`)
+ *
+ * `/w/<name>/` is workspaceName(), not a base. Both read the page URL, but
+ * this function never inspects `location.pathname`.
+ */
 export function basePath(): string {
-  const base = import.meta.env.BASE_URL || '/'
-  return base.endsWith('/') ? base : `${base}/`
+  // Resolved once: hosted-fetch asks on every intercepted request, and the
+  // mount cannot change without a navigation. Doing the DOM lookup and the
+  // data-base-path write per call would put both on the request path.
+  if (resolvedBase !== null) return resolvedBase
+  resolvedBase = resolveBasePath()
+  if (typeof document !== 'undefined' && document.documentElement) {
+    document.documentElement.dataset.basePath = resolvedBase
+  }
+  return resolvedBase
+}
+
+let resolvedBase: string | null = null
+
+function withTrailingSlash(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`
+}
+
+function isRelativeViteBase(base: string): boolean {
+  return base === './' || base === '.' || base === ''
+}
+
+function resolveBasePath(): string {
+  const fromTag = baseHrefFromDocument()
+  if (fromTag) return fromTag
+  const compiled = import.meta.env.BASE_URL || '/'
+  if (isRelativeViteBase(compiled)) {
+    return baseFromModuleUrl() ?? '/'
+  }
+  return withTrailingSlash(compiled)
+}
+
+function baseHrefFromDocument(): string | null {
+  if (typeof document === 'undefined') return null
+  const el = document.querySelector('base[href]')
+  if (!el) return null
+  const raw = el.getAttribute('href')
+  if (raw == null || isRelativeViteBase(raw)) return null
+  try {
+    return withTrailingSlash(new URL(raw, 'http://gadak.invalid/').pathname)
+  } catch {
+    return raw.startsWith('/') ? withTrailingSlash(raw) : null
+  }
+}
+
+/** `{origin}{prefix}assets/{file}` → `{prefix}`. `file:` is vitest; ignore it. */
+function baseFromModuleUrl(): string | null {
+  let href: string
+  try {
+    href = import.meta.url
+  } catch {
+    return null
+  }
+  if (!href || href.startsWith('file:')) return null
+  try {
+    const path = new URL(href).pathname
+    const marker = '/assets/'
+    const i = path.lastIndexOf(marker)
+    if (i < 0) return null
+    const prefix = path.slice(0, i + 1)
+    return prefix === '' ? '/' : prefix
+  } catch {
+    return null
+  }
 }
 
 /**


### PR DESCRIPTION
`basePath()` was `import.meta.env.BASE_URL` — a compile-time constant — so the
hosted site had to build the SPA twice, once per mount, or the two apps would
have fetched each other's `config.json`. That is a second full Vite build on
every deploy and two copies of identical JS in the artifact, for one string.

It reads the mount at runtime now:

1. the document `<base href>`, injected per mount by the hosted build
2. this module's own URL, when Vite emitted a relative base
3. the compile-time value for `gadak serve` and the desktop app — `/`, unchanged

Resolved once per page: hosted-fetch asks on every intercepted request, and a
mount cannot change without a navigation.

So the build runs Vite once with a relative asset base and copies the shell to
`/backlog/`. `pages.yml` gains one step: the committed backlog snapshot still
carries a pre-GDK-676 `/gadak/` `apiBase` and is unpacked over the built tree,
so it is rewritten onto the runtime mount — without it, hosted-fetch and
`config().apiBase` disagree on the deployed site and nowhere else.

**The gate is the artifact, not the build log.** `e2e/hosted/bundle-once.spec.ts`
hashes both asset trees and fails if the bytes differ; `build.mjs` exits
non-zero on a mismatch before the artifact is written.

## Why a PR

It touches `.github/workflows/pages.yml`, and the Pages job is one of the
things a local gate cannot stand in for.

## Verified locally

| gate | result |
|---|---|
| `make typecheck` | 0 errors |
| `npx vitest run` | 58 files / 547 tests passed |
| `npm run build:hosted` | ok (534 demo issues, 634 backlog issues) |
| `npm run test:hosted` | 18 passed |
| CI e2e set | 306 passed |

Not verified locally: the deployed Pages artifact itself — that is what this
PR's Pages job is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)