### PR TITLE
settings: the dialog keeps one width across tabs

### DIFF
--- a/web/src/components/settings/SettingsDialog.svelte
+++ b/web/src/components/settings/SettingsDialog.svelte
@@ -326,7 +326,7 @@
   data-testid="settings-dialog"
   {onclose}
   trap={trapFocus}
-  panelClass="anim-pop max-h-[92vh] max-w-3xl"
+  panelClass="anim-pop max-h-[92vh] w-full max-w-3xl"
   headerClass="flex flex-none flex-col border-b border-border-subtle px-5 pt-4"
   titleRowClass="mb-0.5 flex items-center justify-between"
   footerClass="flex flex-none flex-wrap items-center gap-2 border-t border-border-subtle px-5 py-3"


### PR DESCRIPTION
Fixes the settings-dialog report in discussion #80: clicking 동기화 / 소스 and the other tabs re-centred the dialog because its width followed the tab's content, so the eye and the cursor had to re-find the same spot.

**Cause** — `SettingsDialog.svelte` gave the panel `max-w-3xl` but no width, so it shrank to each tab's content and, being centred, moved its edges on every switch.

**Fix** — `w-full max-w-3xl`: the panel is always as wide as its maximum, whatever the tab holds. One token.

Backlog: GDK-1291 (https://gadak.dev/backlog/#/?ks=GDK-1291).

Gates: `make typecheck` exit 0; full Playwright on an isolated port, 411 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)