### PR TITLE
desktop: a boot that failed before the window says so on screen (GDK-1243)

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -235,6 +235,14 @@ would try to self-swap.
 - `main.go` opens the profile's mirror (`GADAK_PROFILE` respected), builds the
   API handler, starts the sync loop and update check — the same wiring as
   `cmd/gadak serve`, minus the listener and workspace mounts.
+- A boot failure before any window exists (a mirror schema refusal from a
+  newer gadak, an unreadable config, a locked DB) goes through `bootFatal` in
+  `main.go`: the same stderr + log line the old `log.Fatal`
+  wrote, then a native dialog carrying the error verbatim — `MessageBoxW` on
+  Windows (the `fatal_windows.go` primitive), `osascript display dialog` on
+  macOS. Not a wails dialog: before `application.New`, `application.Get()`
+  is nil, and between New and `app.Run` nothing drains the main-queue
+  dispatch a wails dialog needs. Linux keeps stderr (no shipped artifact).
 - v3's asset server takes one handler, not a file system plus a fallback, so
   `assetHandler` in `main.go` does that split: a GET that names a file in the
   embedded bundle is served from it, everything else goes to `fallbackHandler`.

--- a/desktop/gdk1243_test.go
+++ b/desktop/gdk1243_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/midagedev/gadak/internal/config"
+	"github.com/midagedev/gadak/internal/store"
+
+	_ "modernc.org/sqlite" // pure-Go driver: same one internal/store registers
+)
+
+// TestGDK1243MainRoutesBootErrorToBootFatal is the GDK-1243 wiring half: a
+// boot failure returned from run() (mirror schema refusal, locked DB, any
+// pre-window error) must reach bootFatal — the exit that shows a native
+// dialog — not a bare log.Fatal, which a double-clicked app user never sees.
+// AST pin for the same reason gdk658_test.go parses main.go: main() itself is
+// not callable from a test.
+//
+// FAIL-first: against the pre-fix main (log.Fatal on run's error) the
+// bootFatal lookup fails and log.Fatal is still present.
+func TestGDK1243MainRoutesBootErrorToBootFatal(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mainFn *ast.FuncDecl
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "main" || fn.Recv != nil {
+			continue
+		}
+		mainFn = fn
+		break
+	}
+	if mainFn == nil || mainFn.Body == nil {
+		t.Fatal("func main() not found in main.go")
+	}
+	calls := topLevelCallNames(mainFn.Body)
+	hasBootFatal, hasLogFatal := false, false
+	for _, name := range calls {
+		switch name {
+		case "bootFatal":
+			hasBootFatal = true
+		case "log.Fatal":
+			hasLogFatal = true
+		}
+	}
+	if !hasBootFatal {
+		t.Fatalf("GDK-1243: main() never calls bootFatal — a run() error still dies without a dialog. calls=%v", calls)
+	}
+	if hasLogFatal {
+		t.Fatalf("GDK-1243: main() still calls log.Fatal directly — that path has no dialog. calls=%v", calls)
+	}
+}
+
+// writeFutureMirror builds the GDK-1243 repro home: a scratch GADAK_HOME
+// whose gadak.db carries a user_version no gadak build can read (999 > any
+// len(migrations)). Same technique as internal/store's too-new test.
+func writeFutureMirror(t *testing.T, home string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", "file:"+filepath.Join(home, "gadak.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec("PRAGMA user_version = 999"); err != nil {
+		raw.Close()
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGDK1243FutureMirrorReachesDialogSeam is the runtime half: the exact
+// boot the v0.18.1 measurement saw die silently (scratch home, mirror from a
+// newer gadak) must return run()'s error, and reporting it must hand the
+// store's sentence to the dialog seam verbatim. Headless by construction —
+// the seam is swapped, so no modal runs (the CI macos-14 runner has no user
+// session to dismiss one). The real ~/.gadak is never touched: GADAK_HOME
+// points at t.TempDir().
+func TestGDK1243FutureMirrorReachesDialogSeam(t *testing.T) {
+	home := t.TempDir()
+	writeFutureMirror(t, home)
+	t.Setenv("GADAK_HOME", home)
+	config.SetProfile("")
+	t.Cleanup(func() { config.SetProfile("") })
+
+	err := run()
+	if err == nil {
+		t.Fatal("run() with a future mirror returned nil — it would have opened a window; the refusal is gone")
+	}
+	var tooNew *store.SchemaTooNewError
+	if !errors.As(err, &tooNew) {
+		t.Fatalf("boot failure must be the typed store refusal, got %T: %v", err, err)
+	}
+
+	var gotTitle, gotText string
+	shown := 0
+	orig := showBootErrorDialog
+	showBootErrorDialog = func(title, text string) {
+		shown++
+		gotTitle, gotText = title, text
+	}
+	defer func() { showBootErrorDialog = orig }()
+
+	reportBootFailure(err)
+
+	if shown != 1 {
+		t.Fatalf("dialog seam called %d times, want 1", shown)
+	}
+	if gotTitle != "Gadak" {
+		t.Fatalf("dialog title = %q, want Gadak", gotTitle)
+	}
+	if gotText != tooNew.Error() {
+		t.Fatalf("dialog text must be the store's sentence verbatim — no translation, no summary:\n got: %s\nwant: %s", gotText, tooNew.Error())
+	}
+}
+
+// TestGDK1243ReportKeepsStderrTrail pins the CLI-parity half: the dialog is
+// additive, and the stderr/log line the old log.Fatal wrote still happens.
+func TestGDK1243ReportKeepsStderrTrail(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	orig := showBootErrorDialog
+	showBootErrorDialog = func(string, string) {}
+	defer func() { showBootErrorDialog = orig }()
+
+	reportBootFailure(errors.New("boot boom"))
+
+	if !strings.Contains(buf.String(), "boot boom") {
+		t.Fatalf("stderr/log trail lost; log wrote: %q", buf.String())
+	}
+}
+
+// TestGDK1243BootDialogScriptEscaping: the dialog body is arbitrary error
+// prose — quotes, backslashes (Windows paths in the store's recovery
+// command), line breaks. The AppleScript literal must carry all of them.
+func TestGDK1243BootDialogScriptEscaping(t *testing.T) {
+	script := bootDialogScript("Gad\"ak", "mirror \"x\" at C:\\Users\\a\\b.db\nsecond line")
+	want := "display dialog \"mirror \\\"x\\\" at C:\\\\Users\\\\a\\\\b.db\nsecond line\" with title \"Gad\\\"ak\" with icon stop"
+	if script != want {
+		t.Fatalf("script:\n got: %q\nwant: %q", script, want)
+	}
+}
+
+// TestGDK1243BootDialogScriptCompiles is the artifact/code detector for the
+// AppleScript string: bootDialogScript's output is consumed by an external
+// interpreter, so a Go-level string assertion alone cannot prove it is valid
+// AppleScript. osacompile compiles the production script — with a nasty body
+// and with the real store refusal sentence — without running or showing
+// anything. darwin-only; elsewhere the dialog is not the surface anyway.
+func TestGDK1243BootDialogScriptCompiles(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("osacompile is darwin-only; other GOOS keep stderr as the boot-failure surface")
+	}
+	tooNew := &store.SchemaTooNewError{Path: "/tmp/h/gadak.db", Have: 999, Supported: 40}
+	for _, text := range []string{
+		tooNew.Error(),
+		"quote \" backslash \\ and\nnewline",
+	} {
+		out := filepath.Join(t.TempDir(), "probe.scpt")
+		cmd := exec.Command("osacompile", "-o", out, "-e", bootDialogScript("Gadak", text))
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("boot dialog script does not compile as AppleScript (text=%q): %v", text, err)
+		}
+	}
+}

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/midagedev/gadak v0.0.0
 	github.com/wailsapp/wails/v3 v3.0.0-beta.12
 	golang.org/x/sys v0.47.0
+	modernc.org/sqlite v1.56.0
 )
 
 require (
@@ -52,5 +53,4 @@ require (
 	modernc.org/libc v1.74.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.56.0 // indirect
 )

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"runtime"
 	"runtime/debug"
@@ -71,7 +72,7 @@ func main() {
 		server.Version = strings.TrimPrefix(appVersion, "v")
 	}
 	if err := run(); err != nil {
-		log.Fatal(err)
+		bootFatal(err)
 	}
 }
 
@@ -610,6 +611,83 @@ func showNativeError(title, text string) {
 		return
 	}
 	windowsMessageBox(title, text)
+}
+
+// bootFatal is the pre-window boot exit: run() failed before the user had
+// anything to look at — a mirror schema refusal from a newer gadak, an
+// unreadable config, a locked DB. The old `log.Fatal(err)` put the store's
+// sentence on stderr and in the log file, neither of which a double-clicked
+// or gadak:// launch ever shows, so the app died with no window and no
+// message. This is the same output plus a native dialog, then the same exit
+// code log.Fatal used. (Issue key lives in gdk1243_test.go — doc-checks
+// resolves public-surface citations against the backlog snapshot.)
+func bootFatal(err error) {
+	reportBootFailure(err)
+	os.Exit(1)
+}
+
+// reportBootFailure is the stderr/log/dialog half of bootFatal, split off so
+// tests can drive it with the dialog seam swapped (CI has no display to
+// dismiss a modal on).
+func reportBootFailure(err error) {
+	// Same destination log.Fatal wrote to: the applog file plus stderr
+	// (applog.Install mirrors both). The trail is the CLI-parity surface;
+	// the dialog is additive, not a replacement.
+	log.Print(err)
+	showBootErrorDialog("Gadak", err.Error())
+}
+
+// showBootErrorDialog is the production dialog for a pre-window boot
+// failure. It is a package var so tests can replace it and assert the boot
+// path reached the dialog with the store's message verbatim — without
+// showing a real modal.
+var showBootErrorDialog = func(title, text string) {
+	nativeBootErrorDialog(runtime.GOOS, title, text)
+}
+
+// nativeBootErrorDialog surfaces a boot failure where the OS has a cheap
+// pre-window surface. Not a wails dialog, at either failure site:
+//   - an apprun.Open failure (the schema-refusal site) happens before
+//     application.New, so application.Get() is nil — globalApplication is
+//     only assigned inside New (pkg/application/application.go) and the
+//     dialog helpers dispatch through InvokeAsync, which dereferences it.
+//   - a StartOriginPassthrough failure runs after New but before app.Run,
+//     and MessageDialog.Show dispatches through dispatch_async(main_queue),
+//     which nothing drains until app.Run pumps the native event loop — the
+//     dialog would queue and the process would exit without showing it.
+//
+// That is the same judgment fatal_windows.go made for its MessageBoxW
+// isolation. Linux ships no desktop artifact (README), so stderr stays the
+// truth there.
+func nativeBootErrorDialog(goos, title, text string) {
+	switch goos {
+	case "windows":
+		windowsMessageBox(title, text)
+	case "darwin":
+		if err := macOSShowBootError(title, text); err != nil {
+			log.Printf("gadak-desktop: boot dialog: %v", err)
+		}
+	}
+}
+
+// bootDialogScript is the osascript line for a boot failure. Escaping is the
+// same idiom as internal/sync's osascript notifier (notify.go): \ and "
+// only — raw newlines inside an -e argument compile, so multi-line error
+// text stays multi-line (measured).
+func bootDialogScript(title, text string) string {
+	esc := func(s string) string {
+		s = strings.ReplaceAll(s, `\`, `\\`)
+		s = strings.ReplaceAll(s, `"`, `\"`)
+		return s
+	}
+	return fmt.Sprintf(`display dialog "%s" with title "%s" with icon stop`, esc(text), esc(title))
+}
+
+// macOSShowBootError runs the dialog and blocks until it is dismissed —
+// MessageBoxW parity. A context with no user session (SSH, CI) errors and
+// the caller logs it; stderr already carries the message either way.
+func macOSShowBootError(title, text string) error {
+	return exec.Command("osascript", "-e", bootDialogScript(title, text)).Run()
 }
 
 func applyWindowChrome(opts *application.WebviewWindowOptions, chrome string) {


### PR DESCRIPTION
A pre-window boot failure (mirror-schema refusal from a newer gadak, unreadable config, locked DB) died with no window and no message — the store's sentence went to stderr and the log file only. Measured during the v0.19 release audit: the v0.18.1 app on a schema-40 mirror exits silently on double-click and deeplink launches.

- `bootFatal` keeps the stderr/log trail byte-for-byte (CLI parity) and adds a native dialog carrying the store's message verbatim, recovery command included, then exits 1 as before.
- Not a wails dialog at either failure site: before `application.New` the global its helpers dereference is nil; between `New` and `Run` the dialog queues on a main queue nothing drains yet. Same judgment `fatal_windows.go` recorded — windows reuses `windowsMessageBox`, darwin runs osascript (escaping idiom copied from `internal/sync`'s notifier), Linux keeps stderr (no desktop artifact ships).
- The dialog is a swappable seam; tests pin the wiring by AST, reproduce the silent death FAIL-first with a scratch home at `user_version=999`, assert the seam gets the verbatim sentence, and compile the AppleScript with osacompile (darwin).
- `desktop/go.mod`: `modernc.org/sqlite` moves indirect → direct (the test builds a mirror); version unchanged, go.sum unchanged.

This rides the PR lane because desktop/ changes are what the Desktop Windows/Linux build jobs exist for — local gates (desktop go test 65 PASS, root suite 46 ok, gofmt, doc-checks, scan-internal) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)