### PR TITLE
ci: split the race tier across three runners, shard Playwright (GDK-1035)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,18 +75,6 @@ jobs:
       - name: Go tests
         run: go test ./...
 
-      # GDK-270: a startSyncJob goroutine that outlives the test only shows
-      # up when this package is repeated under the race detector. Not
-      # path-scoped — the writer can be introduced from any import of
-      # internal/server. internal/workspace is here too: it owns the same
-      # lifetime one layer up (Registry.Close stops each workspace's sync
-      # before its mirror). count=2 (not 4): the job already ran count=1
-      # above; locally count=4 -race is ~180s, and doubling the package
-      # under race is enough to catch "passes once" while staying modest
-      # in a 20-minute job.
-      - name: Server tests under race (GDK-270)
-        run: go test ./internal/server/ ./internal/workspace/ -count=2 -race
-
       - name: Frontend typecheck
         run: npm run typecheck
 
@@ -123,6 +111,62 @@ jobs:
             exit 1
           fi
 
+
+  # The race tier that used to be the tail of the build job, split across
+  # three runners (GDK-1035).
+  race:
+    name: Server race tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # GDK-270: a startSyncJob goroutine that outlives the test only shows
+      # up when this package is repeated under the race detector. Not
+      # path-scoped — the writer can be introduced from any import of
+      # internal/server. internal/workspace is here too: it owns the same
+      # lifetime one layer up (Registry.Close stops each workspace's sync
+      # before its mirror). count=2 (not 4): the build job's Go tests step
+      # already ran count=1; locally count=4 -race is ~180s, and doubling
+      # the package under race is enough to catch "passes once" while
+      # staying modest in a 20-minute job.
+      #
+      # GDK-1035: this tier ran as one step inside the build job, where it
+      # was 507s of a 698s job and the whole CI critical path (11m38s wall
+      # on run 33018964815). This is a redistribution, not a relaxation —
+      # same -count=2, same -race, same two packages, same total test set,
+      # three runners instead of one. tools/race-partition.sh owns the
+      # split; --check runs in every shard so a test that escaped the
+      # partition fails the job that would otherwise have skipped it
+      # silently.
+      #
+      # The one thing sharding does narrow, said plainly: a leaked
+      # goroutine now shares a process with ~110 later tests instead of
+      # ~330, so a leak that only ever showed up against some unrelated
+      # later test has fewer chances to. GDK-270's own mechanism is
+      # untouched — that leak is caught by the test meeting its own
+      # leftover on the second run, and every test still runs twice in
+      # its shard.
+      - name: Race partition check
+        run: bash tools/race-partition.sh --check 3
+
+      - name: Workspace tests under race (GDK-270)
+        if: matrix.shard == 1
+        run: go test ./internal/workspace/ -count=2 -race
+
+      - name: Server race shard ${{ matrix.shard }}/3
+        run: go test ./internal/server/ -count=2 -race -run "$(bash tools/race-partition.sh ${{ matrix.shard }} 3)"
 
   mobile:
     name: Mobile (TypeScript)
@@ -225,6 +269,15 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # GDK-1035: shard at the runner level only. Each shard is a separate
+    # machine with its own webServer, its own GADAK_E2E_PORT and its own
+    # seeded home, so e2e/playwright.config.ts keeps workers: 1 and
+    # fullyParallel: false — raising workers inside one runner is the
+    # unsafe variant (single shared served instance) and stays out.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v4
@@ -388,7 +441,7 @@ jobs:
           exit 1
 
       - name: Run browser E2E
-        run: npx playwright test --config e2e/playwright.config.ts
+        run: npx playwright test --config e2e/playwright.config.ts --shard=${{ matrix.shard }}/3
 
   # Nested module (desktop/go.mod). package main imports wails v3, which does
   # not compile on Linux with CGO_ENABLED=0 (undefined pointer in the linux

--- a/tools/race-partition.sh
+++ b/tools/race-partition.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# The single owner of how the CI race suite is split across shards (GDK-1035).
+#
+# .github/workflows/ci.yml never spells out a bucket itself — it asks this
+# script which tests belong to shard N of T. Test names are discovered from
+# the package source at run time (never a checked-in list: a checked-in
+# list is the thing that goes stale and silently drops a test), sorted, and
+# dealt round-robin, so the split is deterministic and balanced by count
+# with no timing table.
+#
+# Why a race tier exists at all (GDK-270): a startSyncJob goroutine that
+# outlives its test only shows up when the package is repeated under the
+# race detector. That is why the tier runs -count=2 — and why splitting it
+# must not quietly drop, skip, or double a test. The split is a
+# redistribution across runners, never a relaxation.
+#
+# Usage:
+#   tools/race-partition.sh <shard> <total>   print the -run regex for one shard
+#   tools/race-partition.sh --check <total>   verify the partition: every test
+#                                             in exactly one shard, no empty
+#                                             shard; exit 1 with names if not
+#   tools/race-partition.sh --list <total>    shard / count / first-last map
+#
+# Exit: 0 ok, 1 partition broken (--check), 2 usage error.
+set -euo pipefail
+export LC_ALL=C # byte-order sort, so every machine deals the same round
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SERVER_DIR="$ROOT/internal/server"
+SERVER_PKG="./internal/server/"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  tools/race-partition.sh <shard> <total>   print the -run regex for one shard
+  tools/race-partition.sh --check <total>   verify the partition (exit 1 if broken)
+  tools/race-partition.sh --list <total>    shard / count / first-last map
+EOF
+  exit 2
+}
+
+# Every top-level test function in the package, one per line, sorted, with
+# the Test prefix kept — go test matches -run against full test names, and
+# the go-test -list comparison below holds discovery to exactly that.
+# `sort -u` is belt-and-braces: Go does not compile a package that declares
+# the same test function name twice.
+test_names() {
+  sed -n -E 's/^func (Test[A-Za-z0-9_]+)\(.*/\1/p' "$SERVER_DIR"/*_test.go |
+    sort -u
+}
+
+# The sorted names dealt to one shard: round-robin, i % total.
+shard_names() { # $1 = shard (1-based), $2 = total
+  test_names |
+    awk -v s="$1" -v t="$2" '(NR - 1) % t == (s - 1) % t'
+}
+
+# The go test -run regex for one shard. The anchors are load-bearing:
+# -run matches unanchored, so without ^( )$ the shard holding
+# TestCreateIssue would also run TestCreateIssueDefaultProject (prefix pairs
+# exist in this package), and one test would land in two shards.
+# An empty shard prints ^()$, which matches no test name — --check is what
+# turns that into a failure.
+shard_regex() { # $1 = shard, $2 = total
+  local body
+  body="$(shard_names "$1" "$2" | paste -sd '|' -)"
+  if [[ -n "$body" ]]; then
+    printf '^(%s)$\n' "$body"
+  else
+    printf '^()$\n'
+  fi
+}
+
+[[ $# -eq 2 ]] || usage
+mode=shard
+case "$1" in
+  --check) mode=check ;;
+  --list) mode=list ;;
+  -*) usage ;;
+  *) shard="$1" ;;
+esac
+total="$2"
+[[ "$total" =~ ^[1-9][0-9]*$ ]] || {
+  echo "race-partition: total must be a positive integer, got '$total'" >&2
+  exit 2
+}
+if [[ "$mode" = shard ]]; then
+  [[ "$shard" =~ ^[1-9][0-9]*$ ]] || {
+    echo "race-partition: shard must be a positive integer, got '$shard'" >&2
+    exit 2
+  }
+  [[ "$shard" -le "$total" ]] || {
+    echo "race-partition: shard $shard is out of range 1..$total" >&2
+    exit 2
+  }
+fi
+
+if [[ "$mode" = shard ]]; then
+  re="$(shard_regex "$shard" "$total")"
+  if [[ "$re" = '^()$' ]]; then
+    echo "race-partition: warning: shard $shard of $total selects no test" >&2
+  fi
+  printf '%s\n' "$re" # stdout carries the regex and nothing else
+  exit 0
+fi
+
+names="$(test_names)"
+if [[ -z "$names" ]]; then
+  echo "race-partition: no test functions found in $SERVER_DIR/*_test.go" >&2
+  exit 1
+fi
+
+all=()
+while IFS= read -r n; do all+=("$n"); done <<<"$names"
+
+if [[ "$mode" = list ]]; then
+  echo "race-partition: ${#all[@]} tests across $total shards"
+  s=1
+  while [[ "$s" -le "$total" ]]; do
+    sn="$(shard_names "$s" "$total")"
+    if [[ -n "$sn" ]]; then
+      count="$(printf '%s\n' "$sn" | grep -c .)"
+      first="$(printf '%s\n' "$sn" | sed -n '1p')"
+      last="$(printf '%s\n' "$sn" | sed -n '$p')"
+      printf 'shard %d of %d: %3d tests  %s ... %s\n' \
+        "$s" "$total" "$count" "$first" "$last"
+    else
+      printf 'shard %d of %d:   0 tests  (empty)\n' "$s" "$total"
+    fi
+    s=$((s + 1))
+  done
+  exit 0
+fi
+
+# --check: verification, not re-derivation. The regexes under test are built
+# by the same generator the workflow calls; the assertions below match those
+# regexes against the discovered name list — the round-robin arithmetic that
+# produced them is not consulted, so a generator bug cannot pass its own test.
+#
+# (d) first: discovery must agree with what the Go toolchain actually runs.
+# `go test -list` is generated by the compiler from the same source, so it
+# catches drift between the grep pattern and Go's own notion of a test name.
+# The first draft of this script captured names without the Test prefix —
+# internally consistent, (a)–(c) green, while every regex would have
+# selected zero tests. Only the toolchain comparison sees that class.
+if ! command -v go >/dev/null 2>&1; then
+  echo "race-partition: go is not on PATH; --check needs 'go test -list' to verify discovery" >&2
+  exit 1
+fi
+if ! go_raw="$(cd "$ROOT" && go test "$SERVER_PKG" -list '.*' 2>&1)"; then
+  echo "race-partition: go test -list failed, cannot verify discovery against the toolchain:" >&2
+  printf '%s\n' "$go_raw" | sed 's/^/  /' >&2
+  exit 1
+fi
+go_names="$(printf '%s\n' "$go_raw" | { grep -E '^Test[A-Za-z0-9_]+$' || true; } | sort -u)"
+
+only_grep=() # discovered from source, but the toolchain would not run it
+only_go=()   # runnable per the toolchain, but the discovery missed it
+while IFS= read -r line; do only_grep+=("$line"); done \
+  < <(comm -23 <(printf '%s\n' "$names") <(printf '%s\n' "$go_names"))
+while IFS= read -r line; do only_go+=("$line"); done \
+  < <(comm -13 <(printf '%s\n' "$names") <(printf '%s\n' "$go_names"))
+
+regexes=()
+shard_hit_count=()
+s=1
+while [[ "$s" -le "$total" ]]; do
+  regexes[s]="$(shard_regex "$s" "$total")"
+  shard_hit_count[s]=0
+  s=$((s + 1))
+done
+
+uncovered=()
+doubled=()
+covered=0
+for name in "${all[@]}"; do
+  hits=()
+  s=1
+  while [[ "$s" -le "$total" ]]; do
+    if [[ "$name" =~ ${regexes[s]} ]]; then
+      hits+=("$s")
+    fi
+    s=$((s + 1))
+  done
+  case "${#hits[@]}" in
+    0) uncovered+=("$name") ;;
+    1)
+      covered=$((covered + 1))
+      shard_hit_count[${hits[0]}]=$((shard_hit_count[${hits[0]}] + 1))
+      ;;
+    *)
+      hit_list="$(IFS=','; printf '%s' "${hits[*]}")"
+      doubled+=("$name (shards $hit_list)")
+      ;;
+  esac
+done
+
+empty=()
+s=1
+while [[ "$s" -le "$total" ]]; do
+  if [[ "${shard_hit_count[s]}" -eq 0 ]]; then
+    empty+=("$s")
+  fi
+  s=$((s + 1))
+done
+
+rc=0
+if [[ "${#only_go[@]}" -gt 0 ]]; then
+  i=0
+  for n in "${only_go[@]}"; do
+    i=$((i + 1))
+    if [[ "$i" -gt 20 ]]; then
+      echo "race-partition: ... and $((${#only_go[@]} - 20)) more runnable-but-undiscovered, not listed"
+      break
+    fi
+    echo "race-partition: $n is runnable per go test -list but not discovered from source (${#only_go[@]} hidden of ${#all[@]} discovered) — the partition would skip it"
+  done
+  rc=1
+fi
+if [[ "${#only_grep[@]}" -gt 0 ]]; then
+  i=0
+  for n in "${only_grep[@]}"; do
+    i=$((i + 1))
+    if [[ "$i" -gt 20 ]]; then
+      echo "race-partition: ... and $((${#only_grep[@]} - 20)) more undiscoverable-by-go, not listed"
+      break
+    fi
+    echo "race-partition: $n is discovered from source but not runnable per go test -list (${#only_grep[@]} extra) — no regex would ever select it"
+  done
+  rc=1
+fi
+if [[ "${#uncovered[@]}" -gt 0 ]]; then
+  i=0
+  for n in "${uncovered[@]}"; do
+    i=$((i + 1))
+    if [[ "$i" -gt 20 ]]; then
+      echo "race-partition: ... and $((${#uncovered[@]} - 20)) more uncovered, not listed"
+      break
+    fi
+    echo "race-partition: $n is in no shard (${#uncovered[@]} of ${#all[@]} uncovered)"
+  done
+  rc=1
+fi
+if [[ "${#doubled[@]}" -gt 0 ]]; then
+  i=0
+  for d in "${doubled[@]}"; do
+    i=$((i + 1))
+    if [[ "$i" -gt 20 ]]; then
+      echo "race-partition: ... and $((${#doubled[@]} - 20)) more double-selected, not listed"
+      break
+    fi
+    echo "race-partition: $d — must be in exactly one shard (${#doubled[@]} of ${#all[@]} double-selected)"
+  done
+  rc=1
+fi
+if [[ "${#empty[@]}" -gt 0 ]]; then
+  i=0
+  for s in "${empty[@]}"; do
+    i=$((i + 1))
+    if [[ "$i" -gt 20 ]]; then
+      echo "race-partition: ... and $((${#empty[@]} - 20)) more empty shards, not listed"
+      break
+    fi
+    echo "race-partition: shard $s of $total selects no test (${#empty[@]} empty shards)"
+  done
+  rc=1
+fi
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "race-partition: ${#all[@]} tests covered exactly once across $total shards (covered=$covered; discovery matches go test -list)"
+  s=1
+  while [[ "$s" -le "$total" ]]; do
+    echo "race-partition: shard $s/$total: ${shard_hit_count[s]} tests"
+    s=$((s + 1))
+  done
+fi
+exit "$rc"


### PR DESCRIPTION
The CI wall clock was 11m38s on run 33018964815 and the build job was all of it. Inside that job one step — the race tier — was 507s of 698s. Locally: `internal/server` 332s, `internal/workspace` 27s. The critical path was one package that `go test` runs serially, because nothing in it calls `t.Parallel()`.

- `tools/race-partition.sh` is the single owner of the split: it reads test names out of the package at run time, deals them round-robin, and prints an anchored `-run` regex. The workflow never spells out a bucket.
- `--check` runs in every shard. It matches the generated regexes against the discovered names rather than re-deriving the arithmetic, and holds discovery against `go test -list` — the round's own first draft dropped the `Test` prefix and was self-consistently green while every regex selected nothing.
- Playwright shards at the runner level only. Each shard is its own machine with its own server, port and seeded home, so `e2e/playwright.config.ts` keeps `workers: 1`.

Same `-count=2`, same `-race`, same packages, same test set — three runners instead of one. The one thing sharding narrows is stated in the workflow comment: a leaked goroutine now shares a process with ~110 later tests instead of ~330, while GDK-270's own mechanism (the test meeting its own leftover on the second run) is untouched.

**This PR exists to be measured.** The point is the wall clock on this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)