### PR TITLE
fix(workspace): advertise mounted standalone origins

### DIFF
--- a/desktop/gdk658_test.go
+++ b/desktop/gdk658_test.go
@@ -128,7 +128,7 @@ func TestGDK658SecondProcessStandaloneListenerBusy(t *testing.T) {
 	}
 
 	cfg, api := standaloneApp(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 	stop, err := apprun.StartOriginPassthrough(cfg, api)
 	if err != nil {
 		t.Fatal(err)

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -184,6 +184,20 @@ func (g *coldStartGate) markReady() {
 	}
 }
 
+// shutdownOnce owns native application shutdown because Wails can invoke
+// OnShutdown without returning from app.Run, which would bypass run's defer.
+func shutdownOnce(cancel context.CancelFunc, close func() error) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cancel()
+			if err := close(); err != nil {
+				log.Printf("gadak-desktop: close: %v", err)
+			}
+		})
+	}
+}
+
 func run() error {
 	rt, err := apprun.Open(apprun.Options{
 		Version:         server.Version,
@@ -193,9 +207,6 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	// LIFO with cancel below: cancel Watch, then Close (origin listener
-	// stop before persist flush, API before DB).
-	defer rt.Close()
 	cfg, api := rt.Cfg, rt.API
 
 	ui, ok := gadak.WebUI()
@@ -204,7 +215,8 @@ func run() error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	shutdown := shutdownOnce(cancel, rt.Close)
+	defer shutdown()
 
 	reg := rt.Reg
 
@@ -266,7 +278,7 @@ func run() error {
 				}
 			},
 		},
-		OnShutdown: cancel,
+		OnShutdown: shutdown,
 	})
 
 	openURL = app.Browser.OpenURL

--- a/desktop/originadvertise_test.go
+++ b/desktop/originadvertise_test.go
@@ -22,7 +22,7 @@ func standaloneApp(t *testing.T) (*config.Config, *server.Handler) {
 	config.SetProfile("")
 	t.Cleanup(func() {
 		_ = origin.Close()
-		origin.SetInProcess(false)
+		origin.ResetInProcess()
 		config.SetProfile("")
 	})
 	cfg, err := config.Load()
@@ -54,7 +54,7 @@ func standaloneApp(t *testing.T) (*config.Config, *server.Handler) {
 // pre-fix no-op wiring this fails at "advertise file missing".
 func TestGDK340StandaloneAppAdvertisesOrigin(t *testing.T) {
 	cfg, api := standaloneApp(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 
 	stop, err := apprun.StartOriginPassthrough(cfg, api)
 	if err != nil {
@@ -116,7 +116,7 @@ func TestGDK340StandaloneAppAdvertisesOrigin(t *testing.T) {
 // loopback UI/API surface ("no forced server/port" invariant).
 func TestGDK340ListenerServesOnlyOriginPaths(t *testing.T) {
 	cfg, api := standaloneApp(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 
 	stop, err := apprun.StartOriginPassthrough(cfg, api)
 	if err != nil {

--- a/desktop/runtime_test.go
+++ b/desktop/runtime_test.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/midagedev/gadak/internal/apprun"
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/workspace"
 )
 
 func TestMainWindowOptionsOmitRuntimeJS(t *testing.T) {
@@ -53,4 +60,68 @@ func TestServedIndexHasOneRuntimeJS(t *testing.T) {
 
 func TestRaiseWindowNil(t *testing.T) {
 	raiseWindow(nil)
+}
+
+func TestShutdownOnceCancelsBeforeClosing(t *testing.T) {
+	ctx, cancelContext := context.WithCancel(context.Background())
+	var calls []string
+	shutdown := shutdownOnce(func() {
+		calls = append(calls, "cancel")
+		cancelContext()
+	}, func() error {
+		if ctx.Err() == nil {
+			t.Error("close ran before watch context cancellation")
+		}
+		calls = append(calls, "close")
+		return nil
+	})
+
+	shutdown()
+	shutdown()
+
+	if got, want := strings.Join(calls, ","), "cancel,close"; got != want {
+		t.Fatalf("shutdown calls = %q, want %q", got, want)
+	}
+}
+
+func TestShutdownOnceClosesMountedStandaloneRegistry(t *testing.T) {
+	t.Setenv("GADAK_HOME", t.TempDir())
+	config.SetProfile("")
+	t.Cleanup(func() {
+		config.SetProfile("")
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+
+	cfg, err := config.LoadFor("mounted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := workspace.New()
+	t.Cleanup(reg.Close)
+	if _, err := reg.Get("mounted"); err != nil {
+		t.Fatal(err)
+	}
+	advertise := origin.AdvertisePath(cfg.Directory())
+	if _, err := os.Stat(advertise); err != nil {
+		t.Fatalf("mounted standalone did not advertise its origin: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdown := shutdownOnce(cancel, (&apprun.Runtime{Reg: reg}).Close)
+	shutdown()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("shutdown did not cancel the watch context")
+	}
+	if _, err := os.Stat(advertise); !os.IsNotExist(err) {
+		t.Fatalf("mounted advertise remains after desktop shutdown: %v", err)
+	}
 }

--- a/internal/apprun/apprun.go
+++ b/internal/apprun/apprun.go
@@ -214,7 +214,7 @@ func (rt *Runtime) Close() error {
 			}
 		}
 		if rt.acquiredStandalone {
-			origin.SetInProcess(false)
+			origin.SetInProcess(rt.Cfg, false)
 			rt.acquiredStandalone = false
 		}
 	}

--- a/internal/apprun/apprun_test.go
+++ b/internal/apprun/apprun_test.go
@@ -17,7 +17,7 @@ func testHome(t *testing.T) {
 	config.SetProfile("")
 	t.Cleanup(func() {
 		_ = origin.Close()
-		origin.SetInProcess(false)
+		origin.ResetInProcess()
 		config.SetProfile("")
 	})
 }

--- a/internal/apprun/standalone.go
+++ b/internal/apprun/standalone.go
@@ -3,7 +3,6 @@ package apprun
 import (
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 
 	"github.com/midagedev/gadak/internal/config"
@@ -17,9 +16,9 @@ func (rt *Runtime) acquireStandalone() error {
 	if rt == nil || rt.Cfg == nil || !rt.Cfg.IsStandalone() {
 		return nil
 	}
-	origin.SetInProcess(true)
+	origin.SetInProcess(rt.Cfg, true)
 	if _, err := origin.StandaloneHandler(rt.Cfg); err != nil {
-		origin.SetInProcess(false)
+		origin.SetInProcess(rt.Cfg, false)
 		return err
 	}
 	rt.acquiredStandalone = true
@@ -86,37 +85,20 @@ func StartOriginPassthrough(cfg *config.Config, api http.Handler) (func(), error
 	if dir == "" {
 		return nopStop, nil
 	}
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 	if _, err := origin.StandaloneHandler(cfg); err != nil {
-		origin.SetInProcess(false)
+		origin.SetInProcess(cfg, false)
 		return nopStop, err
 	}
 	note("standalone-persist")
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	stop, err := origin.ServeOriginPassthrough(dir, api)
 	if err != nil {
-		origin.SetInProcess(false)
-		return nopStop, fmt.Errorf("could not open origin passthrough listener: %w", err)
-	}
-	mux := http.NewServeMux()
-	mux.Handle("GET "+origin.ProbePath+"{$}", api)
-	mux.Handle(origin.RESTPrefix+"/", api)
-	srv := &http.Server{Handler: mux}
-	go func() {
-		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
-			log.Printf("warning: origin passthrough listener: %v", err)
-		}
-	}()
-	if err := origin.WriteAdvertise(dir, ln.Addr().String()); err != nil {
-		_ = srv.Close()
-		origin.SetInProcess(false)
-		return nopStop, fmt.Errorf("could not advertise origin owner: %w", err)
+		origin.SetInProcess(cfg, false)
+		return nopStop, err
 	}
 	note("advertise")
 	log.Print("apprun: origin advertised")
-	return func() {
-		_ = origin.RemoveAdvertise(dir)
-		_ = srv.Close()
-	}, nil
+	return stop, nil
 }
 
 // StartOriginPassthrough takes persist (if not already held) and advertises

--- a/internal/apprun/standalone_test.go
+++ b/internal/apprun/standalone_test.go
@@ -42,7 +42,7 @@ func standaloneRuntime(t *testing.T) (*Runtime, *config.Config) {
 
 func TestStartOriginPassthroughAdvertisesAndProbes(t *testing.T) {
 	rt, cfg := standaloneRuntime(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 	stop, err := StartOriginPassthrough(cfg, rt.API)
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestStartOriginPassthroughAdvertisesAndProbes(t *testing.T) {
 
 func TestStartOriginPassthroughServesOnlyOriginPaths(t *testing.T) {
 	rt, cfg := standaloneRuntime(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 	stop, err := StartOriginPassthrough(cfg, rt.API)
 	if err != nil {
 		t.Fatal(err)
@@ -165,7 +165,7 @@ func TestSecondProcessStandaloneListenerBusy(t *testing.T) {
 	}
 
 	rt, cfg := standaloneRuntime(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 	stop, err := StartOriginPassthrough(cfg, rt.API)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/origin/advertise.go
+++ b/internal/origin/advertise.go
@@ -152,7 +152,7 @@ func routedWiki(cfg *config.Config) (*confluence.Client, bool) {
 }
 
 func routedTransport(cfg *config.Config) (*serveOriginTransport, bool) {
-	if inProcess.Load() {
+	if IsInProcess(cfg) {
 		return nil, false
 	}
 	adv, ok := readAdvertise(cfg)

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -277,29 +277,60 @@ type sessionFlight struct {
 }
 
 var (
-	// mu guards live and flights. Contract: no IO under this lock. The
-	// critical section is a map lookup or insert; MkdirAll,
+	// mu guards live, flights, and inProcessPersist. Contract: no IO under
+	// this lock. The critical section is a map lookup or insert; MkdirAll,
 	// issuetap.NewEmbedded (persist read/write), and Embedded.Close run
 	// with the lock released. This mutex is process-global and keyed by
 	// persist path — holding it across persist IO queues every standalone
 	// workspace behind one disk.
-	mu      sync.Mutex
-	live    = map[string]*session{}
-	flights = map[string]*sessionFlight{}
+	mu               sync.Mutex
+	live             = map[string]*session{}
+	flights          = map[string]*sessionFlight{}
+	inProcessPersist = map[string]bool{}
 
 	sessionsConstructed atomic.Uint64
-	inProcess           atomic.Bool
 )
 
 // SessionsConstructed is how many times constructStandalone ran. Tests
 // use a delta to prove a routed Client did not open a second persist graph.
 func SessionsConstructed() uint64 { return sessionsConstructed.Load() }
 
-// SetInProcess marks this process as the persist owner (`gadak serve` on
-// a standalone workspace). Client and Wiki then always use the embedded
-// session and never proxy to the advertise file — that would loop back
-// onto this same listener.
-func SetInProcess(v bool) { inProcess.Store(v) }
+// SetInProcess marks/unmarks this process as the persist owner of cfg's
+// workspace. Keyed by persist path — the same key as live — so owning one
+// workspace's persist does not disable routing for any other (STD-3).
+func SetInProcess(cfg *config.Config, v bool) {
+	p := persistKeyOf(cfg)
+	if p == "" {
+		return
+	}
+	mu.Lock()
+	if v {
+		inProcessPersist[p] = true
+	} else {
+		delete(inProcessPersist, p)
+	}
+	mu.Unlock()
+}
+
+// IsInProcess reports whether this process owns cfg's persist.
+func IsInProcess(cfg *config.Config) bool {
+	p := persistKeyOf(cfg)
+	if p == "" {
+		return false
+	}
+	mu.Lock()
+	owned := inProcessPersist[p]
+	mu.Unlock()
+	return owned
+}
+
+// ResetInProcess clears every ownership mark. Tests only — production
+// unmarks per workspace (Runtime.Close / closeEntry).
+func ResetInProcess() {
+	mu.Lock()
+	inProcessPersist = map[string]bool{}
+	mu.Unlock()
+}
 
 // ForgetLive drops cached embedded sessions without closing them. Tests
 // use this to simulate a second process: the serve handler still holds
@@ -600,6 +631,14 @@ func profileDir(cfg *config.Config) (string, error) {
 	return config.Dir()
 }
 
+func persistKeyOf(cfg *config.Config) string {
+	dir, err := profileDir(cfg)
+	if err != nil || dir == "" {
+		return ""
+	}
+	return PersistPath(dir)
+}
+
 // profileNameOf is profileDir's identity twin: the profile the cfg belongs
 // to, falling back to the active profile only when the cfg was never loaded
 // (same condition profileDir falls back on). Routing decisions must compare
@@ -652,6 +691,39 @@ func Close() error {
 		}
 	}
 	return first
+}
+
+// CloseStandalone checkpoints and drops the live session for cfg's persist
+// and releases its lock. Waits an in-flight constructor for the same key.
+// No-op when nothing is live. Callers that marked SetInProcess unmark it
+// themselves — this only owns the session.
+func CloseStandalone(cfg *config.Config) error {
+	p := persistKeyOf(cfg)
+	if p == "" {
+		return nil
+	}
+	for {
+		mu.Lock()
+		if f, ok := flights[p]; ok {
+			mu.Unlock()
+			<-f.done
+			continue
+		}
+		s := live[p]
+		delete(live, p)
+		mu.Unlock()
+		if s == nil {
+			return nil
+		}
+		var first error
+		if s.emb != nil {
+			first = s.emb.Close()
+		}
+		if s.unlock != nil {
+			s.unlock()
+		}
+		return first
+	}
 }
 
 // selectStandaloneSeed follows issuetap's load order: an existing SQLite

--- a/internal/origin/passthrough.go
+++ b/internal/origin/passthrough.go
@@ -1,0 +1,44 @@
+package origin
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+)
+
+// ServeOriginPassthrough starts the loopback origin-only listener for one
+// standalone workspace and advertises it: 127.0.0.1:0, exactly two routes
+// (GET ProbePath, RESTPrefix/), everything else 404 — this is not a UI/API
+// server (decision 0003). h must answer both routes with the X-Gadak
+// identity headers (a server.Handler does). The caller must already hold
+// the persist lock (GDK-343 lock-before-advertise); on any failure here the
+// caller decides whether to release it. stop withdraws the advertise file
+// first, then closes the listener.
+func ServeOriginPassthrough(dir string, h http.Handler) (stop func(), err error) {
+	if dir == "" || h == nil {
+		return func() {}, errors.New("origin: passthrough: dir and handler are required")
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return func() {}, fmt.Errorf("could not open origin passthrough listener: %w", err)
+	}
+	mux := http.NewServeMux()
+	mux.Handle("GET "+ProbePath+"{$}", h)
+	mux.Handle(RESTPrefix+"/", h)
+	srv := &http.Server{Handler: mux}
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("warning: origin passthrough listener: %v", err)
+		}
+	}()
+	if err := WriteAdvertise(dir, ln.Addr().String()); err != nil {
+		_ = srv.Close()
+		return func() {}, fmt.Errorf("could not advertise origin owner: %w", err)
+	}
+	return func() {
+		_ = RemoveAdvertise(dir)
+		_ = srv.Close()
+	}, nil
+}

--- a/internal/origin/route_test.go
+++ b/internal/origin/route_test.go
@@ -28,7 +28,7 @@ func standaloneHome(t *testing.T) (*config.Config, string) {
 	config.SetProfile("")
 	t.Cleanup(func() {
 		_ = origin.Close()
-		origin.SetInProcess(false)
+		origin.ResetInProcess()
 		config.SetProfile("")
 	})
 	cfg, err := config.Load()
@@ -70,7 +70,7 @@ func searchKey(t *testing.T, c *jira.Client, key string) bool {
 func liveStandaloneServe(t *testing.T) (cfg *config.Config, serveClient *jira.Client, h *server.Handler, ts *httptest.Server) {
 	t.Helper()
 	cfg, _ = standaloneHome(t)
-	origin.SetInProcess(true)
+	origin.SetInProcess(cfg, true)
 
 	dir := t.TempDir()
 	db, err := store.Open(filepath.Join(dir, "mirror.db"))
@@ -101,7 +101,7 @@ func liveStandaloneServe(t *testing.T) (cfg *config.Config, serveClient *jira.Cl
 	t.Cleanup(ts.Close)
 
 	origin.ForgetLive()
-	origin.SetInProcess(false)
+	origin.SetInProcess(cfg, false)
 
 	if err := origin.WriteAdvertise(cfg.Directory(), ts.Listener.Addr().String()); err != nil {
 		t.Fatal(err)
@@ -171,7 +171,7 @@ func TestClientRoutesToLiveServe(t *testing.T) {
 
 func TestClientFallsBackWhenProbeFails(t *testing.T) {
 	cfg, home := standaloneHome(t)
-	origin.SetInProcess(false)
+	origin.SetInProcess(cfg, false)
 
 	if err := origin.WriteAdvertise(home, "127.0.0.1:1"); err != nil {
 		t.Fatal(err)
@@ -297,12 +297,75 @@ func TestForgetLiveKeepsPersistLockAcrossGC(t *testing.T) {
 // transport, and embedding would have opened a second graph (GDK-343).
 func TestSetInProcessSkipsRouting(t *testing.T) {
 	cfg, _, _, _ := liveStandaloneServe(t)
-	origin.SetInProcess(true)
-	t.Cleanup(func() { origin.SetInProcess(false) })
+	origin.SetInProcess(cfg, true)
+	t.Cleanup(func() { origin.SetInProcess(cfg, false) })
 
 	_, err := origin.Client(cfg)
 	if !errors.Is(err, origin.ErrWorkspaceBusy) {
 		t.Fatalf("in-process Client err = %v, want ErrWorkspaceBusy (routing to self is the bug this guards)", err)
+	}
+}
+
+func TestSetInProcessDoesNotSkipOtherWorkspaceRouting(t *testing.T) {
+	cfgA, _, _, _ := liveStandaloneServe(t)
+
+	cfgB, err := config.LoadFor("other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfgB.Kind = config.KindStandalone
+	if err := cfgB.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cfgB, err = config.LoadFor("other")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origin.SetInProcess(cfgB, true)
+	t.Cleanup(func() { origin.SetInProcess(cfgB, false) })
+	hOrigin, err := origin.StandaloneHandler(cfgB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	db, err := store.Open(filepath.Join(dir, "mirror.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	h := server.NewWorkspace(db, cfgB, nil, "other")
+	h.BindOriginHandler(hOrigin)
+	t.Cleanup(func() { _ = h.Close() })
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+
+	origin.ForgetLive()
+	origin.SetInProcess(cfgB, false)
+	if err := origin.WriteAdvertise(cfgB.Directory(), ts.Listener.Addr().String()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = origin.RemoveAdvertise(cfgB.Directory()) })
+
+	origin.SetInProcess(cfgA, true)
+	t.Cleanup(func() { origin.SetInProcess(cfgA, false) })
+	if _, err := origin.Client(cfgA); !errors.Is(err, origin.ErrWorkspaceBusy) {
+		t.Fatalf("owned workspace Client err = %v, want ErrWorkspaceBusy (routing to self is the bug this guards)", err)
+	}
+
+	c, err := origin.Client(cfgB)
+	if err != nil {
+		t.Fatalf("other workspace Client: %v", err)
+	}
+	if !origin.TransportIsServe(c.HTTP.Transport) {
+		t.Fatalf("other workspace transport %T, want serve passthrough", c.HTTP.Transport)
+	}
+	if _, err := c.CreateIssue(context.Background(), map[string]any{
+		"project":   map[string]any{"key": origin.DefaultProjectKey},
+		"summary":   "in-process key isolation",
+		"issuetype": map[string]any{"name": "Task"},
+	}); err != nil {
+		t.Fatalf("other workspace routed CreateIssue: %v", err)
 	}
 }
 

--- a/internal/server/origin_rest.go
+++ b/internal/server/origin_rest.go
@@ -132,13 +132,7 @@ func bearerToken(r *http.Request) string {
 }
 
 func (s *server) standaloneOrigin() http.Handler {
-	if s.originH != nil {
-		return s.originH
-	}
 	s.originOnce.Do(func() {
-		if s.originH != nil {
-			return
-		}
 		h, err := origin.StandaloneHandler(s.config())
 		if err != nil {
 			log.Printf("server: origin passthrough: %v", err)
@@ -149,12 +143,14 @@ func (s *server) standaloneOrigin() http.Handler {
 	return s.originH
 }
 
-// BindOriginHandler pins the passthrough target. Tests use it so they can
-// evict origin.live (simulating a second process) without reconstructing
-// a second issuetap graph on the next request.
+// BindOriginHandler pins the passthrough target before the first request.
+// originOnce also serializes concurrent lazy construction and reads, so callers
+// can bind a workspace-owned handler without racing standaloneOrigin.
 func (h *Handler) BindOriginHandler(next http.Handler) {
-	if h == nil || h.s == nil {
+	if h == nil || h.s == nil || next == nil {
 		return
 	}
-	h.s.originH = next
+	h.s.originOnce.Do(func() {
+		h.s.originH = next
+	})
 }

--- a/internal/workspace/origin.go
+++ b/internal/workspace/origin.go
@@ -1,0 +1,113 @@
+package workspace
+
+import (
+	"errors"
+
+	"github.com/midagedev/gadak/internal/origin"
+)
+
+// testBeforeOriginAcquire holds an ownership attempt after it becomes visible
+// to Registry.Close. Tests use it to prove Close waits for the attempt.
+var testBeforeOriginAcquire func(name string)
+
+// ensureOrigin makes this process the advertised persist owner of a
+// standalone mount (STD-3): a process that acquires the persist lock must
+// advertise a routable origin or every CLI write to the mount hard-fails
+// ErrWorkspaceBusy. Connected mounts and persists already owned in-process
+// (the primary, door A) are no-ops. Busy means another process owns — also a
+// no-op: routing to its advertise is the working state. Idempotent; safe from
+// the rescan loop.
+func (r *Registry) ensureOrigin(name string, e *Entry) {
+	if r == nil || e == nil || e.Cfg == nil || !e.Cfg.IsStandalone() {
+		return
+	}
+	if origin.IsInProcess(e.Cfg) {
+		return
+	}
+
+	r.mu.Lock()
+	if r.closed || e.stopOrigin != nil {
+		r.mu.Unlock()
+		return
+	}
+	if f := r.owningOrigin[name]; f != nil {
+		r.mu.Unlock()
+		<-f.done
+		return
+	}
+	f := &originFlight{done: make(chan struct{})}
+	r.owningOrigin[name] = f
+	logf := r.watchLogf
+	r.mu.Unlock()
+	defer func() {
+		r.mu.Lock()
+		delete(r.owningOrigin, name)
+		close(f.done)
+		r.mu.Unlock()
+	}()
+
+	if testBeforeOriginAcquire != nil {
+		testBeforeOriginAcquire(name)
+	}
+
+	cfg := e.Cfg
+	h, err := origin.StandaloneHandler(cfg)
+	if err != nil {
+		if !errors.Is(err, origin.ErrWorkspaceBusy) && logf != nil {
+			logf("workspace " + name + ": origin owner: " + err.Error())
+		}
+		return
+	}
+	// Only a successful embedded session suppresses advertise routing. A
+	// peer's lock must leave callers free to route through that peer.
+	origin.SetInProcess(cfg, true)
+	// Bind before the entry advertises ownership. Requests can read a published
+	// entry concurrently; server.Handler serializes this binding with lazy use.
+	e.Handler.BindOriginHandler(h)
+
+	stop, err := origin.ServeOriginPassthrough(cfg.Directory(), e.Handler)
+
+	if err != nil {
+		// A held lock without an advertise is exactly the defect (STD-3):
+		// release the lock so a CLI can embed; the rescan loop retries.
+		_ = origin.CloseStandalone(cfg)
+		origin.SetInProcess(cfg, false)
+		if logf != nil {
+			logf("workspace " + name + ": origin advertise: " + err.Error())
+		}
+		return
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		stop()
+		_ = origin.CloseStandalone(cfg)
+		origin.SetInProcess(cfg, false)
+		return
+	}
+	e.stopOrigin = stop
+	e.ownsOrigin = true
+	r.mu.Unlock()
+	if logf != nil {
+		logf("workspace " + name + ": origin advertised")
+	}
+}
+
+// EnsureOrigins retries ownership for every opened entry. The rescan loop
+// calls this so a failed advertise (or a lazily re-taken lock after a
+// rollback) heals within watchRescanInterval.
+func (r *Registry) EnsureOrigins() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	snap := make(map[string]*Entry, len(r.entries))
+	for name, entry := range r.entries {
+		snap[name] = entry
+	}
+	r.mu.Unlock()
+	for name, entry := range snap {
+		r.ensureOrigin(name, entry)
+	}
+}

--- a/internal/workspace/origin_advertise_test.go
+++ b/internal/workspace/origin_advertise_test.go
@@ -1,0 +1,268 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/server"
+	"github.com/midagedev/gadak/internal/store"
+)
+
+func seedStandaloneProfile(t *testing.T, name string) *config.Config {
+	t.Helper()
+	seedProfile(t, name, &config.Config{Projects: []string{origin.DefaultProjectKey}})
+	cfg, err := config.LoadFor(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = config.LoadFor(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func TestSTD3MountedStandaloneAdvertisesAndRoutes(t *testing.T) {
+	setupHome(t)
+	cfg := seedStandaloneProfile(t, "probe")
+
+	reg := New()
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+	t.Cleanup(reg.Close)
+
+	e, err := reg.Get("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e == nil {
+		t.Fatal("mounted standalone entry is nil")
+	}
+	if _, err := os.Stat(origin.AdvertisePath(cfg.Directory())); err != nil {
+		t.Errorf("mounted standalone did not advertise its origin: %v", err)
+	}
+
+	c, err := origin.Client(cfg)
+	if err != nil {
+		t.Fatalf("mount owner Client: %v", err)
+	}
+	if _, err := c.CreateIssue(context.Background(), map[string]any{
+		"project":   map[string]any{"key": origin.DefaultProjectKey},
+		"summary":   "STD-3 mount owner write",
+		"issuetype": map[string]any{"name": "Task"},
+	}); err != nil {
+		t.Fatalf("mount owner CreateIssue: %v", err)
+	}
+
+	origin.ForgetLive()
+	origin.ResetInProcess()
+
+	c2, err := origin.Client(cfg)
+	if err != nil {
+		t.Fatalf("simulated CLI Client: %v", err)
+	}
+	if !origin.TransportIsServe(c2.HTTP.Transport) {
+		t.Fatalf("simulated CLI transport %T, want serve passthrough", c2.HTTP.Transport)
+	}
+	if _, err := c2.CreateIssue(context.Background(), map[string]any{
+		"project":   map[string]any{"key": origin.DefaultProjectKey},
+		"summary":   "STD-3 routed CLI write",
+		"issuetype": map[string]any{"name": "Task"},
+	}); err != nil {
+		t.Fatalf("routed CLI CreateIssue: %v", err)
+	}
+}
+
+func TestMountedConnectedDoesNotOwnOrigin(t *testing.T) {
+	setupHome(t)
+	seedProfile(t, "connected", &config.Config{Projects: []string{"CON"}})
+	cfg, err := config.LoadFor("connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.IsStandalone() {
+		t.Fatal("fixture unexpectedly standalone")
+	}
+
+	reg := New()
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+	t.Cleanup(reg.Close)
+	entry, err := reg.Get("connected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ownsOrigin || entry.stopOrigin != nil {
+		t.Fatal("connected mount claimed an origin")
+	}
+	if _, err := os.Stat(origin.AdvertisePath(cfg.Directory())); !os.IsNotExist(err) {
+		t.Fatalf("connected mount wrote advertise: %v", err)
+	}
+	if _, err := os.Stat(origin.PersistPath(cfg.Directory()) + ".lock"); !os.IsNotExist(err) {
+		t.Fatalf("connected mount took persist lock: %v", err)
+	}
+}
+
+func TestMountedStandaloneCloseReleasesOrigin(t *testing.T) {
+	setupHome(t)
+	cfg := seedStandaloneProfile(t, "probe")
+
+	reg := New()
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+	t.Cleanup(reg.Close)
+	entry, err := reg.Get("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !entry.ownsOrigin {
+		t.Fatal("mounted standalone did not claim its origin")
+	}
+
+	reg.Close()
+	if _, err := os.Stat(origin.AdvertisePath(cfg.Directory())); !os.IsNotExist(err) {
+		t.Fatalf("advertise remains after Registry.Close: %v", err)
+	}
+	if origin.IsInProcess(cfg) {
+		t.Fatal("in-process mark remains after Registry.Close")
+	}
+	before := origin.SessionsConstructed()
+	c, err := origin.Client(cfg)
+	if err != nil {
+		t.Fatalf("Client after Registry.Close: %v", err)
+	}
+	if !origin.TransportIsEmbedded(c.HTTP.Transport) {
+		t.Fatalf("Client after Registry.Close transport %T, want embedded", c.HTTP.Transport)
+	}
+	if got := origin.SessionsConstructed(); got != before+1 {
+		t.Fatalf("SessionsConstructed %d → %d, want +1 after persist release", before, got)
+	}
+}
+
+func TestRegistryCloseWaitsForOriginOwnership(t *testing.T) {
+	setupHome(t)
+	cfg := seedStandaloneProfile(t, "probe")
+	reg := New()
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+	t.Cleanup(reg.Close)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	testBeforeOriginAcquire = func(name string) {
+		if name != "probe" {
+			t.Errorf("ownership attempt for %q, want probe", name)
+		}
+		close(started)
+		<-release
+	}
+	t.Cleanup(func() { testBeforeOriginAcquire = nil })
+
+	got := make(chan error, 1)
+	go func() {
+		_, err := reg.Get("probe")
+		got <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("origin ownership did not start")
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		reg.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+		t.Fatal("Registry.Close returned before origin ownership completed")
+	default:
+	}
+
+	close(release)
+	if err := <-got; err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Registry.Close did not return after origin ownership completed")
+	}
+	if _, err := os.Stat(origin.AdvertisePath(cfg.Directory())); !os.IsNotExist(err) {
+		t.Fatalf("advertise remains after Registry.Close: %v", err)
+	}
+	if origin.IsInProcess(cfg) {
+		t.Fatal("in-process mark remains after Registry.Close")
+	}
+}
+
+func TestMountedStandaloneSkipsDoorAOwner(t *testing.T) {
+	setupHome(t)
+	cfg := seedStandaloneProfile(t, "probe")
+	t.Cleanup(func() {
+		_ = origin.Close()
+		origin.ResetInProcess()
+	})
+
+	origin.SetInProcess(cfg, true)
+	originHandler, err := origin.StandaloneHandler(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbPath, err := config.DBPathFor("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	api := server.NewWorkspace(db, cfg, nil, "probe")
+	api.BindOriginHandler(originHandler)
+	t.Cleanup(func() { _ = api.Close() })
+	stop, err := origin.ServeOriginPassthrough(cfg.Directory(), api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(stop)
+	before, err := os.ReadFile(origin.AdvertisePath(cfg.Directory()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := New()
+	t.Cleanup(reg.Close)
+	entry, err := reg.Get("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ownsOrigin || entry.stopOrigin != nil {
+		t.Fatal("mounted entry claimed the primary's origin")
+	}
+	after, err := os.ReadFile(origin.AdvertisePath(cfg.Directory()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("mounted entry replaced the primary origin advertise")
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/midagedev/gadak/internal/attachcache"
 	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
 	"github.com/midagedev/gadak/internal/server"
 	"github.com/midagedev/gadak/internal/store"
 	syncer "github.com/midagedev/gadak/internal/sync"
@@ -41,22 +42,35 @@ type Entry struct {
 	Handler *server.Handler
 	DB      *store.DB
 	Cfg     *config.Config
+	// stopOrigin withdraws this mount's advertise file and closes its
+	// passthrough listener. nil when this process does not own the persist.
+	// Written under Registry.mu; closeEntry reads it after the registry
+	// snapshot (happens-before via mu).
+	stopOrigin func()
+	// ownsOrigin: closeEntry must release the persist session and the
+	// in-process mark on the way out.
+	ownsOrigin bool
 }
 
 // Registry lazy-opens profile mirrors on first /w/<name>/ request and closes
 // them when the process exits.
 type Registry struct {
-	// mu guards entries, flights, watching, closed, and the watch-owner
-	// fields. Contract: no IO under this lock. The critical section is a
-	// map lookup or insert; construction (config.LoadFor, store.Open,
-	// attachcache.New, server.NewWorkspace) and Close of discarded or
-	// snapshotted entries run with the lock released. Holding it across
-	// disk IO serialises every other profile's Get/EnsureWatch/Close
-	// behind one migration.
+	// mu guards entries, flights, owningOrigin, watching, closed, and the
+	// watch-owner fields, as well as Entry.stopOrigin and Entry.ownsOrigin.
+	// Contract: no IO under this lock. The critical section is a map lookup
+	// or insert; construction (config.LoadFor, store.Open, attachcache.New,
+	// server.NewWorkspace) and Close of discarded or snapshotted entries run
+	// with the lock released. Holding it across disk IO serialises every
+	// other profile's Get/EnsureWatch/Close behind one migration.
 	mu      sync.Mutex
 	entries map[string]*Entry
 	flights map[string]*openFlight
 	closed  bool
+
+	// owningOrigin records in-flight standalone-origin acquisition. Close waits
+	// for these before snapshotting entries, so a late acquisition cannot leave
+	// an advertise file or listener behind after shutdown returns.
+	owningOrigin map[string]*originFlight
 
 	// Watch ownership (D8): one loop per credentialed non-primary profile.
 	// WatchAll arms these; EnsureWatch / the rescan ticker start loops when
@@ -77,11 +91,18 @@ type openFlight struct {
 	err  error
 }
 
+// originFlight is one in-flight origin ownership attempt. Registry.Close waits
+// for it before it snapshots entries for teardown.
+type originFlight struct {
+	done chan struct{}
+}
+
 // New returns an empty workspace registry.
 func New() *Registry {
 	return &Registry{
-		entries: make(map[string]*Entry),
-		flights: make(map[string]*openFlight),
+		entries:      make(map[string]*Entry),
+		flights:      make(map[string]*openFlight),
+		owningOrigin: make(map[string]*originFlight),
 	}
 }
 
@@ -99,8 +120,11 @@ func (r *Registry) Close() {
 	}
 	r.mu.Lock()
 	r.closed = true
-	wait := make([]chan struct{}, 0, len(r.flights))
+	wait := make([]chan struct{}, 0, len(r.flights)+len(r.owningOrigin))
 	for _, f := range r.flights {
+		wait = append(wait, f.done)
+	}
+	for _, f := range r.owningOrigin {
 		wait = append(wait, f.done)
 	}
 	r.mu.Unlock()
@@ -120,6 +144,11 @@ func closeEntry(e *Entry) {
 	if e == nil {
 		return
 	}
+	// Withdraw the advertise and stop the listener first so no new routed
+	// request lands while sync/handler shut down.
+	if e.stopOrigin != nil {
+		e.stopOrigin()
+	}
 	// Stop this workspace's background sync before closing the mirror
 	// it writes to; a job that outlives the DB holds a WAL connection
 	// (GDK-270).
@@ -129,9 +158,14 @@ func closeEntry(e *Entry) {
 	if e.DB != nil {
 		_ = e.DB.Close()
 	}
+	// Release the persist session and the ownership mark last: the sync
+	// loop above may have been mid-write through the embedded session.
+	if e.ownsOrigin {
+		_ = origin.CloseStandalone(e.Cfg)
+		origin.SetInProcess(e.Cfg, false)
+	}
 }
 
-// Get returns a cached workspace entry, opening the profile on first use.
 func (r *Registry) Get(name string) (*Entry, error) {
 	if r == nil {
 		return nil, errRegistryClosed
@@ -143,6 +177,7 @@ func (r *Registry) Get(name string) (*Entry, error) {
 	}
 	if e, ok := r.entries[name]; ok {
 		r.mu.Unlock()
+		r.ensureOrigin(name, e)
 		return e, nil
 	}
 	r.mu.Unlock()
@@ -166,11 +201,15 @@ func (r *Registry) open(name string) (*Entry, error) {
 	}
 	if e, ok := r.entries[name]; ok {
 		r.mu.Unlock()
+		r.ensureOrigin(name, e)
 		return e, nil
 	}
 	if f, ok := r.flights[name]; ok {
 		r.mu.Unlock()
 		<-f.done
+		if f.e != nil && f.err == nil {
+			r.ensureOrigin(name, f.e)
+		}
 		return f.e, f.err
 	}
 	f := &openFlight{done: make(chan struct{})}
@@ -206,12 +245,14 @@ func (r *Registry) open(name string) (*Entry, error) {
 		closeEntry(e)
 		f.e = existing
 		close(f.done)
+		r.ensureOrigin(name, existing)
 		return existing, nil
 	}
 	r.entries[name] = e
 	f.e = e
 	close(f.done)
 	r.mu.Unlock()
+	r.ensureOrigin(name, e)
 	return e, nil
 }
 
@@ -533,6 +574,7 @@ func (r *Registry) rescanLoop(ctx context.Context) {
 			return
 		case <-tick.C:
 			_ = r.EnsureWatches()
+			r.EnsureOrigins()
 		}
 	}
 }


### PR DESCRIPTION
## What / why

A mounted standalone workspace can acquire the issuetap persist lock without advertising a routable origin. A concurrent CLI write then cannot route to the lock owner and fails with `ErrWorkspaceBusy`.

This completes the mounted-workspace ownership path:

- advertise a loopback origin passthrough only after acquiring that workspace's embedded persist session;
- scope in-process ownership to the persist path, so owning one workspace never suppresses routing for another;
- withdraw the advertise file and stop the listener before workspace teardown;
- wait for an in-flight origin-ownership attempt during registry shutdown;
- serialize pinned and lazy origin-handler initialization.

This follows the existing standalone advertise and persist-lock model from #46 and #48. It fixes the remaining mounted-workspace ownership path; it does not change public routes, payloads, sync behavior, schema, or agent output.

Contract touched: HTTP — existing origin-passthrough lifecycle only.

## How to test

```bash
npm ci

go test -race ./internal/workspace ./internal/server ./internal/origin

go build ./... && go vet ./... && go test ./...

npm run typecheck
npm run build
bash scripts/scan-internal.sh

(cd desktop && go build . && go vet ./... && go test ./...)
```

## Checks

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `npm run typecheck && npm run build`
- [x] `bash scripts/scan-internal.sh` passes
- [x] Nothing installation-specific (site URL, token, real issue data, company string)
