### PR TITLE
fix(desktop): the Windows window uses the app menu we build (GDK-700)

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -364,13 +364,15 @@ func run() error {
 	app.Menu.Set(appMenu)
 
 	decision := coldStartDecisionFor(runtime.GOOS, os.Args)
-	// One line answers "which wails, and does this process defer to the
-	// launch event" without opening go.mod or upstream source.
+	// One line answers "which wails, does this process defer to the
+	// launch event, and is the window opted into the application menu"
+	// without opening go.mod or upstream source.
 	coldStart := "argv"
 	if decision.DeferToEvent {
 		coldStart = "event"
 	}
-	log.Printf("gadak-desktop version=%s wails=%s cold_start=%s", appVersion, wailsModuleVersion(), coldStart)
+	windowOpts := mainWindowOptions()
+	log.Printf("gadak-desktop version=%s wails=%s cold_start=%s use_application_menu=%t", appVersion, wailsModuleVersion(), coldStart, windowOpts.UseApplicationMenu)
 	if protocolRegistersFor(runtime.GOOS) {
 		exe, err := os.Executable()
 		if err != nil {
@@ -390,7 +392,7 @@ func run() error {
 		applyDeepLink(raw)
 	}
 
-	window = app.Window.NewWithOptions(mainWindowOptions())
+	window = app.Window.NewWithOptions(windowOpts)
 	window.OnWindowEvent(events.Common.WindowRuntimeReady, func(*application.WindowEvent) {
 		log.Print("wails runtime ready — --wails-draggable listeners are attached")
 		// Cold-start URL source is coldStartDecisionFor, not "!= darwin".
@@ -596,6 +598,15 @@ func mainWindowOptions() application.WebviewWindowOptions {
 		// No JS: option. /wails/runtime.js is injected once by
 		// serveDesktopIndex so a navigation does not load the module twice
 		// (the option ran on every navigation, on top of the <script> tag).
+
+		// Windows creates the HWND with an empty HMENU unless this is set
+		// or a per-window Windows.Menu is supplied
+		// (wails v3.0.0-beta.12, webview_window_windows.go:447-464), so
+		// without it the app menu we build above never reaches the window.
+		// Linux is documented the same way and already falls back on its
+		// own; darwin ignores the flag, since its app menu is always
+		// global (application.go applies it at Run(), by GOOS).
+		UseApplicationMenu: true,
 	}
 	applyWindowChrome(&opts, windowChrome())
 	return opts

--- a/desktop/runtime_test.go
+++ b/desktop/runtime_test.go
@@ -16,6 +16,9 @@ func TestMainWindowOptionsOmitRuntimeJS(t *testing.T) {
 	if strings.Contains(opts.JS, "/wails/runtime.js") {
 		t.Fatalf("JS option references /wails/runtime.js: %q", opts.JS)
 	}
+	if !opts.UseApplicationMenu {
+		t.Fatal("UseApplicationMenu is unset; Windows creates the window with an empty HMENU")
+	}
 }
 
 func TestInjectWailsRuntimeOnce(t *testing.T) {


### PR DESCRIPTION
`app.Menu.Set(appMenu)` installs an application menu with AppMenu/EditMenu/WindowMenu roles on non-darwin, then the window was created without opting into it.

In wails **v3.0.0-beta.12** the Windows backend attaches an `HMENU` only when a per-window `Windows.Menu` is supplied or `UseApplicationMenu` is set:

```go
// pkg/application/webview_window_windows.go:447-464
var appMenu w32.HMENU
if !options.Frameless && !options.Windows.DisableMenu {
    userMenu := w.parent.options.Windows.Menu
    if userMenu != nil {
        …
    } else if options.UseApplicationMenu && globalApplication.applicationMenu != nil {
        …
    }
}
```

With neither, `appMenu` stays the zero `HMENU` and that is what reaches `CreateWindowEx`. So `gadak-desktop.exe` had no File/Edit/Window bar — and paste still worked through WebView2 accelerators, which is why it could ship unnoticed.

**Platform effects**
- **Windows** — the fix.
- **darwin** — unaffected. `UseApplicationMenu` has no reference under any darwin file in that pin, and the app menu is applied at `Run()` by GOOS.
- **Linux** — already falls back to the global menu when `Linux.Menu == nil`, so the flag is documentation conformance there rather than a change in behaviour.

**Recurrence.** `mainWindowOptions()` exists so a test can pin what the window is built with; it now pins this too. FAIL-first confirmed: with the flag removed, `TestMainWindowOptionsOmitRuntimeJS` fails with `UseApplicationMenu is unset; Windows creates the window with an empty HMENU`.

**Debuggability.** The existing startup log line carries `use_application_menu=` beside the wails version and cold-start mode, so the state is answerable from a log rather than from source.

**Verification boundary — read, not observed.** Nobody has opened `gadak-desktop.exe` on Windows from this tree. This is proven against the pinned wails source, and the real-machine check is the Windows section of `docs/runbooks/install-verification.md`, running separately. If that finds a menu bar already present, this is documentation conformance rather than a fix.

Gates: `desktop/` build, vet and test green; root module builds. Opened as a PR because it touches `desktop/`, whose CI jobs cannot run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)