### PR TITLE
detail: "copy link" pastes the origin's page first

### DIFF
--- a/e2e/detail.spec.ts
+++ b/e2e/detail.spec.ts
@@ -1,5 +1,18 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { attachConsoleErrors, gotoApp, searchInput } from './helpers'
+
+/**
+ * Overlay the served config document for this page — the same mock pattern
+ * local-origin.spec.ts owns (serveWorkspaceKind). Kept local because
+ * helpers.ts is not this round's to edit.
+ */
+async function serveConfigOverride(page: Page, extra: Record<string, unknown>): Promise<void> {
+  await page.route('**/config.json', async (route) => {
+    const res = await route.fetch()
+    const doc = (await res.json()) as Record<string, unknown>
+    await route.fulfill({ response: res, json: { ...doc, ...extra } })
+  })
+}
 
 test.describe('detail', () => {
   test('row click opens detail panel with summary/history/comments sections', async ({ page }) => {
@@ -253,7 +266,17 @@ test.describe('detail', () => {
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })
 
-  test('copy-link writes the gadak:// and http issue forms to the clipboard', async ({ page }) => {
+  /*
+   * GDK-1290: the paste's first line is the origin's own page for the key —
+   * the Jira /browse/ URL a teammate can open — followed by the app links, so
+   * a paste into chat still opens gadak. The fixture serves site
+   * https://nimbus.example.com (e2e/serve.sh), so this is the connected-Jira
+   * shape; copy is asserted against the real clipboard, not the toast alone
+   * (GDK-178: a toast that lies is worse than a button that fails aloud).
+   */
+  test('copy-link writes the origin URL first, then the gadak:// and http forms', async ({
+    page,
+  }) => {
     const errors = attachConsoleErrors(page)
     await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
     await gotoApp(page)
@@ -274,8 +297,52 @@ test.describe('detail', () => {
     await copy.click()
 
     const origin = new URL(page.url()).origin
+    const want = `https://nimbus.example.com/browse/NMB-110\ngadak://view?issue=NMB-110\n${origin}/#/?issue=NMB-110`
+    await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(want)
+
+    // The toast names what line one is: the tracker whose page was copied.
+    await expect(page.getByTestId('toast')).toContainText('Jira link copied')
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  /*
+   * GDK-1290, the other side: a workspace with no origin page — the built-in
+   * tracker's serve sends jiraBaseUrl "" (originbind seeds cfg.Site = ""),
+   * originType "gadak", workspaceKind "standalone" — copies exactly what it
+   * copied before: the deep link first, then the serve http line. No first
+   * line is invented for it, and the toast stays the plain "Copied".
+   */
+  test('copy-link without an origin page keeps the gadak:// and http forms', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await serveConfigOverride(page, {
+      jiraBaseUrl: '',
+      originType: 'gadak',
+      workspaceKind: 'standalone',
+    })
+    await gotoApp(page)
+
+    const input = searchInput(page)
+    await input.fill('NMB-110')
+    await expect(page.getByText('NMB-110').first()).toBeVisible()
+    await page
+      .locator('[data-testid="issue-list-scroller"] [role="button"]')
+      .filter({ hasText: 'NMB-110' })
+      .first()
+      .click()
+
+    const panel = page.getByTestId('issue-detail-panel')
+    await expect(panel).toBeVisible()
+    const copy = panel.getByTestId('issue-copy-link')
+    await expect(copy).toBeVisible()
+    await copy.click()
+
+    const origin = new URL(page.url()).origin
     const want = `gadak://view?issue=NMB-110\n${origin}/#/?issue=NMB-110`
     await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(want)
+
+    await expect(page.getByTestId('toast')).toContainText('Copied')
 
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })

--- a/web/src/components/detail/DetailHeader.svelte
+++ b/web/src/components/detail/DetailHeader.svelte
@@ -7,7 +7,7 @@
    */
   import { t } from '../../lib/i18n'
   import type { IssueLite } from '../../lib/types'
-  import { config, isDesktop, profileName, workspaceName } from '../../lib/config'
+  import { config, isDesktop, ORIGIN_LINEAR, profileName, workspaceName } from '../../lib/config'
   import { copyText } from '../../lib/copy-text'
   import { selection } from '../../stores/selection.svelte'
   import { favorites } from '../../stores/favorites.svelte'
@@ -73,14 +73,34 @@
     return `${location.origin}${prefix}/#/?issue=${key}`
   }
 
+  // The tracker whose page is the paste's first line, for the toast. A brand
+  // name, not a translation. Jira is the default because a non-null jiraUrl
+  // is always a Jira /browse/ URL — '' (older server) and 'jira' both mean
+  // it. Linear arrives here only once a Linear URL resolution exists; 'gadak'
+  // never does (no site → no origin URL → no origin toast).
+  function originTrackerName(): string {
+    return config().originType === ORIGIN_LINEAR ? 'Linear' : 'Jira'
+  }
+
   async function copyLink(): Promise<void> {
     const key = issue.issue_key
     const gadak = gadakIssueLink(key)
+    // The origin's page for this key — the address that survives a paste into
+    // chat. Same resolution as the key anchor above (jiraUrl →
+    // jiraBrowseUrl); null on the built-in tracker and any site-less
+    // workspace, where the app links below are the only shareable address.
+    const originUrl = jiraUrl(key)
     // Desktop has no shareable http origin (in-process webview). Serve/hosted
     // copy both lines so a paste into Slack still works without the app.
-    const text = isDesktop() ? gadak : `${gadak}\n${httpIssueLink(key)}`
+    const appText = isDesktop() ? gadak : `${gadak}\n${httpIssueLink(key)}`
+    const text = originUrl ? `${originUrl}\n${appText}` : appText
     if (await copyText(text)) {
-      write.toast(t('detail.linkCopied'), 'success')
+      write.toast(
+        originUrl
+          ? t('detail.originLinkCopied', { tracker: originTrackerName() })
+          : t('detail.linkCopied'),
+        'success',
+      )
     } else {
       write.toast(t('clipboard.copyFailed'), 'error')
     }
@@ -134,7 +154,7 @@
       >
         <Icon name="star" size={14} filled={isFavorite} />
       </button>
-      <!-- Copy gadak:// (and http, off desktop) — same 24px icon-button cluster -->
+      <!-- Copy the origin URL, then gadak:// (+ http, off desktop) — same 24px icon-button cluster -->
       <button
         type="button"
         onclick={() => void copyLink()}

--- a/web/src/lib/i18n/messages/detail.ts
+++ b/web/src/lib/i18n/messages/detail.ts
@@ -185,6 +185,15 @@ export const detail = {
     ko: '복사됨',
     ja: 'コピーしました',
   },
+  // The paste's first line is the origin's own page for the key, so the
+  // toast names the tracker that page belongs to. {tracker} is a brand name
+  // (Jira/Linear) and passes through untranslated. The built-in tracker has
+  // no origin page and keeps detail.linkCopied above.
+  'detail.originLinkCopied': {
+    en: '{tracker} link copied',
+    ko: '{tracker} 링크를 복사했습니다',
+    ja: '{tracker} のリンクをコピーしました',
+  },
   // Toast copy rule: a single-sentence toast carries no trailing period
   // (`filter.saveServerFailed` in list.ts is the standard); hints and
   // local-origin sentences keep theirs. (GDK-1226)


### PR DESCRIPTION
Fixes the copy-link report in discussion #80: the header's 링크 복사 copied a `gadak://view…` deep link, where a teammate pasting it into chat expects the issue's Jira page.

**Change** — the first copied line is the origin's browse URL (`<site>/browse/KEY`, the same resolution the key link already uses); the `gadak://` line and, off desktop, the serve `http` line follow it so the paste still opens in the app. The toast says which tracker's link it was.

**Unchanged** — workspaces on the built-in tracker (and any workspace without a site) have no origin page and copy exactly what they did before. Linear has no browse-URL resolution yet; that is GDK-1149.

Backlog: GDK-1290 (https://gadak.dev/backlog/#/?ks=GDK-1290).

Gates: `make typecheck` 0 · vitest 1049 passed · full Playwright on an isolated port 412 passed · mobile test/check/lint:ios 0. FAIL-first: the new e2e assertion failed against the unchanged code on the missing first line.

Implemented by a GLM-5.3 round under a written spec; reviewed and committed by the maintainer's session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)