### PR TITLE
ci: windows Go cache keys on both go.sum files; npm ci gets its own step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,7 +761,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: desktop/go.mod
-          cache-dependency-path: desktop/go.sum
+          # build-windows.ps1 builds the ROOT module too (cmd/gadak), so the
+          # cache key must cover both go.sum files — a desktop-only key never
+          # rotates on a root dependency change, which then re-downloads on
+          # every run until desktop/go.sum happens to move (GDK-1036).
+          cache-dependency-path: |
+            go.sum
+            desktop/go.sum
           cache: true
 
       - name: Set up Node
@@ -770,8 +776,15 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      # Two steps, not one: when install and build share a step they share a
+      # duration, and the 2026-08-27 npm-ci swing (a git dependency re-cloned
+      # on every run, 2–6.5 minutes) hid inside "Build the web UI" for weeks
+      # (GDK-1036).
+      - name: Install web dependencies
+        run: npm ci
+
       - name: Build the web UI
-        run: npm ci && npm run build
+        run: npm run build
 
       - name: Pack the Windows app
         shell: pwsh


### PR DESCRIPTION
GDK-1036 investigation applied. Measurement (8 recent main runs + the issue-era trio, GitHub step timestamps):

- The 4m01s–7m05s swing was **100% `npm ci` re-cloning the ghostty-web git dependency** over ssh on every run (run #752: `added 97 packages … in 7m`, vite build 9.11s). npm's tarball cache never covers git deps. GDK-1041 (7b78a9a9) removed that dependency; the job now runs 1m38s–2m07s and is no longer the critical path (race shards are, ~4m35s).
- The PR-fast/main-slow observation in the issue was this network variance, not a structural gap.

No performance edit is warranted. Two hygiene fixes ship instead:

1. **Go cache key covers both go.sum files** — `build-windows.ps1` builds the root module too (`go build ./cmd/gadak`), so a desktop-only key never rotates on a root dependency change and re-downloads on every run until `desktop/go.sum` happens to move.
2. **`npm ci` split from `npm run build`** — the 6m30s npm ci of run #752 was invisible inside one merged step duration; that opacity is why the issue had no step breakdown.

Predicted: one cache-rotation run (~+85s, measured on run #769), then identical timings with proper rotation.

PR route because this touches `.github/workflows/` (the job only runs on windows-latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)