### PR TITLE
desktop: a dock click on a fullscreen window no longer leaves fullscreen

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -731,12 +731,18 @@ func mainWindowOptions() application.WebviewWindowOptions {
 }
 
 // raiseWindow is the one raise path: second-instance, deeplink, and dock
-// reopen. Restore un-minimises; Focus brings the window forward.
+// reopen. Only a minimised window is un-minimised; Focus brings the window
+// forward. Restore() is not that verb — wails' Restore also leaves
+// fullscreen and un-maximises, so a dock click on a fullscreen window
+// snapped it back to its normal frame (GDK-1294, reported in discussion
+// #80).
 func raiseWindow(w *application.WebviewWindow) {
 	if w == nil {
 		return
 	}
-	w.Restore()
+	if w.IsMinimised() {
+		w.UnMinimise()
+	}
 	w.Focus()
 }
 


### PR DESCRIPTION
Fixes the macOS report in discussion #80: with the window in native fullscreen, clicking the Dock icon snapped it back to its normal frame.

**Cause** — ours, not wails'. `raiseWindow` (dock reopen, second instance, deeplink) called `Restore()` to un-minimise, but wails v3's `Restore()` is "restore to the normal frame": it un-minimises **or** leaves fullscreen **or** un-maximises (`pkg/application/webview_window.go`, darwin `windowRestore` toggles `NSWindowStyleMaskFullScreen`). A fullscreen window that was never minimised took the fullscreen branch. A maximised window on Windows/Linux takes the third branch the same way.

**Fix** — un-minimise only when `IsMinimised()`, then `Focus()`. One function, three raise paths.

Backlog: GDK-1294 (https://gadak.dev/backlog/#/?ks=GDK-1294).

Gates: `cd desktop && go build ./... && go vet ./... && go test ./... -count=1` exit 0, `gofmt -l` empty. The desktop build jobs run here, which is why this lands as a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)