### PR TITLE
desktop: a Devices tab pairs the phone — same flow, same guard as the CLI (GDK-1047)

### DIFF
--- a/cmd/gadak/pairing.go
+++ b/cmd/gadak/pairing.go
@@ -10,6 +10,15 @@ package main
 // nothing else; it is never a default, and revoking it closes the shells
 // it opened. While any active token exists, all three surfaces require
 // their Bearer.
+//
+// GDK-1047 moved the flow itself (validation, endpoint resolution, the
+// mint, the offer encode, the _home routing-token guard, list row
+// shaping, the QR encodings) into internal/pairflow so the desktop app's
+// Devices tab runs the identical flow. This file keeps what is
+// CLI-shaped only: flag parsing, the stdout/stderr contracts, the hints,
+// and the terminal QR renderer (qr.go). parseTTL and
+// endpointFromAdvertise stay as one-line wrappers because the package's
+// own tests pin them by name.
 
 import (
 	"context"
@@ -17,18 +26,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/jira"
 	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/pairflow"
 	"github.com/midagedev/gadak/internal/pairing"
-	"github.com/midagedev/gadak/internal/serveaddr"
 	"github.com/midagedev/gadak/internal/store"
 )
 
@@ -38,16 +44,6 @@ const pairingUsage = "usage: gadak pairing mint --label NAME [--scope origin|ser
 // of at least minPrefix (8) hex characters — pairing list prints 8, longer
 // prefixes still match (internal/pairing.Revoke).
 const pairingRevokeUsage = "usage: gadak pairing revoke <label|hash-prefix>"
-
-// defaultPairingTTL is 90 days: a device token is revocable, so it does
-// not need a short life, but an unattended one should not outlive a
-// quarter by default either.
-const defaultPairingTTL = 90 * 24 * time.Hour
-
-// homeRoutingTTL is long on purpose: an expiring routing token would
-// re-open the 401 cliff ensureHomeRoutingToken exists to close. Rotation
-// is explicit (`pairing mint --label _home`), not expiry.
-const homeRoutingTTL = 10 * 365 * 24 * time.Hour
 
 func cmdPairing(args []string) error {
 	if wantsHelp(args) {
@@ -77,77 +73,33 @@ func cmdPairing(args []string) error {
 	}
 }
 
-// parseTTL accepts one integer with a single unit — "90d", "24h", "30m",
-// "45s". time.ParseDuration rejects "d", and inventing compound syntax
-// ("1d12h") is surface nobody asked for; a clear error beats guessing.
-func parseTTL(s string) (time.Duration, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return 0, errors.New("empty ttl")
-	}
-	unit := s[len(s)-1]
-	digits := s[:len(s)-1]
-	n, err := strconv.Atoi(digits)
-	if err != nil || n <= 0 {
-		return 0, fmt.Errorf("bad ttl %q: want <N><unit> with unit d, h, m, or s (e.g. 90d, 24h)", s)
-	}
-	switch unit {
-	case 'd':
-		return time.Duration(n) * 24 * time.Hour, nil
-	case 'h':
-		return time.Duration(n) * time.Hour, nil
-	case 'm':
-		return time.Duration(n) * time.Minute, nil
-	case 's':
-		return time.Duration(n) * time.Second, nil
-	default:
-		return 0, fmt.Errorf("bad ttl %q: unit must be d, h, m, or s", s)
-	}
-}
+// parseTTL moved to internal/pairflow.ParseTTL (one owner); this wrapper
+// keeps the package-main name the tests pin.
+func parseTTL(s string) (time.Duration, error) { return pairflow.ParseTTL(s) }
 
-// pairingDir is the profile directory the token store lives in. Pairing
-// protects both gated surfaces of a home serve — the origin passthrough
-// (standalone, GDK-433) and the mirror REST a phone companion
-// reads (GDK-797) — so both workspace kinds may mint; what stays closed
-// for a connected workspace is the passthrough itself (origin_rest.go
-// 404s it). A workspace that is itself paired away cannot mint: its home
-// is another machine.
+// endpointFromAdvertise moved with the rest of endpoint resolution to
+// pairflow.EndpointFromAdvertise; same deal — the tests pin this name.
+func endpointFromAdvertise(addr string) string { return pairflow.EndpointFromAdvertise(addr) }
+
+// pairingDir resolves where the token store lives and refuses the two
+// states that cannot mint (paired away, no credential); the rules moved
+// to pairflow.Dir, which both the CLI and the desktop now call.
 func pairingDir() (string, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return "", err
 	}
-	if rem, err := origin.PairedStatus(cfg); err != nil {
-		return "", err
-	} else if rem != nil {
-		return "", fmt.Errorf("%s — mint and revoke run on the home machine", pairedStatusLine(cfg, rem))
-	}
-	if !cfg.HasCredential() {
-		return "", config.ErrNotConfigured
-	}
-	dir := cfg.Directory()
-	if dir == "" {
-		return "", errors.New("pairing: profile directory not found")
-	}
-	return dir, nil
+	return pairflow.Dir(cfg)
 }
 
 func pairedStatusLine(cfg *config.Config, rem *pairing.Remote) string {
-	line := fmt.Sprintf("this workspace is paired with %q (%s)", rem.Label, rem.Endpoint)
-	if rem.Label == "" {
-		line = fmt.Sprintf("this workspace is paired with %s", rem.Endpoint)
-	}
-	if cfg != nil && strings.TrimSpace(cfg.TokenOwner) != "" {
-		line += " as " + cfg.TokenOwner
-	}
-	return line
+	return pairflow.PairedLine(cfg, rem)
 }
 
 func pairingMint(args []string) error {
 	fs := newFlagSet("pairing mint")
-	// ttlDefault renders defaultPairingTTL in the flag's <N><unit> syntax so
-	// the 90-day default has one owner.
-	ttlDefault := fmt.Sprintf("%dd", int(defaultPairingTTL/(24*time.Hour)))
+	// The 90-day default has one owner: pairflow.DefaultTTL.
+	ttlDefault := pairflow.DefaultTTLFlag()
 	label := fs.String("label", "", "device name shown in `gadak pairing list` (required)")
 	scope := fs.String("scope", "origin", "what the token opens: origin = origin passthrough for a paired gadak (default), serve = the mirror REST for a paired client (a phone companion), terminal = a shell on this machine (never a default — see `gadak help pairing`)")
 	ttlFlag := fs.String("ttl", ttlDefault, "token lifetime: <N><d|h|m|s>, e.g. 90d or 12h")
@@ -157,6 +109,9 @@ func pairingMint(args []string) error {
 	if _, err := parseAround(fs, args); err != nil {
 		return err
 	}
+	// Flag-surface validation keeps the CLI's exact error strings; the
+	// flow re-validates inside pairflow.MintDevice (structural owner), so
+	// the desktop gets the same rules without this file.
 	if strings.TrimSpace(*label) == "" {
 		return errors.New("pairing mint requires --label NAME")
 	}
@@ -165,8 +120,7 @@ func pairingMint(args []string) error {
 	default:
 		return fmt.Errorf("unknown --scope %q: want origin (a paired gadak riding the passthrough), serve (a paired client reading the mirror REST), or terminal (a shell on this machine)", strings.TrimSpace(*scope))
 	}
-	ttl, err := parseTTL(*ttlFlag)
-	if err != nil {
+	if _, err := parseTTL(*ttlFlag); err != nil {
 		return err
 	}
 	dir, err := pairingDir()
@@ -182,51 +136,24 @@ func pairingMint(args []string) error {
 		// stdout stays empty (cannot be piped into init --pairing-code).
 		return pairingMintHome(dir, cfg, strings.TrimRight(strings.TrimSpace(*endpoint), "/"))
 	}
-	// Resolve the endpoint before minting: a mint without a reachable
-	// endpoint is an orphan token nobody can use, and it would already
-	// have flipped the gate on.
-	ep := strings.TrimRight(strings.TrimSpace(*endpoint), "/")
-	if ep == "" {
-		ep = advertisedEndpoint(cfg)
-		if ep == "" {
-			return errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
+	res, err := pairflow.MintDevice(dir, cfg, *label, strings.TrimSpace(*scope), *ttlFlag, *endpoint, time.Now())
+	// The mint already produced the credential: the output contract prints
+	// even when a later step (the routing-token guard) failed, or the
+	// plaintext would exist nowhere and the token would be stranded.
+	if res.Offer != "" {
+		if res.LoopbackWarning {
+			fmt.Fprintf(os.Stderr, "warning: endpoint %s is loopback — remote devices cannot reach it; pass --endpoint with your tailnet URL (e.g. https://<machine>.<tailnet>.ts.net)\n", res.Endpoint)
+		}
+		if outErr := writePairingMintOutput(*asJSON, *noQR, res); outErr != nil {
+			return outErr
 		}
 	}
-	u, err := url.Parse(ep)
-	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
-		return fmt.Errorf("bad endpoint %q: want an http(s) URL", ep)
+	if res.HomeRouting == pairflow.HomeRoutingMinted {
+		fmt.Fprintln(os.Stderr, "minted a _home routing token so this machine's own writes keep passing the gate")
+	} else if res.HomeRouting == pairflow.HomeRoutingReissued {
+		fmt.Fprintln(os.Stderr, "reissued _home routing token so this machine's own writes keep passing the gate")
 	}
-	if host := u.Hostname(); isLoopbackHost(host) {
-		fmt.Fprintf(os.Stderr, "warning: endpoint %s is loopback — remote devices cannot reach it; pass --endpoint with your tailnet URL (e.g. https://<machine>.<tailnet>.ts.net)\n", ep)
-	}
-	token, meta, err := pairing.MintScoped(dir, *label, strings.TrimSpace(*scope), ttl, time.Now())
-	if err != nil {
-		return err
-	}
-	offer, err := pairing.EncodeOffer(pairing.Offer{
-		V:         pairing.OfferV1,
-		Endpoint:  ep,
-		Token:     token,
-		ExpiresAt: pairing.FormatExpiry(meta.ExpiresAt),
-		Label:     *label,
-	})
-	if err != nil {
-		return err
-	}
-	if err := writePairingMintOutput(*asJSON, *noQR, offer, *label, ep, strings.TrimSpace(*scope), meta); err != nil {
-		return err
-	}
-	// The _home routing token is a standalone home's concern: its local
-	// writes ride the passthrough this serve fronts. A connected
-	// workspace's writes go straight to its site, and the routing file
-	// (remote-origin.json) would make origin.pairedRemote read this
-	// workspace as paired with its own serve — never written here.
-	if cfg.IsStandalone() {
-		if err := ensureHomeRoutingToken(dir, cfg, ep); err != nil {
-			return err
-		}
-	}
-	return nil
+	return err
 }
 
 // writePairingMintOutput is the device-mint output contract (GDK-456).
@@ -238,8 +165,7 @@ func pairingMint(args []string) error {
 // scannable QR after the hints (GDK-1047) — decoration on top of the
 // contract, never part of it: it cannot fail the mint, and `_home`
 // rotation (pairingMintHome) never reaches this function.
-func writePairingMintOutput(asJSON, noQR bool, offer, label, endpoint, scope string, meta pairing.Meta) error {
-	expiry := pairing.FormatExpiry(meta.ExpiresAt)
+func writePairingMintOutput(asJSON, noQR bool, res pairflow.MintResult) error {
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetEscapeHTML(false)
@@ -249,25 +175,25 @@ func writePairingMintOutput(asJSON, noQR bool, offer, label, endpoint, scope str
 			Scope     string `json:"scope"`
 			Endpoint  string `json:"endpoint"`
 			ExpiresAt string `json:"expires_at"`
-		}{offer, label, scope, endpoint, expiry})
+		}{res.Offer, res.Label, res.Scope, res.Endpoint, res.ExpiresAt})
 	}
-	fmt.Println(offer)
-	switch scope {
+	fmt.Println(res.Offer)
+	switch res.Scope {
 	case pairing.ScopeServe:
 		fmt.Fprintln(os.Stderr, pairingMintServeHint())
 	case pairing.ScopeTerminal:
 		fmt.Fprintln(os.Stderr, pairingMintTerminalHint())
 	default:
-		fmt.Fprintln(os.Stderr, pairingMintRemoteHint(label))
+		fmt.Fprintln(os.Stderr, pairingMintRemoteHint(res.Label))
 	}
 	fmt.Fprintf(os.Stderr, "paired device %q — offer reusable until %s; revoke with: gadak pairing revoke %s\n",
-		label, expiry, meta.Hash[:8])
+		res.Label, res.ExpiresAt, res.Meta.Hash[:8])
 	if shouldDrawQR(pairingStderrIsTerminal(), noQR, asJSON,
 		os.Getenv("NO_COLOR") != "", os.Getenv("TERM") == "dumb") {
 		// The QR's own errors (a fixed "content too long" class string
 		// from the library — never the payload) cannot fail a mint that
 		// already printed its offer.
-		if err := drawPairingQR(os.Stderr, offer, pairingTerminalWidth()); err != nil {
+		if err := drawPairingQR(os.Stderr, res.Offer, pairingTerminalWidth()); err != nil {
 			fmt.Fprintf(os.Stderr, "pairing: QR not drawn (%v) — the offer line on stdout is unaffected\n", err)
 		}
 	}
@@ -304,207 +230,16 @@ func pairingMintTerminalHint() string {
 		"revoking it closes the shells it opened, within a couple of seconds, without stopping the serve."
 }
 
-// ensureHomeRoutingToken is the single owner of "_home is valid". Once one
-// token exists the gate takes Bearer only — no loopback bypass — and the
-// home machine's writes route through the same passthrough (GDK-333 single
-// persist owner). Standalone excludes the file from the paired-remote
-// branch (origin.pairedRemote), so here it only ever carries the routing
-// token localRoutingToken reads.
-//
-// Called after every device mint. If remote-origin.json's token is missing
-// or no longer active in the store while the gate is on, it reissues
-// `_home` and rewrites the file — the recovery path for a routing token
-// revoked by an older build (GDK-450).
-func ensureHomeRoutingToken(dir string, cfg *config.Config, mintEndpoint string) error {
-	rem, err := pairing.LoadRemote(dir)
-	if err != nil {
-		return err
-	}
-	now := time.Now()
-	if rem != nil {
-		v, aerr := pairing.Authorize(dir, rem.Token, now)
-		if aerr != nil {
-			return aerr
-		}
-		if v == pairing.VerdictAccept {
-			return nil
-		}
-		if v == pairing.VerdictOff {
-			// Gate off: no active tokens, local writes need no bearer.
-			return nil
-		}
-	} else {
-		v, aerr := pairing.Authorize(dir, "", now)
-		if aerr != nil {
-			return aerr
-		}
-		if v == pairing.VerdictOff {
-			return nil
-		}
-	}
-	first := rem == nil
-	if _, err := issueHomeRoutingToken(dir, cfg, mintEndpoint); err != nil {
-		return err
-	}
-	if first {
-		fmt.Fprintln(os.Stderr, "minted a _home routing token so this machine's own writes keep passing the gate")
-	} else {
-		fmt.Fprintln(os.Stderr, "reissued _home routing token so this machine's own writes keep passing the gate")
-	}
-	return nil
-}
-
-// pairingMintHome is `pairing mint --label _home`: routing-token rotation,
-// not a device offer. stdout stays empty so the line cannot be piped into
-// `init --pairing-code`. Standalone only — a connected workspace's writes
-// go straight to its site, and the routing file here would make
-// origin.pairedRemote read this workspace as paired with its own serve.
+// pairingMintHome is the CLI half of `_home` rotation: the flow lives in
+// pairflow.MintHome; this prints the one stderr line. stdout stays empty
+// so the line cannot be piped into `init --pairing-code`.
 func pairingMintHome(dir string, cfg *config.Config, endpoint string) error {
-	if !cfg.IsStandalone() {
-		return errors.New("_home is a standalone workspace's routing token — this workspace's writes go to its site directly, and a routing file here would misread this workspace as paired")
-	}
-	ep, err := resolveHomeEndpoint(cfg, dir, endpoint)
-	if err != nil {
-		return err
-	}
-	meta, err := issueHomeRoutingToken(dir, cfg, ep)
+	meta, err := pairflow.MintHome(dir, cfg, endpoint, time.Now())
 	if err != nil {
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "rotated _home routing token (%s) — local writes keep passing the gate\n", meta.Hash[:8])
 	return nil
-}
-
-func resolveHomeEndpoint(cfg *config.Config, dir, endpoint string) (string, error) {
-	ep := strings.TrimRight(strings.TrimSpace(endpoint), "/")
-	if ep == "" {
-		ep = advertisedEndpoint(cfg)
-	}
-	if ep == "" {
-		if rem, err := pairing.LoadRemote(dir); err == nil && rem != nil {
-			ep = strings.TrimRight(strings.TrimSpace(rem.Endpoint), "/")
-		}
-	}
-	if ep == "" {
-		return "", errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
-	}
-	u, err := url.Parse(ep)
-	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
-		return "", fmt.Errorf("bad endpoint %q: want an http(s) URL", ep)
-	}
-	return ep, nil
-}
-
-func issueHomeRoutingToken(dir string, cfg *config.Config, mintEndpoint string) (pairing.Meta, error) {
-	token, meta, err := pairing.Rotate(dir, pairing.HomeLabel, homeRoutingTTL, time.Now())
-	if err != nil {
-		return pairing.Meta{}, err
-	}
-	ep := strings.TrimRight(strings.TrimSpace(mintEndpoint), "/")
-	if ep == "" {
-		ep = advertisedEndpoint(cfg)
-	}
-	if ep == "" {
-		if rem, rerr := pairing.LoadRemote(dir); rerr == nil && rem != nil {
-			ep = rem.Endpoint
-		}
-	}
-	if ep == "" {
-		return pairing.Meta{}, errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
-	}
-	if err := pairing.SaveRemote(dir, pairing.Remote{Endpoint: ep, Token: token, Label: pairing.HomeLabel}); err != nil {
-		return pairing.Meta{}, err
-	}
-	return meta, nil
-}
-
-// isLoopbackHost names the hosts only this machine can dial. Used for the
-// mint warning, never for a trust decision (GDK-433 prior art: a tunnel
-// can look like loopback).
-func isLoopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
-}
-
-// advertisedEndpoint turns a live UI-serve listen address into the URL
-// form --endpoint validation wants. Discovery uses the home-root run
-// directory (serveaddr), not leftover serve-origin.json. An explicit
-// --endpoint is not normalized: making the user name the scheme is the point.
-func advertisedEndpoint(cfg *config.Config) string {
-	dir, err := serveaddr.Dir()
-	if err != nil {
-		return ""
-	}
-	want := ""
-	if cfg != nil {
-		want = cfg.ProfileName()
-	}
-	for _, rec := range serveaddr.List(dir) {
-		got := origin.ProbeGadakOnPort(rec.Port, 0)
-		if !got.IsGadak {
-			continue
-		}
-		if got.Profile != want {
-			continue
-		}
-		return endpointFromAdvertise(rec.Addr)
-	}
-	return ""
-}
-
-func endpointFromAdvertise(addr string) string {
-	if addr == "" {
-		return ""
-	}
-	if !strings.Contains(addr, "://") {
-		return "http://" + addr
-	}
-	return addr
-}
-
-// pairingListTime is the table/JSON timestamp for pairing list columns.
-const pairingListTime = "2006-01-02T15:04Z"
-
-// pairingListRow is one pairing-list table row. JSON tags are the same
-// columns the human table prints — never the plaintext token, never the
-// full hash (only the 8-char prefix pairing list already showed).
-type pairingListRow struct {
-	Hash     string `json:"hash"`
-	Label    string `json:"label"`
-	Scope    string `json:"scope"`
-	Created  string `json:"created"`
-	Expires  string `json:"expires"`
-	LastUsed string `json:"last_used"`
-	State    string `json:"state"`
-}
-
-func pairingListRowFrom(m pairing.Meta, now time.Time) pairingListRow {
-	last := "-"
-	if m.LastUsedAt != nil {
-		last = m.LastUsedAt.UTC().Format(pairingListTime)
-	}
-	state := "active"
-	if m.RevokedAt != nil {
-		state = "revoked " + m.RevokedAt.UTC().Format(pairingListTime)
-	} else if now.After(m.ExpiresAt) {
-		state = "expired"
-	}
-	scope := m.Scope
-	if m.Label == pairing.HomeLabel {
-		scope = pairing.ScopeLocalRouting
-	}
-	return pairingListRow{
-		Hash:     m.Hash[:8],
-		Label:    m.Label,
-		Scope:    scope,
-		Created:  m.CreatedAt.UTC().Format(pairingListTime),
-		Expires:  m.ExpiresAt.UTC().Format(pairingListTime),
-		LastUsed: last,
-		State:    state,
-	}
 }
 
 func pairingList(args []string) error {
@@ -536,7 +271,7 @@ func pairingList(args []string) error {
 			}
 			return json.NewEncoder(os.Stdout).Encode(map[string]any{
 				"paired": paired,
-				"tokens": jsonList([]pairingListRow{}),
+				"tokens": jsonList([]pairflow.Row{}),
 			})
 		}
 		fmt.Println(pairedStatusLine(cfg, rem))
@@ -546,29 +281,22 @@ func pairingList(args []string) error {
 	if err != nil {
 		return err
 	}
-	toks, err := pairing.List(dir)
+	rows, err := pairflow.Rows(dir, time.Now())
 	if err != nil {
 		return err
 	}
-	now := time.Now()
 	if *asJSON {
 		// Empty --json is {"tokens":[]} (jsonList), never the human
 		// sentence and never null: a JSON consumer that gets English on
 		// stdout is a bug. pairingGateOpenLine stays on stderr.
-		rows := make([]pairingListRow, 0, len(toks))
-		for _, m := range toks {
-			rows = append(rows, pairingListRowFrom(m, now))
-		}
-		if err := json.NewEncoder(os.Stdout).Encode(map[string]any{"tokens": jsonList(rows)}); err != nil {
-			return err
-		}
-	} else if len(toks) == 0 {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"tokens": jsonList(rows)})
+	}
+	if len(rows) == 0 {
 		fmt.Println("no pairing tokens — the origin passthrough is open to loopback (implicit trust)")
 	} else {
 		fmt.Printf("%-8s  %-20s  %-14s  %-20s  %-20s  %-20s  %s\n",
 			"HASH", "LABEL", "SCOPE", "CREATED", "EXPIRES", "LAST-USED", "STATE")
-		for _, m := range toks {
-			row := pairingListRowFrom(m, now)
+		for _, row := range rows {
 			fmt.Printf("%-8s  %-20s  %-14s  %-20s  %-20s  %-20s  %s\n",
 				row.Hash, truncate([]byte(row.Label), 20), row.Scope,
 				row.Created, row.Expires, row.LastUsed, row.State)
@@ -580,14 +308,14 @@ func pairingList(args []string) error {
 	return nil
 }
 
-// pairingGateOpenLine is the GDK-481 copy when Authorize would return
-// VerdictOff (no active token, including _home). Empty when the gate is
-// still closed. _home is counted: Authorize includes ScopeLocalRouting, so
+// pairingGateOpenLine is the GDK-481 copy when the gate has fallen back
+// open (no active token, including _home). Empty when the gate is still
+// closed. _home is counted: Authorize includes ScopeLocalRouting, so
 // revoking the last device token while _home remains must not claim the
-// gate is open.
+// gate is open. The sentence is presentation and stays here; the boolean
+// moved to pairflow.GateOpen.
 func pairingGateOpenLine(dir string) string {
-	v, err := pairing.Authorize(dir, "", time.Now())
-	if err != nil || v != pairing.VerdictOff {
+	if !pairflow.GateOpen(dir, time.Now()) {
 		return ""
 	}
 	return "no active tokens remain — the gate is open again; stop the serve to cut access"
@@ -606,7 +334,7 @@ func pairingRevoke(args []string) error {
 	if err != nil {
 		return err
 	}
-	meta, err := pairing.Revoke(dir, rest[0], time.Now())
+	meta, err := pairflow.Revoke(dir, rest[0], time.Now())
 	if err != nil {
 		return err
 	}

--- a/cmd/gadak/qr.go
+++ b/cmd/gadak/qr.go
@@ -36,7 +36,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/skip2/go-qrcode"
+	"github.com/midagedev/gadak/internal/pairflow"
 )
 
 // Terminal colors for the QR. Every line opens with both and closes with
@@ -94,17 +94,12 @@ func terminalWidth() int {
 	return n
 }
 
-// pairingQRModules encodes the offer at EC Medium and returns the module
-// matrix, quiet zone included (the library's default 4-module border).
-// Medium rather than Lower: pairing happens once per device, and a code
-// that scans from a phone held at an angle beats a dense one; higher than
-// Medium buys almost nothing at this payload size.
+// pairingQRModules moved to pairflow.QRModules (GDK-1047: the desktop
+// renders the same matrix as a PNG); this wrapper keeps the package-main
+// name qr_test.go pins. The matrix carries the quiet zone (the library's
+// default 4-module border).
 func pairingQRModules(offer string) ([][]bool, error) {
-	q, err := qrcode.New(offer, qrcode.Medium)
-	if err != nil {
-		return nil, err
-	}
-	return q.Bitmap(), nil
+	return pairflow.QRModules(offer)
 }
 
 // renderQRHalfblock draws text's QR into out, two modules per terminal row

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/midagedev/issuetap v0.0.0-20260823220829-e46d5c1547db // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -44,6 +44,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wailsapp/wails/v3 v3.0.0-beta.12 h1:Vema2kFgJvkwPovQ8GMBBrkZNm5cKVR4bYzSCMgU+PU=

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -779,6 +779,10 @@ func fallbackHandler(api http.Handler, ui fs.FS, reg *workspace.Registry, openUR
 	// bundled CLI (gadak raycast|skill|mcp install) line by line.
 	mux.HandleFunc("GET /desktop/integrations", handleIntegrationsGET)
 	mux.HandleFunc("POST /desktop/integrations/{id}/install", handleIntegrationsInstall)
+	// Settings → Devices (GDK-1047). Desktop-only, same as integrations:
+	// the mint/revoke/list surface for phone pairing, run through
+	// internal/pairflow — the same flow `gadak pairing` uses.
+	registerPairingRoutes(mux)
 	// The in-app browser pane. The SPA sends Atlassian-origin links here
 	// instead of /desktop/open (web/src/lib/desktop-links.ts decides which);
 	// each becomes an embedded webview tab layered over the pane rect the SPA

--- a/desktop/pairing.go
+++ b/desktop/pairing.go
@@ -1,0 +1,293 @@
+package main
+
+// Settings → Devices (GDK-1047): the desktop app's half of phone pairing.
+// The flow itself lives in internal/pairflow — the same code `gadak
+// pairing` runs — so a mint from this tab and a mint from the terminal
+// produce the identical token, offer, and _home routing-token guard. What
+// this file owns is the route surface: JSON in, JSON out, and the QR as a
+// PNG data URI the webview can put in an <img>.
+//
+// Reachability is the same story as every /desktop/* route: the mux hangs
+// off the Wails asset handler, there is no TCP listener, and only the
+// webview can call it. Gadak serve never mounts these.
+//
+// The offer is a credential. It appears in exactly one response — the
+// mint's — and never in a log line, an error body, or the devices list.
+// Error bodies carry stable codes, not store wording.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/pairflow"
+	"github.com/midagedev/gadak/internal/pairing"
+)
+
+// registerPairingRoutes hangs the Devices tab's three routes on the
+// desktop mux. main.go calls this once inside fallbackHandler.
+func registerPairingRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /desktop/pairing", handlePairingGET)
+	mux.HandleFunc("POST /desktop/pairing/mint", handlePairingMint)
+	mux.HandleFunc("POST /desktop/pairing/revoke", handlePairingRevoke)
+}
+
+// deviceRow is one Devices-tab row: what `gadak pairing list` prints, at
+// rest. Never a token, never the full hash — the 8-char prefix is the
+// floor revoke accepts.
+type deviceRow struct {
+	Label      string `json:"label"`
+	Scope      string `json:"scope"`
+	ExpiresAt  string `json:"expires_at"`
+	HashPrefix string `json:"hash_prefix"`
+	State      string `json:"state"`
+}
+
+// handlePairingGET answers the tab's whole world state: the device rows,
+// the endpoint a mint would advertise, and whether this workspace is
+// standalone (the routing-token guard only applies to a standalone home).
+// When the workspace cannot own devices — paired away, or no credential
+// yet — the answer is still 200 with empty rows and `unavailable` naming
+// why, so the tab can render its disabled reason instead of guessing from
+// a failed POST. advertised_endpoint empty means "no live serve found";
+// the mint form treats that as "endpoint required".
+func handlePairingGET(w http.ResponseWriter, r *http.Request) {
+	cfg, err := config.Load()
+	if err != nil {
+		// No credential yet is a renderable state, not a fault: the tab
+		// shows its disabled reason instead of an error banner.
+		if errors.Is(err, config.ErrNotConfigured) {
+			writePairingJSON(w, map[string]any{
+				"devices":             []deviceRow{},
+				"advertised_endpoint": "",
+				"standalone":          false,
+				"unavailable":         "not_configured",
+			})
+			return
+		}
+		log.Printf("pairing list: %v", err)
+		writePairingErr(w, http.StatusInternalServerError, "list_failed")
+		return
+	}
+	resp := map[string]any{
+		"devices":             []deviceRow{},
+		"advertised_endpoint": pairflow.AdvertisedEndpoint(cfg),
+		"standalone":          cfg.IsStandalone(),
+	}
+	dir, err := pairflow.Dir(cfg)
+	if err != nil {
+		if unavailable := pairingUnavailable(err); unavailable != "" {
+			resp["unavailable"] = unavailable
+			writePairingJSON(w, resp)
+			return
+		}
+		log.Printf("pairing list: %v", err)
+		writePairingErr(w, http.StatusInternalServerError, "list_failed")
+		return
+	}
+	rows, err := pairflow.Rows(dir, time.Now())
+	if err != nil {
+		log.Printf("pairing list: %v", err)
+		writePairingErr(w, http.StatusInternalServerError, "list_failed")
+		return
+	}
+	devices := make([]deviceRow, 0, len(rows))
+	for _, row := range rows {
+		devices = append(devices, deviceRow{
+			Label:      row.Label,
+			Scope:      row.Scope,
+			ExpiresAt:  row.Expires,
+			HashPrefix: row.Hash,
+			State:      row.State,
+		})
+	}
+	resp["devices"] = devices
+	writePairingJSON(w, resp)
+}
+
+// handlePairingMint runs the shared device mint for the webview's form.
+// The scope allowlist is origin|serve only: a terminal token opens a shell
+// on this machine, and that power belongs to the person at the terminal
+// who can see `gadak help pairing` — a point-and-click surface must not
+// hand it out. `_home` is refused here too; rotation of the routing key
+// stays a CLI verb (it has no offer to show).
+func handlePairingMint(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Label    string `json:"label"`
+		Scope    string `json:"scope"`
+		TTL      string `json:"ttl"`
+		Endpoint string `json:"endpoint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writePairingErr(w, http.StatusBadRequest, "bad_request")
+		return
+	}
+	label := strings.TrimSpace(body.Label)
+	if label == "" {
+		writePairingErr(w, http.StatusBadRequest, "label_required")
+		return
+	}
+	if label == pairing.HomeLabel {
+		writePairingErr(w, http.StatusBadRequest, "reserved_label")
+		return
+	}
+	scope := strings.TrimSpace(body.Scope)
+	if scope == "" {
+		scope = pairing.ScopeServe // the phone is the common case here
+	}
+	if scope != pairing.ScopeOrigin && scope != pairing.ScopeServe {
+		writePairingErr(w, http.StatusBadRequest, "bad_scope")
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		writePairingLoadErr(w, err)
+		return
+	}
+	dir, err := pairflow.Dir(cfg)
+	if err != nil {
+		if unavailable := pairingUnavailable(err); unavailable != "" {
+			writePairingErr(w, http.StatusConflict, unavailable)
+			return
+		}
+		log.Printf("pairing mint: %v", err)
+		writePairingErr(w, http.StatusInternalServerError, "mint_failed")
+		return
+	}
+	res, err := pairflow.MintDevice(dir, cfg, label, scope, body.TTL, strings.TrimSpace(body.Endpoint), time.Now())
+	if err != nil && res.Offer == "" {
+		// The flow refuses before minting; classify by its own wording,
+		// which never carries the credential.
+		switch {
+		case strings.Contains(err.Error(), "already exists"):
+			writePairingErr(w, http.StatusConflict, "label_exists")
+		case strings.Contains(err.Error(), "no live serve"):
+			writePairingErr(w, http.StatusConflict, "no_serve")
+		case strings.Contains(err.Error(), "bad endpoint"):
+			writePairingErr(w, http.StatusBadRequest, "bad_endpoint")
+		case strings.Contains(err.Error(), "bad ttl"):
+			writePairingErr(w, http.StatusBadRequest, "bad_ttl")
+		default:
+			log.Printf("pairing mint: %v", err)
+			writePairingErr(w, http.StatusInternalServerError, "mint_failed")
+		}
+		return
+	}
+	// The QR the phone scans: same module matrix the terminal draws,
+	// rendered as a PNG data URI so the webview needs no decode step.
+	png, qrErr := pairflow.QRPNG(res.Offer)
+	if qrErr != nil {
+		// The mint itself succeeded; the offer must still reach the user.
+		log.Printf("pairing mint QR: %v", qrErr)
+	}
+	resp := map[string]any{
+		"offer":            res.Offer,
+		"label":            res.Label,
+		"scope":            res.Scope,
+		"endpoint":         res.Endpoint,
+		"expires_at":       res.ExpiresAt,
+		"hash_prefix":      res.Meta.Hash[:8],
+		"loopback_warning": res.LoopbackWarning,
+	}
+	if qrErr == nil {
+		resp["qr_png"] = "data:image/png;base64," + base64.StdEncoding.EncodeToString(png)
+	}
+	// A guard failure after the mint (disk-level, rare): the credential
+	// exists exactly once, in this response — withholding it would strand
+	// the token, so the mint answers success with the warning attached.
+	if err != nil {
+		log.Printf("pairing mint (post-mint step): %v", err)
+		resp["warning"] = "home_routing"
+	}
+	writePairingJSON(w, resp)
+}
+
+// handlePairingRevoke closes one device token by label or hash prefix —
+// the same selector `gadak pairing revoke` takes. The `_home` refusal and
+// the ambiguity/already-revoked wordings come from the store unchanged;
+// they are classified to codes by their pinned sentences.
+func handlePairingRevoke(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Selector string `json:"selector"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Selector) == "" {
+		writePairingErr(w, http.StatusBadRequest, "bad_request")
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		writePairingLoadErr(w, err)
+		return
+	}
+	dir, err := pairflow.Dir(cfg)
+	if err != nil {
+		if unavailable := pairingUnavailable(err); unavailable != "" {
+			writePairingErr(w, http.StatusConflict, unavailable)
+			return
+		}
+		log.Printf("pairing revoke: %v", err)
+		writePairingErr(w, http.StatusInternalServerError, "revoke_failed")
+		return
+	}
+	meta, err := pairflow.Revoke(dir, strings.TrimSpace(body.Selector), time.Now())
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "own routing key"):
+			writePairingErr(w, http.StatusBadRequest, "home_refused")
+		case strings.Contains(err.Error(), "already revoked"):
+			writePairingErr(w, http.StatusConflict, "already_revoked")
+		case strings.Contains(err.Error(), "no token matches"):
+			writePairingErr(w, http.StatusNotFound, "not_found")
+		case strings.Contains(err.Error(), "matches"):
+			writePairingErr(w, http.StatusBadRequest, "ambiguous")
+		default:
+			log.Printf("pairing revoke: %v", err)
+			writePairingErr(w, http.StatusInternalServerError, "revoke_failed")
+		}
+		return
+	}
+	writePairingJSON(w, map[string]any{"revoked": meta.Label, "hash_prefix": meta.Hash[:8]})
+}
+
+// pairingUnavailable classifies the two workspace states that cannot own
+// devices: paired away (its home is another machine) and no credential
+// yet. Empty string means the error is something else.
+func pairingUnavailable(err error) string {
+	if errors.Is(err, config.ErrNotConfigured) {
+		return "not_configured"
+	}
+	if strings.Contains(err.Error(), "run on the home machine") {
+		return "paired_away"
+	}
+	return ""
+}
+
+// writePairingLoadErr answers a config.Load failure: unconfigured is a
+// state the tab renders (409 + code), anything else is a fault (500).
+func writePairingLoadErr(w http.ResponseWriter, err error) {
+	if errors.Is(err, config.ErrNotConfigured) {
+		writePairingErr(w, http.StatusConflict, "not_configured")
+		return
+	}
+	log.Printf("pairing config: %v", err)
+	writePairingErr(w, http.StatusInternalServerError, "load_failed")
+}
+
+func writePairingJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	// Mint responses carry the offer; nothing downstream may cache one.
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writePairingErr(w http.ResponseWriter, status int, code string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	http.Error(w, `{"error":`+strconv.Quote(code)+`}`, status)
+}

--- a/desktop/pairing_test.go
+++ b/desktop/pairing_test.go
@@ -1,0 +1,380 @@
+package main
+
+// GDK-1047 gates for the Devices tab's route surface. The load-bearing
+// one is the guard at the HTTP boundary: a mint through
+// /desktop/pairing/mint must leave a usable _home routing token in
+// remote-origin.json — the exact assertion the FAIL-first run showed red
+// against a naive pairing.MintScoped mint (round report has it verbatim).
+// Beyond that: the QR data URI is the same matrix the terminal draws, the
+// offer appears in exactly one response and nowhere else, scope origin|serve
+// only (terminal is refused by design), `_home` is refused, revoke works
+// by hash prefix, and the paired-away workspace is answered with a code,
+// never a stack-flavored 500.
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/pairflow"
+	"github.com/midagedev/gadak/internal/pairing"
+)
+
+func pairingMuxForTest() http.Handler {
+	return fallbackHandler(http.NotFoundHandler(), nil, nil, nil, newBrowseTabs(), nil)
+}
+
+// standaloneDesktopHome stands up a temp GADAK_HOME holding a standalone
+// workspace — the home-serve shape the Devices tab operates on.
+func standaloneDesktopHome(t *testing.T) string {
+	t.Helper()
+	for _, k := range []string{"GADAK_SITE", "GADAK_EMAIL", "GADAK_TOKEN"} {
+		t.Setenv(k, "")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GADAK_HOME", filepath.Join(home, ".gadak"))
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	return cfg.Directory()
+}
+
+func postPairing(t *testing.T, h http.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, strings.NewReader(body)))
+	return rec
+}
+
+func getPairing(t *testing.T, h http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/desktop/pairing", nil))
+	return rec
+}
+
+func pairingErrCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var doc struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("error body is not {\"error\":code}: %d %s", rec.Code, rec.Body.String())
+	}
+	return doc.Error
+}
+
+// TestPairingMintGuardAndQR is the round's namesake gate: mint through the
+// route, and the standalone home still holds a usable _home routing token;
+// the QR in the response is the same module matrix the terminal renders;
+// the offer round-trips and appears only where it belongs.
+func TestPairingMintGuardAndQR(t *testing.T) {
+	dir := standaloneDesktopHome(t)
+	h := pairingMuxForTest()
+
+	rec := postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","ttl":"1h","endpoint":"http://192.0.2.10:7877"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mint: %d %s", rec.Code, rec.Body.String())
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("mint Cache-Control is %q — a credential response must be no-store", cc)
+	}
+	var doc struct {
+		Offer           string `json:"offer"`
+		Label           string `json:"label"`
+		Scope           string `json:"scope"`
+		Endpoint        string `json:"endpoint"`
+		ExpiresAt       string `json:"expires_at"`
+		HashPrefix      string `json:"hash_prefix"`
+		LoopbackWarning bool   `json:"loopback_warning"`
+		QRPNG           string `json:"qr_png"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("mint body: %v\n%s", err, rec.Body.String())
+	}
+	if doc.Offer == "" || doc.Label != "phone" || doc.Scope != "serve" || doc.Endpoint != "http://192.0.2.10:7877" {
+		t.Fatalf("mint carries %+v", doc)
+	}
+	if len(doc.HashPrefix) != 8 {
+		t.Fatalf("hash_prefix %q, want 8 chars", doc.HashPrefix)
+	}
+	if doc.LoopbackWarning {
+		t.Fatal("a TEST-NET endpoint is not loopback")
+	}
+	offer, err := pairing.DecodeOffer(doc.Offer)
+	if err != nil {
+		t.Fatalf("offer does not round-trip: %v", err)
+	}
+	if offer.Endpoint != doc.Endpoint || offer.Label != "phone" {
+		t.Fatalf("offer carries %+v", offer)
+	}
+
+	// The guard, asserted at the HTTP boundary: the mint this route ran
+	// left the home machine a routing token it can still use.
+	rem, err := pairing.LoadRemote(dir)
+	if err != nil || rem == nil {
+		t.Fatalf("no _home routing token after a route mint: %v %v", rem, err)
+	}
+	if v, err := pairing.Authorize(dir, rem.Token, time.Now()); err != nil || v != pairing.VerdictAccept {
+		t.Fatalf("routing token verdict %v (%v), want accept", v, err)
+	}
+
+	// The QR is a PNG data URI of the same matrix the terminal draws.
+	if !strings.HasPrefix(doc.QRPNG, "data:image/png;base64,") {
+		t.Fatalf("qr_png prefix: %q", doc.QRPNG[:40])
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(doc.QRPNG, "data:image/png;base64,"))
+	if err != nil {
+		t.Fatalf("qr_png is not base64: %v", err)
+	}
+	img, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("qr_png does not decode as PNG: %v", err)
+	}
+	mods, err := pairflow.QRModules(doc.Offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	side := len(mods) * 8
+	if img.Bounds().Dx() != side || img.Bounds().Dy() != side {
+		t.Fatalf("QR is %dx%d, want %d (modules %d × 8px)", img.Bounds().Dx(), img.Bounds().Dy(), side, len(mods))
+	}
+
+	// The loopback flag is data, both polarities: a loopback endpoint warns.
+	rec = postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"tablet","scope":"serve","ttl":"1h","endpoint":"http://127.0.0.1:7877"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("loopback mint: %d %s", rec.Code, rec.Body.String())
+	}
+	var loop struct {
+		LoopbackWarning bool `json:"loopback_warning"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &loop)
+	if !loop.LoopbackWarning {
+		t.Fatal("a loopback endpoint must set loopback_warning")
+	}
+}
+
+// TestPairingMintRefusals: the route refuses what it must, with stable
+// codes — terminal scope (by design: it opens a shell), the reserved
+// _home label, an empty label, a non-http endpoint, no endpoint with no
+// live serve, and a duplicate active label.
+func TestPairingMintRefusals(t *testing.T) {
+	standaloneDesktopHome(t)
+	h := pairingMuxForTest()
+
+	cases := []struct {
+		name, body string
+		status     int
+		code       string
+	}{
+		{"terminal scope", `{"label":"sh","scope":"terminal","endpoint":"http://192.0.2.10:7877"}`, 400, "bad_scope"},
+		{"made-up scope", `{"label":"x","scope":"admin","endpoint":"http://192.0.2.10:7877"}`, 400, "bad_scope"},
+		{"reserved label", `{"label":"_home","scope":"serve","endpoint":"http://192.0.2.10:7877"}`, 400, "reserved_label"},
+		{"empty label", `{"label":"  ","scope":"serve"}`, 400, "label_required"},
+		{"bad endpoint scheme", `{"label":"p","scope":"serve","endpoint":"ftp://192.0.2.10:7877"}`, 400, "bad_endpoint"},
+		{"no serve no endpoint", `{"label":"p","scope":"serve"}`, 409, "no_serve"},
+		{"bad body", `not json`, 400, "bad_request"},
+	}
+	for _, tc := range cases {
+		rec := postPairing(t, h, "/desktop/pairing/mint", tc.body)
+		if rec.Code != tc.status {
+			t.Fatalf("%s: %d %s, want %d", tc.name, rec.Code, rec.Body.String(), tc.status)
+		}
+		if got := pairingErrCode(t, rec); got != tc.code {
+			t.Fatalf("%s: code %q, want %q", tc.name, got, tc.code)
+		}
+	}
+
+	// Duplicate active label: the first mint owns it.
+	if rec := postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","ttl":"1h","endpoint":"http://192.0.2.10:7877"}`); rec.Code != http.StatusOK {
+		t.Fatalf("first mint: %d %s", rec.Code, rec.Body.String())
+	}
+	rec := postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","ttl":"1h","endpoint":"http://192.0.2.10:7877"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate label: %d %s", rec.Code, rec.Body.String())
+	}
+	if got := pairingErrCode(t, rec); got != "label_exists" {
+		t.Fatalf("duplicate label code %q", got)
+	}
+}
+
+// TestPairingListAndRevoke walks the tab's loop: GET shows the minted
+// devices (and _home, marked as local-routing — it is not a device), the
+// list never carries a token or an offer, revoke closes by the hash
+// prefix the list itself printed, and revoking _home is refused with the
+// same sentence the CLI refuses it with.
+func TestPairingListAndRevoke(t *testing.T) {
+	standaloneDesktopHome(t)
+	h := pairingMuxForTest()
+
+	getDevices := func() []map[string]any {
+		rec := getPairing(t, h)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET: %d %s", rec.Code, rec.Body.String())
+		}
+		var doc struct {
+			Devices []map[string]any `json:"devices"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+			t.Fatalf("GET body: %v\n%s", err, rec.Body.String())
+		}
+		return doc.Devices
+	}
+
+	if rec := postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","ttl":"1h","endpoint":"http://192.0.2.10:7877"}`); rec.Code != http.StatusOK {
+		t.Fatalf("mint: %d %s", rec.Code, rec.Body.String())
+	}
+	devices := getDevices()
+	byLabel := map[string]map[string]any{}
+	for _, d := range devices {
+		byLabel[d["label"].(string)] = d
+	}
+	if len(byLabel) != 2 {
+		t.Fatalf("devices after one mint: %v", byLabel)
+	}
+	phone, ok := byLabel["phone"]
+	if !ok {
+		t.Fatalf("phone row missing: %v", byLabel)
+	}
+	if phone["scope"] != "serve" || phone["state"] != "active" {
+		t.Fatalf("phone row is %v", phone)
+	}
+	home, ok := byLabel[pairing.HomeLabel]
+	if !ok || home["scope"] != pairing.ScopeLocalRouting {
+		t.Fatalf("_home row missing or mislabeled: %v", home)
+	}
+	prefix, _ := phone["hash_prefix"].(string)
+	if len(prefix) != 8 {
+		t.Fatalf("hash_prefix %q", prefix)
+	}
+
+	// Revoke by the prefix the list printed.
+	rec := postPairing(t, h, "/desktop/pairing/revoke", `{"selector":"`+prefix+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("revoke: %d %s", rec.Code, rec.Body.String())
+	}
+	for _, d := range getDevices() {
+		if d["label"] == "phone" {
+			if state, _ := d["state"].(string); !strings.HasPrefix(state, "revoked ") {
+				t.Fatalf("revoked row state is %q", state)
+			}
+		}
+	}
+
+	// The refusals, with codes.
+	for _, tc := range []struct {
+		name, selector, code string
+		status               int
+	}{
+		{"home refused", "_home", "home_refused", 400},
+		{"unknown selector", "deadbeef", "not_found", 404},
+		{"empty selector", "  ", "bad_request", 400},
+	} {
+		rec := postPairing(t, h, "/desktop/pairing/revoke", `{"selector":"`+tc.selector+`"}`)
+		if rec.Code != tc.status {
+			t.Fatalf("%s: %d %s, want %d", tc.name, rec.Code, rec.Body.String(), tc.status)
+		}
+		if got := pairingErrCode(t, rec); got != tc.code {
+			t.Fatalf("%s: code %q, want %q", tc.name, got, tc.code)
+		}
+	}
+}
+
+// TestPairingPairedAway: a workspace that is itself paired to another
+// machine owns no devices — GET answers the state as data and mint/revoke
+// answer a 409 code, never a stack-flavored 500.
+func TestPairingPairedAway(t *testing.T) {
+	dir := standaloneDesktopHome(t)
+	if err := pairing.SaveRemote(dir, pairing.Remote{
+		Endpoint: "http://192.0.2.10:7877",
+		Token:    "paired-away-not-a-pairing-token",
+		Label:    "desk",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = ""
+	cfg.Site = "https://example.atlassian.net"
+	cfg.Email = "home@example.net"
+	cfg.Token = "secret-not-a-pairing-token"
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	h := pairingMuxForTest()
+
+	rec := getPairing(t, h)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET: %d %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"unavailable":"paired_away"`) {
+		t.Fatalf("GET body does not name the state: %s", rec.Body.String())
+	}
+	rec = postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","endpoint":"http://192.0.2.10:7877"}`)
+	if rec.Code != http.StatusConflict || pairingErrCode(t, rec) != "paired_away" {
+		t.Fatalf("mint on a paired-away workspace: %d %s", rec.Code, rec.Body.String())
+	}
+	rec = postPairing(t, h, "/desktop/pairing/revoke", `{"selector":"phone"}`)
+	if rec.Code != http.StatusConflict || pairingErrCode(t, rec) != "paired_away" {
+		t.Fatalf("revoke on a paired-away workspace: %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPairingNeverLeaksTheOffer: the offer appears in exactly one response
+// — the mint's. Error bodies and the devices list never carry it.
+func TestPairingNeverLeaksTheOffer(t *testing.T) {
+	standaloneDesktopHome(t)
+	h := pairingMuxForTest()
+
+	rec := postPairing(t, h, "/desktop/pairing/mint",
+		`{"label":"phone","scope":"serve","ttl":"1h","endpoint":"http://192.0.2.10:7877"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mint: %d %s", rec.Code, rec.Body.String())
+	}
+	var minted struct {
+		Offer string `json:"offer"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &minted); err != nil || minted.Offer == "" {
+		t.Fatalf("mint body has no offer: %v %s", err, rec.Body.String())
+	}
+	// The devices list never carries it.
+	if body := getPairing(t, h).Body.String(); strings.Contains(body, minted.Offer) {
+		t.Fatal("the devices list carries the offer")
+	}
+	// Neither do refusal bodies (the duplicate-label one reuses the label).
+	for _, tc := range []struct{ path, body string }{
+		{"/desktop/pairing/mint", `{"label":"phone","scope":"serve","endpoint":"http://192.0.2.10:7877"}`},
+		{"/desktop/pairing/mint", `{"label":"p2","scope":"terminal","endpoint":"http://192.0.2.10:7877"}`},
+		{"/desktop/pairing/revoke", `{"selector":"deadbeef"}`},
+		{"/desktop/pairing/revoke", `{"selector":"_home"}`},
+	} {
+		rec := postPairing(t, h, tc.path, tc.body)
+		if strings.Contains(rec.Body.String(), minted.Offer) {
+			t.Fatalf("%s %s leaked the offer: %s", tc.path, tc.body, rec.Body.String())
+		}
+	}
+}

--- a/internal/pairflow/mint.go
+++ b/internal/pairflow/mint.go
@@ -1,0 +1,507 @@
+// Package pairflow owns the device-pairing mint flow shared by the CLI
+// (`gadak pairing`, GDK-433/450/797) and the desktop app's Devices tab
+// (GDK-1047): endpoint resolution and validation, the scoped mint plus
+// offer encode, the _home routing-token guard, list row shaping, and the
+// two QR encodings (the terminal module matrix and the PNG a phone scans).
+//
+// One owner so the surfaces cannot drift. The guard that motivates the
+// extraction is ensureHomeRoutingToken: once one device token exists the
+// serve gate takes Bearer only — no loopback bypass — so a mint that skips
+// the home routing token locks the standalone home out of its own
+// passthrough. The CLI carried that guard; before this package the desktop
+// would have had to copy it, and a copy is where a guard goes missing.
+//
+// Presentation stays with the callers: this package returns values (the
+// offer, the loopback flag, which _home action ran) and prints nothing.
+package pairflow
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/skip2/go-qrcode"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/origin"
+	"github.com/midagedev/gadak/internal/pairing"
+	"github.com/midagedev/gadak/internal/serveaddr"
+)
+
+// DefaultTTL is 90 days: a device token is revocable, so it does not need
+// a short life, but an unattended one should not outlive a quarter by
+// default either.
+const DefaultTTL = 90 * 24 * time.Hour
+
+// homeRoutingTTL is long on purpose: an expiring routing token would
+// re-open the 401 cliff ensureHomeRoutingToken exists to close. Rotation
+// is explicit (`pairing mint --label _home`), not expiry.
+const homeRoutingTTL = 10 * 365 * 24 * time.Hour
+
+// DefaultTTLFlag renders DefaultTTL in the <N><unit> syntax --ttl speaks,
+// so the 90-day default has one owner.
+func DefaultTTLFlag() string {
+	return fmt.Sprintf("%dd", int(DefaultTTL/(24*time.Hour)))
+}
+
+// ParseTTL accepts one integer with a single unit — "90d", "24h", "30m",
+// "45s". time.ParseDuration rejects "d", and inventing compound syntax
+// ("1d12h") is surface nobody asked for; a clear error beats guessing.
+func ParseTTL(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errors.New("empty ttl")
+	}
+	unit := s[len(s)-1]
+	digits := s[:len(s)-1]
+	n, err := strconv.Atoi(digits)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("bad ttl %q: want <N><unit> with unit d, h, m, or s (e.g. 90d, 24h)", s)
+	}
+	switch unit {
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	case 'h':
+		return time.Duration(n) * time.Hour, nil
+	case 'm':
+		return time.Duration(n) * time.Minute, nil
+	case 's':
+		return time.Duration(n) * time.Second, nil
+	default:
+		return 0, fmt.Errorf("bad ttl %q: unit must be d, h, m, or s", s)
+	}
+}
+
+// MintResult is everything a mint produced. The offer is a credential: it
+// exists here and in the caller output, never in a log or an error.
+type MintResult struct {
+	Offer, Label, Scope, Endpoint, ExpiresAt string
+	Meta                                     pairing.Meta
+	// LoopbackWarning says the endpoint is a loopback address — remote
+	// devices cannot reach it. The caller renders its own copy.
+	LoopbackWarning bool
+	// HomeRouting names what ensureHomeRoutingToken did, so the CLI can
+	// print its stderr note and the desktop can stay quiet.
+	HomeRouting HomeRoutingAction
+}
+
+// HomeRoutingAction is what a mint did about the _home routing token.
+type HomeRoutingAction string
+
+const (
+	// HomeRoutingNone: the existing credential is valid, or the gate is
+	// off, or the workspace is connected (no routing token by design).
+	HomeRoutingNone HomeRoutingAction = ""
+	// HomeRoutingMinted: this mint created the first _home credential.
+	HomeRoutingMinted HomeRoutingAction = "minted"
+	// HomeRoutingReissued: the stored credential was stale or revoked
+	// while the gate was on (GDK-450 recovery).
+	HomeRoutingReissued HomeRoutingAction = "reissued"
+)
+
+// Dir is the profile directory the token store lives in. Pairing protects
+// both gated surfaces of a home serve — the origin passthrough
+// (standalone, GDK-433) and the mirror REST a phone companion reads
+// (GDK-797) — so both workspace kinds may mint; what stays closed for a
+// connected workspace is the passthrough itself (origin_rest.go 404s it).
+// A workspace that is itself paired away cannot mint: its home is another
+// machine.
+func Dir(cfg *config.Config) (string, error) {
+	if rem, err := origin.PairedStatus(cfg); err != nil {
+		return "", err
+	} else if rem != nil {
+		return "", fmt.Errorf("%s — mint and revoke run on the home machine", PairedLine(cfg, rem))
+	}
+	if !cfg.HasCredential() {
+		return "", config.ErrNotConfigured
+	}
+	dir := cfg.Directory()
+	if dir == "" {
+		return "", errors.New("pairing: profile directory not found")
+	}
+	return dir, nil
+}
+
+// PairedLine is the self-status sentence a paired workspace gets where it
+// tried to act as a home.
+func PairedLine(cfg *config.Config, rem *pairing.Remote) string {
+	line := fmt.Sprintf("this workspace is paired with %q (%s)", rem.Label, rem.Endpoint)
+	if rem.Label == "" {
+		line = fmt.Sprintf("this workspace is paired with %s", rem.Endpoint)
+	}
+	if cfg != nil && strings.TrimSpace(cfg.TokenOwner) != "" {
+		line += " as " + cfg.TokenOwner
+	}
+	return line
+}
+
+// MintDevice is the device-mint flow: validate, resolve the endpoint,
+// mint the scoped token, encode the offer, and — for a standalone home —
+// keep the _home routing token valid. Callers pre-validate their own input
+// surface (flags, form fields); this function re-validates because it is
+// the structural owner, not a trusted callee.
+//
+// endpoint may be empty: a live serve for cfg's profile is then discovered
+// via serveaddr. ttl may be empty: DefaultTTL applies. On a failure after
+// the token was minted (the routing-token step is the only one) the
+// result still carries the offer: the plaintext exists exactly once, in
+// the caller output, or a minted token would be stranded unrecoverable.
+func MintDevice(dir string, cfg *config.Config, label, scope, ttl, endpoint string, now time.Time) (MintResult, error) {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return MintResult{}, errors.New("pairing mint requires --label NAME")
+	}
+	if label == pairing.HomeLabel {
+		return MintResult{}, fmt.Errorf("%s is the machine routing key, not a device label — mint devices under any other name", pairing.HomeLabel)
+	}
+	scope = strings.TrimSpace(scope)
+	switch scope {
+	case pairing.ScopeOrigin, pairing.ScopeServe, pairing.ScopeTerminal:
+	default:
+		return MintResult{}, fmt.Errorf("unknown scope %q: want origin (a paired gadak riding the passthrough), serve (a paired client reading the mirror REST), or terminal (a shell on this machine)", scope)
+	}
+	ttlDur := DefaultTTL
+	if strings.TrimSpace(ttl) != "" {
+		var err error
+		ttlDur, err = ParseTTL(ttl)
+		if err != nil {
+			return MintResult{}, err
+		}
+	}
+	// Resolve the endpoint before minting: a mint without a reachable
+	// endpoint is an orphan token nobody can use, and it would already
+	// have flipped the gate on.
+	ep := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if ep == "" {
+		ep = AdvertisedEndpoint(cfg)
+		if ep == "" {
+			return MintResult{}, errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
+		}
+	}
+	u, err := url.Parse(ep)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return MintResult{}, fmt.Errorf("bad endpoint %q: want an http(s) URL", ep)
+	}
+	loopback := isLoopbackHost(u.Hostname())
+	token, meta, err := pairing.MintScoped(dir, label, scope, ttlDur, now)
+	if err != nil {
+		return MintResult{}, err
+	}
+	offer, err := pairing.EncodeOffer(pairing.Offer{
+		V:         pairing.OfferV1,
+		Endpoint:  ep,
+		Token:     token,
+		ExpiresAt: pairing.FormatExpiry(meta.ExpiresAt),
+		Label:     label,
+	})
+	if err != nil {
+		return MintResult{}, err
+	}
+	res := MintResult{
+		Offer:           offer,
+		Label:           label,
+		Scope:           scope,
+		Endpoint:        ep,
+		ExpiresAt:       pairing.FormatExpiry(meta.ExpiresAt),
+		Meta:            meta,
+		LoopbackWarning: loopback,
+	}
+	// The _home routing token is a standalone home concern: its local
+	// writes ride the passthrough this serve fronts. A connected
+	// workspace writes go straight to its site, and the routing file
+	// (remote-origin.json) would make origin.pairedRemote read this
+	// workspace as paired with its own serve — never written here.
+	if cfg.IsStandalone() {
+		action, err := ensureHomeRoutingToken(dir, cfg, ep, now)
+		res.HomeRouting = action
+		if err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+// ensureHomeRoutingToken is the single owner of "_home is valid". Once one
+// token exists the gate takes Bearer only — no loopback bypass — and the
+// home machine writes route through the same passthrough (GDK-333 single
+// persist owner). Standalone excludes the file from the paired-remote
+// branch (origin.pairedRemote), so here it only ever carries the routing
+// token localRoutingToken reads.
+//
+// Called after every device mint. If remote-origin.json token is missing
+// or no longer active in the store while the gate is on, it reissues
+// `_home` and rewrites the file — the recovery path for a routing token
+// revoked by an older build (GDK-450).
+func ensureHomeRoutingToken(dir string, cfg *config.Config, mintEndpoint string, now time.Time) (HomeRoutingAction, error) {
+	rem, err := pairing.LoadRemote(dir)
+	if err != nil {
+		return HomeRoutingNone, err
+	}
+	if rem != nil {
+		v, aerr := pairing.Authorize(dir, rem.Token, now)
+		if aerr != nil {
+			return HomeRoutingNone, aerr
+		}
+		if v == pairing.VerdictAccept {
+			return HomeRoutingNone, nil
+		}
+		if v == pairing.VerdictOff {
+			// Gate off: no active tokens, local writes need no bearer.
+			return HomeRoutingNone, nil
+		}
+	} else {
+		v, aerr := pairing.Authorize(dir, "", now)
+		if aerr != nil {
+			return HomeRoutingNone, aerr
+		}
+		if v == pairing.VerdictOff {
+			return HomeRoutingNone, nil
+		}
+	}
+	first := rem == nil
+	if _, err := issueHomeRoutingToken(dir, cfg, mintEndpoint, now); err != nil {
+		return HomeRoutingNone, err
+	}
+	if first {
+		return HomeRoutingMinted, nil
+	}
+	return HomeRoutingReissued, nil
+}
+
+// MintHome is `pairing mint --label _home`: routing-token rotation, not a
+// device offer. No offer is produced. Standalone only — a connected
+// workspace writes go straight to its site, and the routing file here
+// would make origin.pairedRemote read this workspace as paired with its
+// own serve.
+func MintHome(dir string, cfg *config.Config, endpoint string, now time.Time) (pairing.Meta, error) {
+	if !cfg.IsStandalone() {
+		return pairing.Meta{}, errors.New("_home is a standalone workspace's routing token — this workspace's writes go to its site directly, and a routing file here would misread this workspace as paired")
+	}
+	ep, err := resolveHomeEndpoint(cfg, dir, endpoint)
+	if err != nil {
+		return pairing.Meta{}, err
+	}
+	return issueHomeRoutingToken(dir, cfg, ep, now)
+}
+
+func resolveHomeEndpoint(cfg *config.Config, dir, endpoint string) (string, error) {
+	ep := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if ep == "" {
+		ep = AdvertisedEndpoint(cfg)
+	}
+	if ep == "" {
+		if rem, err := pairing.LoadRemote(dir); err == nil && rem != nil {
+			ep = strings.TrimRight(strings.TrimSpace(rem.Endpoint), "/")
+		}
+	}
+	if ep == "" {
+		return "", errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
+	}
+	u, err := url.Parse(ep)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", fmt.Errorf("bad endpoint %q: want an http(s) URL", ep)
+	}
+	return ep, nil
+}
+
+func issueHomeRoutingToken(dir string, cfg *config.Config, mintEndpoint string, now time.Time) (pairing.Meta, error) {
+	token, meta, err := pairing.Rotate(dir, pairing.HomeLabel, homeRoutingTTL, now)
+	if err != nil {
+		return pairing.Meta{}, err
+	}
+	ep := strings.TrimRight(strings.TrimSpace(mintEndpoint), "/")
+	if ep == "" {
+		ep = AdvertisedEndpoint(cfg)
+	}
+	if ep == "" {
+		if rem, rerr := pairing.LoadRemote(dir); rerr == nil && rem != nil {
+			ep = rem.Endpoint
+		}
+	}
+	if ep == "" {
+		return pairing.Meta{}, errors.New("no live serve found for this profile; start `gadak serve` first or pass --endpoint <url>")
+	}
+	if err := pairing.SaveRemote(dir, pairing.Remote{Endpoint: ep, Token: token, Label: pairing.HomeLabel}); err != nil {
+		return pairing.Meta{}, err
+	}
+	return meta, nil
+}
+
+// isLoopbackHost names the hosts only this machine can dial. Used for the
+// mint warning, never for a trust decision (GDK-433 prior art: a tunnel
+// can look like loopback).
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// AdvertisedEndpoint turns a live UI-serve listen address into the URL
+// form endpoint validation wants. Discovery uses the home-root run
+// directory (serveaddr), not leftover serve-origin.json. An explicit
+// endpoint is not normalized: making the user name the scheme is the
+// point.
+func AdvertisedEndpoint(cfg *config.Config) string {
+	dir, err := serveaddr.Dir()
+	if err != nil {
+		return ""
+	}
+	want := ""
+	if cfg != nil {
+		want = cfg.ProfileName()
+	}
+	for _, rec := range serveaddr.List(dir) {
+		got := origin.ProbeGadakOnPort(rec.Port, 0)
+		if !got.IsGadak {
+			continue
+		}
+		if got.Profile != want {
+			continue
+		}
+		return EndpointFromAdvertise(rec.Addr)
+	}
+	return ""
+}
+
+// EndpointFromAdvertise upgrades the raw bind address the advertise file
+// stores (host:port) to the URL form, leaving an address that already
+// carries a scheme alone.
+func EndpointFromAdvertise(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	if !strings.Contains(addr, "://") {
+		return "http://" + addr
+	}
+	return addr
+}
+
+// rowTime is the table/JSON timestamp for pairing list columns.
+const rowTime = "2006-01-02T15:04Z"
+
+// Row is one pairing-list row. JSON tags are the table columns — never
+// the plaintext token, never the full hash (only the 8-char prefix the
+// list already showed).
+type Row struct {
+	Hash     string `json:"hash"`
+	Label    string `json:"label"`
+	Scope    string `json:"scope"`
+	Created  string `json:"created"`
+	Expires  string `json:"expires"`
+	LastUsed string `json:"last_used"`
+	State    string `json:"state"`
+}
+
+// Rows shapes every stored token for listing: the _home row reads as
+// local-routing (not a device scope), and state distinguishes revoked and
+// expired from active.
+func Rows(dir string, now time.Time) ([]Row, error) {
+	toks, err := pairing.List(dir)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]Row, 0, len(toks))
+	for _, m := range toks {
+		rows = append(rows, RowFrom(m, now))
+	}
+	return rows, nil
+}
+
+// RowFrom shapes one stored token. The 8-char hash prefix is the same
+// floor revoke accepts.
+func RowFrom(m pairing.Meta, now time.Time) Row {
+	last := "-"
+	if m.LastUsedAt != nil {
+		last = m.LastUsedAt.UTC().Format(rowTime)
+	}
+	state := "active"
+	if m.RevokedAt != nil {
+		state = "revoked " + m.RevokedAt.UTC().Format(rowTime)
+	} else if now.After(m.ExpiresAt) {
+		state = "expired"
+	}
+	scope := m.Scope
+	if m.Label == pairing.HomeLabel {
+		scope = pairing.ScopeLocalRouting
+	}
+	return Row{
+		Hash:     m.Hash[:8],
+		Label:    m.Label,
+		Scope:    scope,
+		Created:  m.CreatedAt.UTC().Format(rowTime),
+		Expires:  m.ExpiresAt.UTC().Format(rowTime),
+		LastUsed: last,
+		State:    state,
+	}
+}
+
+// GateOpen reports whether the serve gate has fallen back open: no active
+// token exists (including _home). The GDK-481 sentence callers print is
+// theirs; this is the one boolean behind it.
+func GateOpen(dir string, now time.Time) bool {
+	v, err := pairing.Authorize(dir, "", now)
+	return err == nil && v == pairing.VerdictOff
+}
+
+// Revoke is the store call the CLI and desktop share: selector is an exact
+// label or a hash prefix of at least 8 hex characters (what Rows prints).
+// The _home refusal and ambiguity wording live in internal/pairing —
+// callers classify by that error, they do not rewrite it.
+func Revoke(dir, selector string, now time.Time) (pairing.Meta, error) {
+	return pairing.Revoke(dir, selector, now)
+}
+
+// QRModules encodes the offer at EC Medium and returns the module matrix,
+// quiet zone included (the library default 4-module border). Medium rather
+// than Lower: pairing happens once per device, and a code that scans from
+// a phone held at an angle beats a dense one; higher than Medium buys
+// almost nothing at this payload size.
+func QRModules(offer string) ([][]bool, error) {
+	q, err := qrcode.New(offer, qrcode.Medium)
+	if err != nil {
+		return nil, err
+	}
+	return q.Bitmap(), nil
+}
+
+// qrPNGScale is px per module in QRPNG — the same 8 px/module the standing
+// scanner-repro tool in cmd/gadak/qr_test.go writes.
+const qrPNGScale = 8
+
+// QRPNG renders the offer QR as a PNG: white background, black modules,
+// quiet zone included via the module matrix, square. The desktop serves
+// it to the webview as a data URI; the geometry matches what the terminal
+// half-block renderer draws, so both encodings are the same code.
+func QRPNG(offer string) ([]byte, error) {
+	mods, err := QRModules(offer)
+	if err != nil {
+		return nil, err
+	}
+	n := len(mods) * qrPNGScale
+	img := image.NewRGBA(image.Rect(0, 0, n, n))
+	white, black := color.RGBA{R: 255, G: 255, B: 255, A: 255}, color.RGBA{A: 255}
+	for y := 0; y < n; y++ {
+		for x := 0; x < n; x++ {
+			if mods[y/qrPNGScale][x/qrPNGScale] {
+				img.SetRGBA(x, y, black)
+			} else {
+				img.SetRGBA(x, y, white)
+			}
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/pairflow/mint_test.go
+++ b/internal/pairflow/mint_test.go
@@ -1,0 +1,433 @@
+package pairflow
+
+// GDK-1047 gates for the shared mint flow. The load-bearing one is
+// TestMintDeviceKeepsHomeRoutingToken: a naive mint that skips
+// ensureHomeRoutingToken flips the serve gate on with no _home credential
+// in remote-origin.json, locking the home machine out of its own
+// passthrough. TestNaiveMintLocksOutHome pins that the naive mint really
+// produces the lockout state — it is the counterfactual that makes the
+// guard in TestMintDeviceKeepsHomeRoutingToken mean something, and it is
+// the exact arrangement the FAIL-first run of the guard assertion was
+// shown red against (see the round report).
+
+import (
+	"bytes"
+	"image/png"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/pairing"
+)
+
+// pairflowHome stands up a temp GADAK_HOME with a standalone workspace —
+// the shape the mint flow operates on — and returns (dir, cfg).
+func pairflowHome(t *testing.T) (string, *config.Config) {
+	t.Helper()
+	for _, k := range []string{"GADAK_SITE", "GADAK_EMAIL", "GADAK_TOKEN", "GADAK_PROJECTS"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("GADAK_HOME", t.TempDir())
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = config.KindStandalone
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	return cfg.Directory(), cfg
+}
+
+// homeRoutingTokenUsable is the guard assertion: remote-origin.json holds
+// a credential the store still accepts. Everything else in the guard test
+// decorates this one check.
+func homeRoutingTokenUsable(t *testing.T, dir string, now time.Time) {
+	t.Helper()
+	rem, err := pairing.LoadRemote(dir)
+	if err != nil {
+		t.Fatalf("remote-origin.json unreadable: %v", err)
+	}
+	if rem == nil {
+		t.Fatal("no _home routing token in remote-origin.json — the home machine's own writes cannot pass the gate it just turned on")
+	}
+	v, err := pairing.Authorize(dir, rem.Token, now)
+	if err != nil {
+		t.Fatalf("authorizing the routing token: %v", err)
+	}
+	if v != pairing.VerdictAccept {
+		t.Fatalf("stored routing token verdict is %v, want accept", v)
+	}
+}
+
+// TestMintDeviceKeepsHomeRoutingToken is the guard: after a device mint on
+// a standalone home, the _home routing token exists and authorizes. First
+// mint reports minted; a second mint (credential already valid) reports
+// none; a stale credential (file token no longer in the store — the
+// GDK-450 shape) is reissued by the next mint.
+func TestMintDeviceKeepsHomeRoutingToken(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	now := time.Now()
+	endpoint := "http://127.0.0.1:7877"
+
+	res, err := MintDevice(dir, cfg, "phone", pairing.ScopeServe, "1h", endpoint, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.HomeRouting != HomeRoutingMinted {
+		t.Fatalf("first mint reports %q, want minted", res.HomeRouting)
+	}
+	homeRoutingTokenUsable(t, dir, now)
+
+	if _, err := MintDevice(dir, cfg, "tablet", pairing.ScopeServe, "1h", endpoint, now); err != nil {
+		t.Fatal(err)
+	}
+	homeRoutingTokenUsable(t, dir, now)
+
+	// GDK-450 recovery: corrupt the stored credential's token (the file
+	// entry no longer matches any store hash) — the next mint reissues.
+	rem, err := pairing.LoadRemote(dir)
+	if err != nil || rem == nil {
+		t.Fatalf("fixture: routing token missing before the stale step: %v %v", rem, err)
+	}
+	stale := strings.Repeat("s", len(rem.Token))
+	if err := pairing.SaveRemote(dir, pairing.Remote{Endpoint: rem.Endpoint, Token: stale, Label: rem.Label}); err != nil {
+		t.Fatal(err)
+	}
+	res, err = MintDevice(dir, cfg, "laptop", pairing.ScopeServe, "1h", endpoint, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.HomeRouting != HomeRoutingReissued {
+		t.Fatalf("mint after a stale credential reports %q, want reissued", res.HomeRouting)
+	}
+	homeRoutingTokenUsable(t, dir, now)
+}
+
+// TestNaiveMintLocksOutHome pins the counterfactual: pairing.MintScoped
+// called directly — what a second surface that skipped pairflow would do —
+// leaves the gate on with no routing token. If this ever fails because
+// MintScoped itself mints _home, the guard has moved and
+// TestMintDeviceKeepsHomeRoutingToken should move with it.
+func TestNaiveMintLocksOutHome(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	now := time.Now()
+	if _, _, err := pairing.MintScoped(dir, "phone", pairing.ScopeServe, time.Hour, now); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := pairing.Authorize(dir, "", now); err != nil || v != pairing.VerdictReject {
+		t.Fatalf("gate after a naive mint is %v (%v), want reject — the device token alone must close it", v, err)
+	}
+	if rem, err := pairing.LoadRemote(dir); err != nil || rem != nil {
+		t.Fatalf("naive mint left a routing token (%v %v) — it cannot; only the guard writes one", rem, err)
+	}
+	// And the guard assertion, applied to this dir, is the FAIL-first
+	// arrangement: homeRoutingTokenUsable(t, dir, now) fails here. It is
+	// asserted by refusal above; calling it would abort this test.
+	_ = cfg
+}
+
+// TestMintDeviceContract pins the mint result itself: offer round-trips,
+// fields carry what was asked, expiry honors the ttl, the loopback flag
+// answers for both kinds of endpoint, and the reserved label is refused.
+func TestMintDeviceContract(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	res, err := MintDevice(dir, cfg, "phone", pairing.ScopeServe, "2h", "http://192.0.2.10:7877", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offer, err := pairing.DecodeOffer(res.Offer)
+	if err != nil {
+		t.Fatalf("mint result does not round-trip: %v", err)
+	}
+	if offer.Endpoint != "http://192.0.2.10:7877" || offer.Label != "phone" || offer.V != pairing.OfferV1 {
+		t.Fatalf("offer carries %+v", offer)
+	}
+	if res.Endpoint != offer.Endpoint || res.Label != "phone" || res.Scope != pairing.ScopeServe {
+		t.Fatalf("result fields carry %+v", res)
+	}
+	if res.ExpiresAt != pairing.FormatExpiry(now.Add(2*time.Hour)) {
+		t.Fatalf("expires_at is %q, want the mint time + 2h", res.ExpiresAt)
+	}
+	if res.LoopbackWarning {
+		t.Fatal("a TEST-NET endpoint is not loopback")
+	}
+	if res.HomeRouting != HomeRoutingMinted {
+		t.Fatalf("standalone mint reports %q, want minted", res.HomeRouting)
+	}
+
+	// The warning is the caller's copy to render; both polarities are data.
+	loop, err := MintDevice(dir, cfg, "tablet", pairing.ScopeServe, "1h", "http://localhost:7877", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loop.LoopbackWarning {
+		t.Fatal("localhost is loopback — the mint must say so")
+	}
+
+	// Refusals, each naming its own cause.
+	if _, err := MintDevice(dir, cfg, "", pairing.ScopeServe, "1h", "http://192.0.2.10:7877", now); err == nil ||
+		!strings.Contains(err.Error(), "--label") {
+		t.Fatalf("empty label refused with: %v", err)
+	}
+	if _, err := MintDevice(dir, cfg, pairing.HomeLabel, pairing.ScopeServe, "1h", "http://192.0.2.10:7877", now); err == nil ||
+		!strings.Contains(err.Error(), pairing.HomeLabel) {
+		t.Fatalf("_home label refused with: %v", err)
+	}
+	if _, err := MintDevice(dir, cfg, "watch", "admin", "1h", "http://192.0.2.10:7877", now); err == nil ||
+		!strings.Contains(err.Error(), "unknown scope") {
+		t.Fatalf("unknown scope refused with: %v", err)
+	}
+	if _, err := MintDevice(dir, cfg, "watch", pairing.ScopeServe, "1x", "http://192.0.2.10:7877", now); err == nil ||
+		!strings.Contains(err.Error(), "bad ttl") {
+		t.Fatalf("bad ttl refused with: %v", err)
+	}
+	if _, err := MintDevice(dir, cfg, "watch", pairing.ScopeServe, "1h", "ftp://192.0.2.10:7877", now); err == nil ||
+		!strings.Contains(err.Error(), "bad endpoint") {
+		t.Fatalf("non-http endpoint refused with: %v", err)
+	}
+	// No explicit endpoint and no live serve: the orphan-token refusal.
+	if _, err := MintDevice(dir, cfg, "watch", pairing.ScopeServe, "1h", "", now); err == nil ||
+		!strings.Contains(err.Error(), "no live serve") {
+		t.Fatalf("endpoint-less mint without a serve refused with: %v", err)
+	}
+}
+
+// TestMintDeviceConnectedWritesNoRoutingFile: a connected workspace's
+// writes go straight to its site — remote-origin.json must not appear, or
+// origin.pairedRemote would read the workspace as paired with its own
+// serve.
+func TestMintDeviceConnectedWritesNoRoutingFile(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	cfg.Kind = ""
+	cfg.Site = "https://example.atlassian.net"
+	cfg.Email = "home@example.net"
+	cfg.Token = "secret-not-a-pairing-token"
+	now := time.Now()
+
+	res, err := MintDevice(dir, cfg, "phone", pairing.ScopeServe, "1h", "http://192.0.2.10:7877", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.HomeRouting != HomeRoutingNone {
+		t.Fatalf("connected mint reports %q, want none", res.HomeRouting)
+	}
+	if rem, err := pairing.LoadRemote(dir); err != nil || rem != nil {
+		t.Fatalf("connected mint wrote a routing file: %v %v", rem, err)
+	}
+}
+
+// TestMintHomeRotationAndRefusal: _home rotation answers with the meta the
+// caller prints, refuses a non-standalone workspace, and — like the device
+// mint — refuses to guess an endpoint.
+func TestMintHomeRotationAndRefusal(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	now := time.Now()
+
+	meta, err := MintHome(dir, cfg, "http://127.0.0.1:7877", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(meta.Hash) < 8 {
+		t.Fatalf("rotation meta hash is %q", meta.Hash)
+	}
+	homeRoutingTokenUsable(t, dir, now)
+
+	cfg.Kind = ""
+	cfg.Site = "https://example.atlassian.net"
+	cfg.Email = "home@example.net"
+	cfg.Token = "secret-not-a-pairing-token"
+	if _, err := MintHome(dir, cfg, "http://127.0.0.1:7877", now); err == nil ||
+		!strings.Contains(err.Error(), "standalone") {
+		t.Fatalf("connected _home mint refused with: %v", err)
+	}
+}
+
+// TestDirRefusals: a workspace paired away cannot mint (its home is
+// another machine), and a workspace with no credential cannot either.
+func TestDirRefusals(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	// Paired away: connected workspace holding a remote credential.
+	if err := pairing.SaveRemote(dir, pairing.Remote{Endpoint: "http://192.0.2.10:7877", Token: "paired-away-not-a-pairing-token", Label: "desk"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Kind = ""
+	cfg.Site = "https://example.atlassian.net"
+	cfg.Email = "home@example.net"
+	cfg.Token = "secret-not-a-pairing-token"
+	if _, err := Dir(cfg); err == nil || !strings.Contains(err.Error(), "run on the home machine") {
+		t.Fatalf("paired-away mint refused with: %v", err)
+	}
+
+	// No credential at all.
+	_, cfg2 := pairflowHome(t)
+	cfg2.Kind = ""
+	if _, err := Dir(cfg2); err == nil {
+		t.Fatal("a workspace with no credential must not mint")
+	}
+}
+
+// TestParseTTLAndDefault: the flow owns the 90d default and the
+// <N><unit> syntax; the CLI wrapper and the desktop form both ride this.
+func TestParseTTLAndDefault(t *testing.T) {
+	for in, want := range map[string]time.Duration{
+		"90d":  90 * 24 * time.Hour,
+		"1h":   time.Hour,
+		"30m":  30 * time.Minute,
+		"45s":  45 * time.Second,
+		" 2d ": 48 * time.Hour,
+	} {
+		got, err := ParseTTL(in)
+		if err != nil || got != want {
+			t.Fatalf("ParseTTL(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"", "0d", "-1h", "1w", "d", "1.5h", "1x"} {
+		if _, err := ParseTTL(bad); err == nil {
+			t.Fatalf("ParseTTL(%q) accepted", bad)
+		}
+	}
+	if got := DefaultTTLFlag(); got != "90d" {
+		t.Fatalf("DefaultTTLFlag() = %q, want 90d", got)
+	}
+	if DefaultTTL != 90*24*time.Hour {
+		t.Fatalf("DefaultTTL = %v", DefaultTTL)
+	}
+}
+
+// TestEndpointFromAdvertise: a bare bind address gains the http scheme the
+// URL validation demands; an address that already names one is left alone.
+func TestEndpointFromAdvertise(t *testing.T) {
+	for in, want := range map[string]string{
+		"":                  "",
+		"127.0.0.1:7877":    "http://127.0.0.1:7877",
+		"[::1]:7877":        "http://[::1]:7877",
+		"https://h.example": "https://h.example",
+	} {
+		if got := EndpointFromAdvertise(in); got != want {
+			t.Fatalf("EndpointFromAdvertise(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// No live serve in an empty home: discovery answers empty, not an
+	// error — the mint turns it into the no-live-serve refusal.
+	pairflowHome(t)
+	var nilCfg *config.Config
+	if got := AdvertisedEndpoint(nilCfg); got != "" {
+		t.Fatalf("AdvertisedEndpoint with no serve = %q, want empty", got)
+	}
+}
+
+// TestRowsShaping: list rows never carry the token or the full hash, the
+// _home row reads as local-routing, and state separates active, expired,
+// and revoked.
+func TestRowsShaping(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	if _, err := MintDevice(dir, cfg, "phone", pairing.ScopeServe, "1h", "http://192.0.2.10:7877", now); err != nil {
+		t.Fatal(err)
+	}
+	// An already-expired token (minted "in the past" relative to listing).
+	if _, err := MintDevice(dir, cfg, "old-tablet", pairing.ScopeServe, "1h", "http://192.0.2.10:7877", now.Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MintHome(dir, cfg, "http://192.0.2.10:7877", now); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := Rows(dir, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byLabel := map[string]Row{}
+	for _, r := range rows {
+		byLabel[r.Label] = r
+		if len(r.Hash) != 8 {
+			t.Fatalf("row for %q carries hash %q — want the 8-char prefix only", r.Label, r.Hash)
+		}
+	}
+	if n := len(byLabel); n != 3 {
+		t.Fatalf("Rows returned %d labels, want 3 (phone, old-tablet, _home): %+v", n, rows)
+	}
+	if r := byLabel["phone"]; r.Scope != pairing.ScopeServe || r.State != "active" || r.LastUsed != "-" {
+		t.Fatalf("phone row is %+v", r)
+	}
+	if r := byLabel["old-tablet"]; r.State != "expired" {
+		t.Fatalf("old-tablet row state is %q, want expired", r.State)
+	}
+	if r := byLabel[pairing.HomeLabel]; r.Scope != pairing.ScopeLocalRouting {
+		t.Fatalf("_home row scope is %q, want %s", r.Scope, pairing.ScopeLocalRouting)
+	}
+	// Revoke leaves a row (audit), marked.
+	if _, err := Revoke(dir, "phone", now); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = Rows(dir, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if r.Label == "phone" && !strings.HasPrefix(r.State, "revoked ") {
+			t.Fatalf("revoked phone row state is %q", r.State)
+		}
+	}
+	// Revoke refuses _home with the pinned sentence (the desktop
+	// classifies by it).
+	if _, err := Revoke(dir, pairing.HomeLabel, now); err == nil ||
+		!strings.Contains(err.Error(), "_home is this machine's own routing key") {
+		t.Fatalf("_home revoke refused with: %v", err)
+	}
+}
+
+// TestQRPNGIsTheMatrix: the PNG a phone scans and the matrix the terminal
+// renders are the same code — every pixel answers its module, the quiet
+// zone is white, and the side is modules × 8.
+func TestQRPNGIsTheMatrix(t *testing.T) {
+	dir, cfg := pairflowHome(t)
+	res, err := MintDevice(dir, cfg, "phone", pairing.ScopeServe, "1h", "http://192.0.2.10:7877", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mods, err := QRModules(res.Offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := QRPNG(res.Offer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("QRPNG does not decode: %v", err)
+	}
+	side := len(mods) * 8
+	if img.Bounds().Dx() != side || img.Bounds().Dy() != side {
+		t.Fatalf("QR PNG is %dx%d, want %dx%d (modules %d × 8)", img.Bounds().Dx(), img.Bounds().Dy(), side, side, len(mods))
+	}
+	dark := 0
+	for y := 0; y < side; y++ {
+		for x := 0; x < side; x++ {
+			r, g, b, _ := img.At(x, y).RGBA()
+			black := mods[y/8][x/8]
+			if black {
+				dark++
+				if r != 0 || g != 0 || b != 0 {
+					t.Fatalf("pixel (%d,%d) should be black for a dark module", x, y)
+				}
+			} else {
+				if r != 0xffff || g != 0xffff || b != 0xffff {
+					t.Fatalf("pixel (%d,%d) should be white for a light module", x, y)
+				}
+			}
+		}
+	}
+	// The finder pattern's dark modules must exist (a blank rect passes
+	// the pixel-map loop above if the matrix itself were all false).
+	if dark == 0 {
+		t.Fatal("the PNG carries no dark module")
+	}
+}

--- a/web/src/components/settings/DevicesTab.svelte
+++ b/web/src/components/settings/DevicesTab.svelte
@@ -1,0 +1,390 @@
+<script lang="ts">
+  /*
+   * Devices (desktop only) — GDK-1047, the UI half of phone pairing.
+   *
+   * Mint a pairing offer, show it as the same QR the terminal draws, and
+   * revoke devices that are gone. The mint and revoke run through
+   * /desktop/pairing — the desktop app's route over internal/pairflow —
+   * so this tab and `gadak pairing` operate the identical token store.
+   *
+   * The offer is a credential, and this screen is credential UI: the QR is
+   * the intended transport (scan with the phone), the offer STRING stays
+   * masked behind an explicit reveal for the paste-into-terminal case, and
+   * none of it is persisted — component state only, gone when the dialog
+   * closes. The mask is not security theater around the QR: a QR and its
+   * plaintext are the same bytes; the reveal exists so a shoulder-surfing
+   * thumbnail or a screenshot of the tab does not carry the credential.
+   *
+   * Scope is deliberately two choices. A terminal token opens a shell on
+   * this machine and is minted from the terminal, not from a form; the
+   * server refuses it too (bad_scope), and this select never offers it.
+   */
+  import { onMount } from 'svelte'
+  import { t, type MessageKey } from '../../lib/i18n'
+  import { copyText } from '../../lib/copy-text'
+  import LoadingState from '../ui/LoadingState.svelte'
+  import { ADD_BTN, COPY_BTN, INPUT, SELECT, SELECT_CHEVRON } from './controls'
+
+  interface DeviceRow {
+    label: string
+    scope: string
+    expires_at: string
+    hash_prefix: string
+    state: string
+  }
+
+  /** The one place the freshly minted credential lives. Never persisted. */
+  interface Minted {
+    offer: string
+    label: string
+    endpoint: string
+    expires_at: string
+    hash_prefix: string
+    loopback_warning: boolean
+    qr_png: string
+  }
+
+  let devices = $state<DeviceRow[]>([])
+  let advertised = $state('')
+  /** not_configured | paired_away | null — why the mint form is disabled. */
+  let unavailable = $state<string | null>(null)
+  let loading = $state(true)
+  let loadError = $state<string | null>(null)
+
+  let label = $state('')
+  let scope = $state<'serve' | 'origin'>('serve')
+  let endpoint = $state('')
+  let ttl = $state('')
+  let minting = $state(false)
+  let mintError = $state<string | null>(null)
+  let minted = $state<Minted | null>(null)
+  let revealed = $state(false)
+  let offerCopied = $state(false)
+
+  /** Server scope values → row copy. local-routing is the _home row. */
+  function scopeLabel(scope: string): string {
+    if (scope === 'local-routing') return t('settings.devicesScopeLocalRouting')
+    if (scope === 'origin') return t('settings.devicesScopeOrigin')
+    return t('settings.devicesScopeServe')
+  }
+
+  /** active | expired | revoked <ts> → one word; the timestamp stays. */
+  function stateLabel(state: string): string {
+    if (state.startsWith('revoked')) return t('settings.devicesStateRevoked')
+    if (state === 'expired') return t('settings.devicesStateExpired')
+    return t('settings.devicesStateActive')
+  }
+
+  const MINT_ERROR: Record<string, MessageKey> = {
+    label_required: 'settings.devicesErrLabelRequired',
+    reserved_label: 'settings.devicesErrReservedLabel',
+    bad_scope: 'settings.devicesErrBadScope',
+    bad_endpoint: 'settings.devicesErrBadEndpoint',
+    bad_ttl: 'settings.devicesErrBadTtl',
+    no_serve: 'settings.devicesErrNoServe',
+    label_exists: 'settings.devicesErrLabelExists',
+    not_configured: 'settings.devicesUnavailableNotConfigured',
+    paired_away: 'settings.devicesUnavailablePairedAway',
+    mint_failed: 'settings.devicesErrFailed',
+  }
+
+  async function load(): Promise<void> {
+    loading = true
+    try {
+      const res = await fetch('/desktop/pairing')
+      if (!res.ok) throw new Error(String(res.status))
+      const doc = (await res.json()) as {
+        devices: DeviceRow[]
+        advertised_endpoint?: string
+        unavailable?: string
+      }
+      devices = doc.devices ?? []
+      advertised = doc.advertised_endpoint ?? ''
+      unavailable = doc.unavailable ?? null
+      // Prefill once: the advertised endpoint is what the phone would
+      // reach; the user edits it when a tailnet URL is the better answer.
+      if (endpoint === '' && advertised !== '') endpoint = advertised
+      loadError = null
+    } catch {
+      // The route lives on the desktop app's mux only. Reaching this in
+      // the desktop app means the server is older or broken, not that the
+      // device list is empty — so say "could not read", never draw zero
+      // devices. Rows already on screen stay: the error is a banner.
+      loadError = t('settings.devicesLoadFailed')
+    }
+    loading = false
+  }
+
+  onMount(load)
+
+  async function mint(): Promise<void> {
+    if (minting || unavailable !== null) return
+    minting = true
+    mintError = null
+    try {
+      const res = await fetch('/desktop/pairing/mint', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: label.trim(), scope, ttl: ttl.trim(), endpoint: endpoint.trim() }),
+      })
+      if (!res.ok) {
+        const doc = (await res.json().catch(() => ({}))) as { error?: string }
+        mintError = t(MINT_ERROR[doc.error ?? ''] ?? 'settings.devicesErrFailed')
+        return
+      }
+      minted = (await res.json()) as Minted
+      revealed = false
+      offerCopied = false
+      // The new token is in the store now; the list should say so.
+      await load()
+    } catch {
+      mintError = t('settings.devicesErrFailed')
+    } finally {
+      minting = false
+    }
+  }
+
+  async function revoke(row: DeviceRow): Promise<void> {
+    try {
+      const res = await fetch('/desktop/pairing/revoke', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ selector: row.label }),
+      })
+      if (!res.ok) {
+        const doc = (await res.json().catch(() => ({}))) as { error?: string }
+        // not_found / already_revoked both mean "the list knows better" —
+        // reload rather than argue with a stale row.
+        if (doc.error !== 'not_found' && doc.error !== 'already_revoked') {
+          mintError = t('settings.devicesErrFailed')
+          return
+        }
+      }
+      await load()
+    } catch {
+      mintError = t('settings.devicesErrFailed')
+    }
+  }
+
+  async function copyOffer(): Promise<void> {
+    if (!minted) return
+    // copy-text.ts owns the desktop-vs-web transport (GDK-178); "copied"
+    // shows only for a write that actually happened.
+    if (await copyText(minted.offer)) {
+      offerCopied = true
+      setTimeout(() => {
+        offerCopied = false
+      }, 1500)
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-2.5" data-testid="devices-tab">
+  <p class="text-micro leading-relaxed text-text-muted">{t('settings.devicesIntro')}</p>
+
+  {#if loadError}
+    <div
+      class="flex flex-wrap items-center gap-2 rounded border border-border-subtle bg-bg-elevated px-2 py-1.5"
+      data-testid="devices-error"
+    >
+      <span class="min-w-0 flex-1 text-micro text-status-reopen">{loadError}</span>
+      <button type="button" class={COPY_BTN} disabled={loading} onclick={() => void load()}>
+        {t('settings.integrationRecheck')}
+      </button>
+    </div>
+  {/if}
+
+  {#if unavailable}
+    <p
+      class="rounded border border-border-subtle bg-bg-elevated px-2 py-1.5 text-micro leading-relaxed text-text-secondary"
+      data-testid="devices-unavailable"
+    >
+      {t(unavailable === 'paired_away'
+        ? 'settings.devicesUnavailablePairedAway'
+        : 'settings.devicesUnavailableNotConfigured')}
+    </p>
+  {/if}
+
+  {#if loading && devices.length === 0 && !unavailable}
+    <LoadingState label={t('settings.devicesLoading')} />
+  {:else if devices.length === 0}
+    {#if !loadError && !unavailable}
+      <p class="py-6 text-center text-text-muted">{t('settings.devicesEmpty')}</p>
+    {/if}
+  {:else}
+    <table class="w-full text-micro" data-testid="devices-list">
+      <thead>
+        <tr class="text-left text-text-muted">
+          <th class="py-1 pr-2 font-medium">{t('settings.devicesColLabel')}</th>
+          <th class="py-1 pr-2 font-medium">{t('settings.devicesColScope')}</th>
+          <th class="py-1 pr-2 font-medium">{t('settings.devicesColExpires')}</th>
+          <th class="py-1 pr-2 font-medium">{t('settings.devicesColState')}</th>
+          <th class="py-1 font-medium" aria-label={t('settings.devicesRevoke')}></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each devices as row (row.hash_prefix + row.label)}
+          {@const isHome = row.scope === 'local-routing'}
+          {@const revoked = row.state.startsWith('revoked')}
+          <tr class="border-t border-border-subtle align-top" data-testid="devices-row-{row.label}">
+            <td class="py-1.5 pr-2">
+              <span class="font-mono text-text-primary">{row.label}</span>
+              {#if isHome}
+                <p class="mt-0.5 text-micro leading-relaxed text-text-muted">
+                  {t('settings.devicesHomeRowHint')}
+                </p>
+              {/if}
+            </td>
+            <td class="py-1.5 pr-2 text-text-secondary">{scopeLabel(row.scope)}</td>
+            <!-- nowrap: the vision pass caught every row's date wrapping
+                 mid-value (2026-11- / 25) at the dialog's table width — a
+                 credential table's expiry must read as one token. -->
+            <td class="whitespace-nowrap py-1.5 pr-2 font-mono text-text-secondary">{row.expires_at}</td>
+            <td class="py-1.5 pr-2 {revoked ? 'text-status-reopen' : 'text-text-secondary'}">
+              {stateLabel(row.state)}
+            </td>
+            <td class="py-1.5 text-right">
+              {#if !isHome}
+                <button
+                  type="button"
+                  class={COPY_BTN}
+                  disabled={revoked}
+                  onclick={() => void revoke(row)}
+                  data-testid="devices-revoke-{row.label}"
+                >
+                  {t('settings.devicesRevoke')}
+                </button>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+
+  {#if minted}
+    <!-- The mint result: QR first (the intended transport), offer string
+         masked behind an explicit reveal, everything in component state —
+         closing the dialog drops the credential from memory. -->
+    <section
+      class="rounded-md border border-border-subtle bg-bg-base/60 px-3 py-2.5"
+      data-testid="devices-minted"
+    >
+      <p class="text-micro leading-relaxed text-text-primary">
+        {t('settings.devicesMinted', { label: minted.label, expires: minted.expires_at })}
+      </p>
+      {#if minted.loopback_warning}
+        <p class="mt-1 text-micro leading-relaxed text-status-reopen" data-testid="devices-loopback-warning">
+          {t('settings.devicesLoopbackWarning')}
+        </p>
+      {/if}
+      <div class="mt-2 flex flex-col items-center gap-2">
+        <img
+          src={minted.qr_png}
+          alt={t('settings.devicesQrAlt')}
+          class="h-56 w-56 rounded border border-border-subtle bg-white p-1"
+          data-testid="devices-qr"
+        />
+        <div
+          class="flex w-full max-w-md items-center gap-1.5 rounded border border-border-subtle bg-bg-base px-2 py-1"
+          data-testid="devices-offer"
+        >
+          <span class="sr-only">{t('settings.devicesOfferLabel')}</span>
+          <code
+            class="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-micro text-text-secondary"
+            >{revealed ? minted.offer : `${minted.offer.slice(0, 6)}…${minted.offer.slice(-4)}`}</code
+          >
+          <button
+            type="button"
+            class="{COPY_BTN} flex-none"
+            onclick={() => {
+              revealed = !revealed
+              offerCopied = false
+            }}
+            aria-pressed={revealed}
+            data-testid="devices-offer-reveal"
+          >
+            {t(revealed ? 'settings.devicesOfferHide' : 'settings.devicesOfferShow')}
+          </button>
+          <button
+            type="button"
+            class="{COPY_BTN} flex-none"
+            onclick={() => void copyOffer()}
+            aria-label={t('settings.devicesCopyOffer')}
+            data-testid="devices-offer-copy"
+          >
+            {offerCopied ? t('settings.copied') : t('settings.copy')}
+          </button>
+        </div>
+      </div>
+    </section>
+  {/if}
+
+  {#if unavailable === null}
+    <form
+      class="mt-1 flex flex-wrap items-end gap-2"
+      onsubmit={(e) => {
+        e.preventDefault()
+        void mint()
+      }}
+      data-testid="devices-form"
+    >
+      <label class="flex flex-col gap-1">
+        <span class="text-micro text-text-muted">{t('settings.devicesLabelLabel')}</span>
+        <input
+          class={INPUT}
+          bind:value={label}
+          data-testid="devices-label-input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-micro text-text-muted">{t('settings.devicesScopeLabel')}</span>
+        <select
+          class="{SELECT} {SELECT_CHEVRON}"
+          bind:value={scope}
+          data-testid="devices-scope-select"
+        >
+          <option value="serve">{t('settings.devicesScopeServe')}</option>
+          <option value="origin">{t('settings.devicesScopeOrigin')}</option>
+        </select>
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-micro text-text-muted">{t('settings.devicesEndpointLabel')}</span>
+        <input
+          class={INPUT}
+          bind:value={endpoint}
+          placeholder="http://127.0.0.1:7877"
+          data-testid="devices-endpoint-input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <span class="text-micro text-text-muted">{t('settings.devicesEndpointHint')}</span>
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="text-micro text-text-muted">{t('settings.devicesTtlLabel')}</span>
+        <input
+          class={INPUT}
+          bind:value={ttl}
+          placeholder="90d"
+          data-testid="devices-ttl-input"
+          autocomplete="off"
+          spellcheck="false"
+        />
+      </label>
+      <button
+        type="submit"
+        class={ADD_BTN}
+        disabled={minting}
+        data-testid="devices-mint-button"
+      >
+        {t(minting ? 'settings.devicesMintBusy' : 'settings.devicesMint')}
+      </button>
+    </form>
+  {/if}
+
+  {#if mintError}
+    <p class="text-micro text-status-reopen" data-testid="devices-mint-error">{mintError}</p>
+  {/if}
+</div>

--- a/web/src/components/settings/DevicesTab.test.ts
+++ b/web/src/components/settings/DevicesTab.test.ts
@@ -1,0 +1,174 @@
+/*
+ * GDK-1047 gates for the Devices tab (desktop only). Same story as
+ * FeaturesTab.test.ts: the unit vitest project is environment 'node' with
+ * no svelte plugin, so mounting the component is not a thing this project
+ * can do — the render contract is asserted against the source the
+ * compiler emits, and everything with real logic (tab visibility) is a
+ * genuine unit test against the lib.
+ *
+ * The one behavior this file owns outright: the Devices tab must NOT exist
+ * under gadak serve — neither in the header nor via a pasted
+ * `settings=devices` URL. No e2e spec asserts the tab set (settings.spec
+ * walks tabs by name), so this is where that absence is pinned.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { SETTINGS_TABS } from '../../lib/settings-tabs'
+import { isVisibleSettingsTab, visibleSettingsTabs } from '../../lib/integrations'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const DEVICES_TAB = join(HERE, 'DevicesTab.svelte')
+const SETTINGS_DIALOG = join(HERE, 'SettingsDialog.svelte')
+const MESSAGES = join(HERE, '../../lib/i18n/messages')
+
+function catalogSource(): string {
+  // Copy lives in messages/*.ts ({en,ko,ja} per key), not en.ts/ko.ts/ja.ts.
+  return readdirSync(MESSAGES)
+    .filter((n) => n.endsWith('.ts'))
+    .map((n) => readFileSync(join(MESSAGES, n), 'utf8'))
+    .join('\n')
+}
+
+describe('GDK-1047 devices tab is desktop-only', () => {
+  test('serve hides it from the header (visibleSettingsTabs)', () => {
+    expect(visibleSettingsTabs(SETTINGS_TABS, false)).not.toContain('devices')
+    expect(visibleSettingsTabs(SETTINGS_TABS, true)).toContain('devices')
+  })
+
+  test('serve refuses a pasted settings=devices URL (isVisibleSettingsTab)', () => {
+    expect(isVisibleSettingsTab('devices', SETTINGS_TABS, false)).toBe(false)
+    expect(isVisibleSettingsTab('devices', SETTINGS_TABS, true)).toBe(true)
+  })
+
+  test('the tab sits between integrations and about', () => {
+    const tabs = [...SETTINGS_TABS]
+    expect(tabs.indexOf('devices')).toBe(tabs.indexOf('integrations') + 1)
+    expect(tabs.indexOf('about')).toBe(tabs.indexOf('devices') + 1)
+  })
+})
+
+describe('GDK-1047 devices tab render contract', () => {
+  const src = readFileSync(DEVICES_TAB, 'utf8')
+
+  test('the QR is an <img> fed by the server data URI, not a client-side renderer', () => {
+    expect(src).toMatch(/<img\s[^>]*src=\{minted\.qr_png\}/)
+    // No new npm dependency: nothing imports a QR library.
+    expect(src).not.toMatch(/from '[^']*qr/i)
+    expect(src).not.toMatch(/import\s+qrcode/)
+  })
+
+  test('the offer string is masked until explicitly revealed', () => {
+    // Masked rendering: head…tail, never the full string by default.
+    expect(src).toMatch(/minted\.offer\.slice\(0, 6\)/)
+    expect(src).toMatch(/minted\.offer\.slice\(-4\)/)
+    // The full offer renders only behind the revealed flag.
+    expect(src).toMatch(/\{revealed \? minted\.offer :/)
+    // Reveal is explicit UI state, default hidden.
+    expect(src).toMatch(/let revealed = \$state\(false\)/)
+  })
+
+  test('the credential lives in component state only — no persistence', () => {
+    expect(src).not.toMatch(/localStorage/)
+    expect(src).not.toMatch(/sessionStorage/)
+    expect(src).not.toMatch(/indexedDB/)
+  })
+
+  test('the scope select offers serve and origin only — terminal is not minted from a form', () => {
+    expect(src).toMatch(/<option value="serve">/)
+    expect(src).toMatch(/<option value="origin">/)
+    expect(src).not.toMatch(/<option value="terminal">/)
+  })
+
+  test('the local-routing row (_home) carries no revoke button', () => {
+    expect(src).toMatch(/\{#if !isHome\}/)
+  })
+
+  test('mint errors map server codes to catalog keys, with a fallback', () => {
+    expect(src).toMatch(/MINT_ERROR\[doc\.error \?\? ''\]/)
+    expect(src).toMatch(/'settings\.devicesErrFailed'/)
+  })
+})
+
+describe('GDK-1047 devices tab is wired into the dialog', () => {
+  const dialog = readFileSync(SETTINGS_DIALOG, 'utf8')
+
+  test('labeled, shown, and mounted', () => {
+    expect(dialog).toMatch(/devices: t\('settings\.tabDevices'\)/)
+    expect(dialog).toMatch(/const showDevices = TABS\.some/)
+    expect(dialog).toMatch(/tab === 'devices' && showDevices/)
+    expect(dialog).toMatch(/<DevicesTab \/>/)
+  })
+})
+
+describe('GDK-1047 devices copy is complete in every locale', () => {
+  const catalog = catalogSource()
+
+  // Every key the component or dialog references, pinned here so a rename
+  // fails loudly instead of rendering a raw key.
+  const keys = [
+    'settings.tabDevices',
+    'settings.devicesIntro',
+    'settings.devicesLoadFailed',
+    'settings.devicesLoading',
+    'settings.devicesEmpty',
+    'settings.devicesUnavailableNotConfigured',
+    'settings.devicesUnavailablePairedAway',
+    'settings.devicesColLabel',
+    'settings.devicesColScope',
+    'settings.devicesColExpires',
+    'settings.devicesColState',
+    'settings.devicesScopeServe',
+    'settings.devicesScopeOrigin',
+    'settings.devicesScopeLocalRouting',
+    'settings.devicesLabelLabel',
+    'settings.devicesScopeLabel',
+    'settings.devicesEndpointLabel',
+    'settings.devicesEndpointHint',
+    'settings.devicesTtlLabel',
+    'settings.devicesMint',
+    'settings.devicesMintBusy',
+    'settings.devicesMinted',
+    'settings.devicesLoopbackWarning',
+    'settings.devicesOfferLabel',
+    'settings.devicesOfferShow',
+    'settings.devicesOfferHide',
+    'settings.devicesCopyOffer',
+    'settings.devicesQrAlt',
+    'settings.devicesErrLabelRequired',
+    'settings.devicesErrReservedLabel',
+    'settings.devicesErrBadScope',
+    'settings.devicesErrBadEndpoint',
+    'settings.devicesErrBadTtl',
+    'settings.devicesErrNoServe',
+    'settings.devicesErrLabelExists',
+    'settings.devicesErrFailed',
+    'settings.devicesRevoke',
+    'settings.devicesRevoked',
+    'settings.devicesHomeRowHint',
+    'settings.devicesStateActive',
+    'settings.devicesStateExpired',
+    'settings.devicesStateRevoked',
+  ]
+
+  test.each(keys)('%s exists in the catalog', (key) => {
+    expect(catalog).toMatch(new RegExp(`'${key.replace(/\./g, '\\.')}':`))
+  })
+
+  test('the params the copy interpolates are named, not positional', () => {
+    expect(catalog).toMatch(/'settings\.devicesMinted':[\s\S]*?\{label\}[\s\S]*?\{expires\}/)
+    expect(catalog).toMatch(/'settings\.devicesErrLabelExists':[\s\S]*?\{label\}/)
+  })
+
+  test('every devices entry carries all three locales', () => {
+    const src = readFileSync(join(MESSAGES, 'settings.ts'), 'utf8')
+    const blocks = src.match(/'settings\.devices[A-Za-z]*':\s*\{[\s\S]*?\},/g) ?? []
+    const tab = src.match(/'settings\.tabDevices':\s*\{[\s\S]*?\},/)?.[0] ?? ''
+    for (const block of [...blocks, tab]) {
+      expect(block, `${block.slice(0, 40)}… misses a locale`).toMatch(/en:/)
+      expect(block).toMatch(/ko:/)
+      expect(block).toMatch(/ja:/)
+    }
+  })
+})

--- a/web/src/components/settings/SettingsDialog.svelte
+++ b/web/src/components/settings/SettingsDialog.svelte
@@ -53,6 +53,7 @@
   import MembersTab from './MembersTab.svelte'
   import FieldsTab from './FieldsTab.svelte'
   import IntegrationsTab from './IntegrationsTab.svelte'
+  import DevicesTab from './DevicesTab.svelte'
   import AboutTab from './AboutTab.svelte'
   import { trapFocus } from '../../lib/focus-trap'
   import Icon from '../ui/Icon.svelte'
@@ -73,16 +74,19 @@
     members: t('settings.tabMembers'),
     fields: t('settings.tabFields'),
     integrations: t('settings.tabIntegrations'),
+    devices: t('settings.tabDevices'),
     about: t('settings.tabAbout'),
   }
   /* Header order is SETTINGS_TABS order, minus the tabs this surface has no
-     server for (Integrations is desktop-only). One list, so the header and the
-     `settings=` URL guard can never disagree about what exists. */
+     server for (Integrations and Devices are desktop-only). One list, so the
+     header and the `settings=` URL guard can never disagree about what
+     exists. */
   const TABS: [Tab, string][] = visibleSettingsTabs(SETTINGS_TABS, isDesktop()).map((id) => [
     id,
     LABELS[id],
   ])
   const showIntegrations = TABS.some(([id]) => id === 'integrations')
+  const showDevices = TABS.some(([id]) => id === 'devices')
 
   let loading = $state(true)
   let saving = $state(false)
@@ -364,6 +368,8 @@
           <MembersTab bind:draft bind:openMember />
         {:else if tab === 'integrations' && showIntegrations}
           <IntegrationsTab />
+        {:else if tab === 'devices' && showDevices}
+          <DevicesTab />
         {:else if tab === 'about'}
           <AboutTab {runtime} />
         {:else}

--- a/web/src/lib/i18n/messages/settings.ts
+++ b/web/src/lib/i18n/messages/settings.ts
@@ -705,6 +705,218 @@ export const settings = {
     ko: '설치하기 전에 먼저 준비해야 할 것이 있습니다.',
     ja: 'インストールの前に用意が必要なものがあります。',
   },
+
+  /* ── Devices (desktop only, GDK-1047) ── */
+  'settings.tabDevices': {
+    en: 'Devices',
+    ko: '기기',
+    ja: 'デバイス',
+  },
+  'settings.devicesIntro': {
+    en: 'Pair a phone or another gadak with this workspace: mint a pairing offer, let the device scan its QR, and revoke any device here once it is gone.',
+    ko: '휴대폰이나 다른 gadak를 이 워크스페이스에 연결합니다: 페어링 오퍼를 발급해 기기가 QR을 스캔하게 하고, 떠난 기기는 여기서 해지하세요.',
+    ja: 'スマホや別のgadakをこのワークスペースに組み込みます：ペアリングオファーを発行して端末にQRをスキャンさせ、いなくなった端末はここで失効させます。',
+  },
+  'settings.devicesLoadFailed': {
+    en: 'Could not read the device list from the app. Try again, or check the desktop app.',
+    ko: '앱에서 기기 목록을 읽지 못했습니다. 다시 시도하거나 데스크톱 앱을 확인하세요.',
+    ja: 'アプリから端末一覧を読めませんでした。再試行するか、デスクトップアプリを確認してください。',
+  },
+  'settings.devicesLoading': {
+    en: 'Loading devices…',
+    ko: '기기를 불러오는 중…',
+    ja: '端末を読み込み中…',
+  },
+  'settings.devicesEmpty': {
+    en: 'No paired devices yet. Pair one below.',
+    ko: '아직 연결된 기기가 없습니다. 아래에서 연결하세요.',
+    ja: 'まだ組み込んだ端末がありません。下から組み込んでください。',
+  },
+  'settings.devicesUnavailableNotConfigured': {
+    en: 'This workspace has no origin yet — set it up before pairing devices.',
+    ko: '이 워크스페이스에는 아직 원본이 없습니다 — 기기를 연결하기 전에 먼저 설정하세요.',
+    ja: 'このワークスペースにはまだオリジンがありません — 端末を組み込む前に設定してください。',
+  },
+  'settings.devicesUnavailablePairedAway': {
+    en: 'This workspace is itself paired with another machine. Devices are minted on the home machine.',
+    ko: '이 워크스페이스는 다른 머신에 연결되어 있습니다. 기기 발급은 홈 머신에서 합니다.',
+    ja: 'このワークスペース自体が別のマシンに組み込まれています。端末の発行はホームマシンで行います。',
+  },
+  'settings.devicesColLabel': {
+    en: 'Device',
+    ko: '기기',
+    ja: '端末',
+  },
+  'settings.devicesColScope': {
+    en: 'Scope',
+    ko: '권한',
+    ja: 'スコープ',
+  },
+  'settings.devicesColExpires': {
+    en: 'Expires',
+    ko: '만료',
+    ja: '有効期限',
+  },
+  'settings.devicesColState': {
+    en: 'State',
+    ko: '상태',
+    ja: '状態',
+  },
+  'settings.devicesScopeServe': {
+    en: 'Mirror API (phone app)',
+    ko: '미러 API (휴대폰 앱)',
+    ja: 'ミラーAPI（スマホアプリ）',
+  },
+  'settings.devicesScopeOrigin': {
+    en: 'Origin passthrough (another gadak)',
+    ko: '원본 패스스루 (다른 gadak)',
+    ja: 'オリジンパススルー（別のgadak）',
+  },
+  'settings.devicesScopeLocalRouting': {
+    en: 'This machine (routing key)',
+    ko: '이 머신 (라우팅 키)',
+    ja: 'このマシン（ルーティングキー）',
+  },
+  'settings.devicesLabelLabel': {
+    en: 'Device name',
+    ko: '기기 이름',
+    ja: '端末名',
+  },
+  'settings.devicesScopeLabel': {
+    en: 'What the token opens',
+    ko: '토큰이 여는 것',
+    ja: 'トークンが開くもの',
+  },
+  'settings.devicesEndpointLabel': {
+    en: 'Endpoint',
+    ko: '엔드포인트',
+    ja: 'エンドポイント',
+  },
+  'settings.devicesEndpointHint': {
+    en: 'Empty uses the live serve address of this machine.',
+    ko: '비워 두면 이 머신의 실행 중인 serve 주소를 사용합니다.',
+    ja: '空欄にすると、このマシンの稼働中のserveアドレスを使います。',
+  },
+  'settings.devicesTtlLabel': {
+    en: 'Lifetime',
+    ko: '수명',
+    ja: '有効期間',
+  },
+  'settings.devicesMint': {
+    en: 'Pair device',
+    ko: '기기 연결',
+    ja: '端末を組み込む',
+  },
+  'settings.devicesMintBusy': {
+    en: 'Minting…',
+    ko: '발급 중…',
+    ja: '発行中…',
+  },
+  'settings.devicesMinted': {
+    en: 'Paired {label}. The offer is reusable until {expires} — scan it with the phone now.',
+    ko: '{label} 연결됨. 오퍼는 {expires}까지 재사용 가능합니다 — 지금 휴대폰으로 스캔하세요.',
+    ja: '{label} を組み込みました。オファーは {expires} まで再利用できます — 今すぐスマホでスキャンしてください。',
+  },
+  'settings.devicesLoopbackWarning': {
+    en: 'This endpoint is loopback — only a device on this machine can reach it. Use the tailnet URL instead (e.g. https://<machine>.<tailnet>.ts.net).',
+    ko: '이 엔드포인트는 루프백입니다 — 이 머신의 기기만 접근할 수 있습니다. 테일넷 URL(예: https://<machine>.<tailnet>.ts.net)을 사용하세요.',
+    ja: 'このエンドポイントはループバックです — このマシンの端末しか届きません。TailnetのURL（例: https://<machine>.<tailnet>.ts.net）を使ってください。',
+  },
+  'settings.devicesOfferLabel': {
+    en: 'Pairing offer',
+    ko: '페어링 오퍼',
+    ja: 'ペアリングオファー',
+  },
+  'settings.devicesOfferShow': {
+    en: 'Show',
+    ko: '표시',
+    ja: '表示',
+  },
+  'settings.devicesOfferHide': {
+    en: 'Hide',
+    ko: '숨기기',
+    ja: '隠す',
+  },
+  'settings.devicesCopyOffer': {
+    en: 'Copy offer',
+    ko: '오퍼 복사',
+    ja: 'オファーをコピー',
+  },
+  'settings.devicesQrAlt': {
+    en: 'Pairing QR code',
+    ko: '페어링 QR 코드',
+    ja: 'ペアリングQRコード',
+  },
+  'settings.devicesErrLabelRequired': {
+    en: 'Name the device first.',
+    ko: '먼저 기기 이름을 입력하세요.',
+    ja: 'まず端末名を入力してください。',
+  },
+  'settings.devicesErrReservedLabel': {
+    en: 'The name _home is the routing key of this machine — pick another name.',
+    ko: '_home는 이 머신의 라우팅 키입니다 — 다른 이름을 쓰세요.',
+    ja: '_home はこのマシンのルーティングキーです — 別の名前にしてください。',
+  },
+  'settings.devicesErrBadScope': {
+    en: 'That scope cannot be minted here.',
+    ko: '이곳에서 발급할 수 없는 권한입니다.',
+    ja: 'ここでは発行できないスコープです。',
+  },
+  'settings.devicesErrBadEndpoint': {
+    en: 'The endpoint must be an http(s) URL.',
+    ko: '엔드포인트는 http(s) URL이어야 합니다.',
+    ja: 'エンドポイントはhttp(s) URLである必要があります。',
+  },
+  'settings.devicesErrBadTtl': {
+    en: 'Lifetime must look like 90d, 12h, 30m, or 45s.',
+    ko: '수명은 90d, 12h, 30m, 45s 형식이어야 합니다.',
+    ja: '有効期間は 90d、12h、30m、45s の形である必要があります。',
+  },
+  'settings.devicesErrNoServe': {
+    en: 'No live serve found for this workspace — start one, or fill in the endpoint.',
+    ko: '이 워크스페이스의 실행 중인 serve를 찾지 못했습니다 — 하나 띄우거나 엔드포인트를 입력하세요.',
+    ja: 'このワークスペースの稼働中のserveが見つかりません — 起動するか、エンドポイントを入力してください。',
+  },
+  'settings.devicesErrLabelExists': {
+    en: 'An active token named {label} already exists — revoke it first, or pick another name.',
+    ko: '이름이 {label}인 활성 토큰이 이미 있습니다 — 먼저 해지하거나 다른 이름을 쓰세요.',
+    ja: '{label} という名前の有効なトークンがすでにあります — 先に失効させるか、別の名前にしてください。',
+  },
+  'settings.devicesErrFailed': {
+    en: 'The mint failed.',
+    ko: '발급에 실패했습니다.',
+    ja: '発行に失敗しました。',
+  },
+  'settings.devicesRevoke': {
+    en: 'Revoke',
+    ko: '해지',
+    ja: '失効',
+  },
+  'settings.devicesRevoked': {
+    en: 'Revoked {label}.',
+    ko: '{label} 해지됨.',
+    ja: '{label} を失効させました。',
+  },
+  'settings.devicesHomeRowHint': {
+    en: 'The routing key of this machine. Rotate it from the terminal: gadak pairing mint --label _home',
+    ko: '이 머신의 라우팅 키입니다. 터미널에서 교체하세요: gadak pairing mint --label _home',
+    ja: 'このマシンのルーティングキーです。ターミナルから交代してください: gadak pairing mint --label _home',
+  },
+  'settings.devicesStateActive': {
+    en: 'Active',
+    ko: '활성',
+    ja: '有効',
+  },
+  'settings.devicesStateExpired': {
+    en: 'Expired',
+    ko: '만료됨',
+    ja: '期限切れ',
+  },
+  'settings.devicesStateRevoked': {
+    en: 'Revoked',
+    ko: '해지됨',
+    ja: '失効',
+  },
   'settings.groupLabels': {
     en: 'Group labels & colors',
     ko: '그룹 라벨·색상',

--- a/web/src/lib/integrations.ts
+++ b/web/src/lib/integrations.ts
@@ -371,10 +371,11 @@ export function installBlocked(item: IntegrationItem): boolean {
 /**
  * Settings tabs that only exist inside the desktop app, because the server
  * behind them only exists there. A browser tab asking `/desktop/integrations`
- * gets a 404 from `gadak serve`, so the tab must not be offered — including
- * via a `settings=integrations` URL somebody pasted out of the desktop app.
+ * or `/desktop/pairing` gets a 404 from `gadak serve`, so the tab must not
+ * be offered — including via a `settings=devices` URL somebody pasted out
+ * of the desktop app.
  */
-const DESKTOP_ONLY_SETTINGS_TABS = ['integrations'] as const satisfies readonly SettingsTab[]
+const DESKTOP_ONLY_SETTINGS_TABS = ['integrations', 'devices'] as const satisfies readonly SettingsTab[]
 
 function isDesktopOnlyTab(tab: string): boolean {
   return (DESKTOP_ONLY_SETTINGS_TABS as readonly string[]).includes(tab)

--- a/web/src/lib/settings-tabs.ts
+++ b/web/src/lib/settings-tabs.ts
@@ -12,6 +12,7 @@ export const SETTINGS_TABS = [
   'members',
   'fields',
   'integrations',
+  'devices',
   'about',
 ] as const
 

--- a/web/src/lib/skeleton-grace.test.ts
+++ b/web/src/lib/skeleton-grace.test.ts
@@ -87,6 +87,10 @@ const ALLOWLIST: { file: string; reason: string }[] = [
     reason: 'integration status is a live origin check, not the mirror',
   },
   {
+    file: join(WEB_SRC, 'components/settings/DevicesTab.svelte'),
+    reason: 'pairing device list is an in-process store read, not the mirror',
+  },
+  {
     file: join(WEB_SRC, 'components/write/NewIssueDialog.svelte'),
     reason: 'write-path create-meta; a write in flight is not a read',
   },


### PR DESCRIPTION
The desktop half of GDK-1047. The CLI half (terminal QR) landed as 75c96d43.

- `internal/pairflow`: the mint flow extracted to one owner — endpoint resolution, mint, offer encode, and the `_home` routing-token guard (once any token exists the gate takes Bearer only; skipping the guard locks a standalone home out of its own passthrough). CLI keeps byte-exact output; its 829 package tests pass unmodified.
- `/desktop/pairing` routes (webview-only, in-process — the `/desktop/*` pattern): list (never tokens), mint (origin|serve only; terminal and `_home` refused), revoke. QR ships as a Go-generated PNG data URI — no new web dependency.
- Settings → Devices tab, desktop-only: device list, mint form with the advertised endpoint prefilled, credential-shaped result card (QR first, offer masked behind explicit reveal, component-state only). en/ko/ja.
- FAIL-first on the guard (naive mint leaves no routing token — red), HTTP-boundary test pins offer ⇒ routing token present. Vision verdict: SHIP.

This PR exists because desktop/ is CI-only turf (Windows/Linux desktop builds cannot run locally); every local gate is green: go 46 ok, desktop tests ok, typecheck 0, vitest 796, mobile trio ok, playwright 334, doc-checks, scan-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)