### PR TITLE
issue links: open the issue on its own origin, not a Jira browse URL (GDK-1149)

### DIFF
--- a/cmd/gadak/agent.go
+++ b/cmd/gadak/agent.go
@@ -2707,9 +2707,12 @@ func resolveAccount(ctx context.Context, c origin.Writer, who, source string) (s
 	return "", fmt.Errorf("%q matches %d users — be more specific: %s", who, len(users), strings.Join(names, "; "))
 }
 
-// cmdOpen jumps from a key in the terminal to the issue on the Jira site.
-// gadak is the fast path for reading; this is the escape hatch for everything
-// the mirror deliberately does not do (boards, admin, workflow).
+// cmdOpen jumps from a key in the terminal to the issue's page on its origin
+// — the stored items.url first (Jira /browse/KEY, or the page Linear
+// minted), then the site's /browse/KEY. gadak is the fast path for reading;
+// this is the escape hatch for everything the mirror deliberately does not
+// do (boards, admin, workflow). The web's issueOriginUrl resolves the same
+// way (GDK-1149).
 func cmdOpen(args []string) error {
 	fs := newFlagSet("open")
 	if wantsHelp(args) {
@@ -2751,7 +2754,7 @@ func cmdOpen(args []string) error {
 	if web := serveFocusURL("issue=" + key); web != "" {
 		return openIssueURL(web)
 	}
-	return fmt.Errorf("this workspace has no Jira site to browse — use `gadak views open %s` (or `gadak serve`)", key)
+	return fmt.Errorf("this workspace has no origin site to browse — use `gadak views open %s` (or `gadak serve`)", key)
 }
 
 func openIssueURL(u string) error {

--- a/cmd/gadak/agent_test.go
+++ b/cmd/gadak/agent_test.go
@@ -672,7 +672,7 @@ func TestOpenLocalOriginRelativeURLDoesNotSucceed(t *testing.T) {
 	if strings.Contains(msg, "gadak init") {
 		t.Fatalf("prescribed re-init on an already-inited workspace: %s", msg)
 	}
-	if !strings.Contains(msg, "no Jira site to browse") || !strings.Contains(msg, "gadak views open") {
+	if !strings.Contains(msg, "no origin site to browse") || !strings.Contains(msg, "gadak views open") {
 		t.Fatalf("want no-site browse advice, got %q", msg)
 	}
 	if *got != "" {
@@ -709,7 +709,7 @@ func TestOpenLocalOriginKnownKeyWithoutSite(t *testing.T) {
 	if strings.Contains(msg, "gadak init") {
 		t.Fatalf("prescribed re-init: %s", msg)
 	}
-	if !strings.Contains(msg, "no Jira site to browse") {
+	if !strings.Contains(msg, "no origin site to browse") {
 		t.Fatalf("want no-site browse advice, got %q", msg)
 	}
 }

--- a/cmd/gadak/help.go
+++ b/cmd/gadak/help.go
@@ -401,7 +401,7 @@ var helps = map[string]cmdHelp{
 		seeAlso: []string{"gadak issue", "gadak search", "gadak open", "gadak views open"},
 	},
 	"open": {
-		summary: "open the issue on your Jira site in the browser",
+		summary: "open the issue on its origin (Jira or Linear) in the browser",
 		usage:   "gadak [--workspace <name>] open <KEY>",
 		examples: []string{
 			"gadak open NMB-140",

--- a/cmd/gadak/main.go
+++ b/cmd/gadak/main.go
@@ -165,7 +165,7 @@ Reading the mirror (no network; see docs/MIRROR.md):
   issue      full detail for one or more issues
                    <KEY> [KEY...] [--keys -] [--json] [--derive] [--link] [--editmeta]
   show       alias of issue               <KEY> [KEY...] [--keys -] [--json] [--derive] [--link]
-  open       open the issue on your Jira site in the browser  <KEY>
+  open       open the issue on its origin (Jira or Linear) in the browser  <KEY>
   search     full-text or JQL            [--jql] [--emit] [--limit N] [--json] "text|JQL|URL"
   list       open issues, priority rank first   [--limit N] [--all] [--ready] [--json|--csv|--no-header]
   ready      open issues nothing open blocks (alias of list --ready)   [--limit N] [--json|--csv|--no-header]

--- a/docs/AGENT_ACCESS.md
+++ b/docs/AGENT_ACCESS.md
@@ -26,9 +26,9 @@ agent *answers*. Presentation is a different axis:
 | --- | --- | --- | --- |
 | **Views** | `gadak views open` (`--jql`, `--keys`, `--keys -`, or a KEY) | the human should *see* the set in gadak, not in a pasted table | a running Gadak.app or `gadak serve` tab |
 
-The database stays the answer interface. `gadak open` is the Jira escape hatch
-(system browser to `/browse/KEY`); `gadak views open` is the "open in gadak"
-verb. The names collide; the verbs do not.
+The database stays the answer interface. `gadak open` is the origin escape hatch
+(system browser to the issue's page on Jira or Linear); `gadak views open` is the
+"open in gadak" verb. The names collide; the verbs do not.
 
 There is no fourth layer for writes: the CLI and REST write paths both call Jira
 and then re-read the issue into the mirror. Writing to SQLite directly is not a

--- a/docs/AGENT_SETUP.md
+++ b/docs/AGENT_SETUP.md
@@ -96,7 +96,7 @@ Jira issues are mirrored to a local SQLite file. Prefer these over any Jira API:
   list mirrored Jira filters and put the running app or serve tab on that
   view. Do not describe chips to the user; set them. When the user wants to
   *see* issues, do not paste a table — `gadak views open`. `gadak open` is
-  the Jira-site escape hatch; `gadak views open` is open-in-gadak.
+  the origin (Jira/Linear) escape hatch; `gadak views open` is open-in-gadak.
 - `gadak comment <KEY> -m "…"`, `gadak transition <KEY> "<status>"` — writes go
   through the origin (the Jira site on a Jira workspace, the local origin on
   the built-in tracker).

--- a/docs/MIRROR.md
+++ b/docs/MIRROR.md
@@ -218,9 +218,10 @@ Rules that come with the file:
 
 ### CLI reference
 
-`gadak open` is the Jira escape hatch (system browser to `/browse/KEY`);
-`gadak views open` is the "open in gadak" verb (focus the running app or
-serve tab). The names collide; the verbs do not.
+`gadak open` is the origin escape hatch (system browser to the issue's page on
+Jira or Linear — the stored `items.url`); `gadak views open` is the "open in
+gadak" verb (focus the running app or serve tab). The names collide; the
+verbs do not.
 
 **Handing a view to a human.** `gadak views open` acts — it pulls the window
 forward now. When you would rather offer than act, or you are on a host with
@@ -239,7 +240,7 @@ gadak sql --no-header "select key from issues_full where parent_key='NMB-140'" |
 # `gadak issue` is the context pack: one call returns everything an LLM needs
 # about an issue — no follow-up requests, no pagination.
 
-gadak open NMB-140                    # Jira escape hatch: system browser to /browse/KEY
+gadak open NMB-140                    # origin escape hatch: system browser to the issue's Jira/Linear page
 
 gadak search "flaky upload" --limit 5
 gadak search "idempotency" --json     # matching IssueLite rows, best match first

--- a/e2e/cache-upgrade.spec.ts
+++ b/e2e/cache-upgrade.spec.ts
@@ -63,7 +63,7 @@ test.describe('IssueLite cache network wiring', () => {
 })
 
 // GDK-835: a v2 cached row that predates `labels` must not collapse the list.
-// Seeded at version 2 so the v1→v2 wipe cannot be what saves us. Bootstrap
+// Seeded at the current version so the upgrade wipe cannot be what saves us. Bootstrap
 // and delta are aborted so the first paint is the cached row, not a network
 // replace.
 const LEGACY_KEY = 'LEGACY-835'
@@ -72,7 +72,10 @@ async function seedLegacyV2Row(page: Page): Promise<void> {
   await page.evaluate(
     async ({ name, key }) => {
       await new Promise<void>((resolve, reject) => {
-        const request = indexedDB.open(name, 2)
+        // Seed at the current cache version (web/src/lib/db.ts ISSUE_CACHE_DB_VERSION)
+        // so the upgrade wipe cannot be what saves us — an older version is dropped
+        // whole on open (v2 rows predate `url`, GDK-1149).
+        const request = indexedDB.open(name, 3)
         request.onupgradeneeded = () => {
           const db = request.result
           if (!db.objectStoreNames.contains('issues')) {

--- a/e2e/detail.spec.ts
+++ b/e2e/detail.spec.ts
@@ -321,6 +321,16 @@ test.describe('detail', () => {
       originType: 'gadak',
       workspaceKind: 'standalone',
     })
+    // The built-in tracker stores a relative /browse/KEY as the row's url
+    // (measured on a paired mirror); the Jira fixture's rows carry the
+    // absolute nimbus URL, so the bootstrap is rewritten to the real shape —
+    // otherwise the row-first resolver (GDK-1149) would honestly find a page.
+    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
+      const res = await route.fetch()
+      const doc = (await res.json()) as { issues: Array<Record<string, unknown>> }
+      for (const it of doc.issues) it.url = `/browse/${String(it.issue_key)}`
+      await route.fulfill({ response: res, json: doc })
+    })
     await gotoApp(page)
 
     const input = searchInput(page)
@@ -343,6 +353,89 @@ test.describe('detail', () => {
     await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(want)
 
     await expect(page.getByTestId('toast')).toContainText('Copied')
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})
+
+/*
+ * GDK-1149: a Linear workspace has no site — its serve sends jiraBaseUrl ""
+ * — but every mirrored row carries the page Linear itself minted
+ * (items.url, "https://linear.app/<slug>/issue/KEY/<title>"). The origin
+ * affordances that were Jira-only (key anchor, copy-link's first line, the
+ * `o` command, the palette entry) must resolve through that stored URL, and
+ * the copy names Linear, not Jira. The fixture is Jira-shaped, so the
+ * bootstrap is rewritten in flight to give NMB-110 a Linear-shaped url.
+ */
+test.describe('detail — Linear origin (GDK-1149)', () => {
+  const LINEAR_URL = 'https://linear.app/nimbus/issue/NMB-110/example-title-slug'
+
+  async function serveLinearShape(page: Page): Promise<void> {
+    await serveConfigOverride(page, {
+      jiraBaseUrl: '',
+      originType: 'linear',
+      workspaceKind: 'connected',
+    })
+    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
+      const res = await route.fetch()
+      const doc = (await res.json()) as { issues: Array<Record<string, unknown>> }
+      for (const it of doc.issues) {
+        if (it.issue_key === 'NMB-110') it.url = LINEAR_URL
+      }
+      await route.fulfill({ response: res, json: doc })
+    })
+  }
+
+  test('key anchor, copy-link and the o command resolve the Linear page', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await serveLinearShape(page)
+    await page.addInitScript(() => {
+      const opened: string[] = []
+      ;(window as unknown as { __gadakOpened: string[] }).__gadakOpened = opened
+      window.open = (url?: string | URL) => {
+        opened.push(String(url ?? ''))
+        return null
+      }
+    })
+    await gotoApp(page)
+
+    const input = searchInput(page)
+    await input.fill('NMB-110')
+    await expect(page.getByText('NMB-110').first()).toBeVisible()
+    await page
+      .locator('[data-testid="issue-list-scroller"] [role="button"]')
+      .filter({ hasText: 'NMB-110' })
+      .first()
+      .click()
+    const panel = page.getByTestId('issue-detail-panel')
+    await expect(panel).toBeVisible()
+
+    // Key anchor: href is Linear's page; its title names Linear.
+    const anchor = panel.getByRole('link', { name: 'NMB-110', exact: true }).first()
+    await expect(anchor).toHaveAttribute('href', LINEAR_URL)
+    await expect(anchor).toHaveAttribute('title', 'Open in Linear')
+
+    // Copy-link: Linear page first, then the app links; toast names Linear.
+    await panel.getByTestId('issue-copy-link').click()
+    const origin = new URL(page.url()).origin
+    const want = `${LINEAR_URL}\ngadak://view?issue=NMB-110\n${origin}/#/?issue=NMB-110`
+    await expect.poll(async () => page.evaluate(() => navigator.clipboard.readText())).toBe(want)
+    await expect(page.getByTestId('toast')).toContainText('Linear link copied')
+
+    // `o` with the detail open goes to the same page (serve: window.open).
+    await page.keyboard.press('o')
+    const opened = await page.evaluate(
+      () => (window as unknown as { __gadakOpened: string[] }).__gadakOpened,
+    )
+    expect(opened).toEqual([LINEAR_URL])
+
+    // Palette entry carries the tracker name.
+    await page.keyboard.press('ControlOrMeta+k')
+    const palette = page.getByRole('dialog', { name: 'Command palette' })
+    await expect(palette).toBeVisible()
+    await page.keyboard.type('Open in', { delay: 15 })
+    await expect(palette.getByRole('option').filter({ hasText: 'Open in Linear' })).toHaveCount(1)
 
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })

--- a/internal/store/read.go
+++ b/internal/store/read.go
@@ -87,6 +87,14 @@ type IssueLite struct {
 	// Id is the key (names localize); the name is display-only.
 	SecurityLevelID *string `json:"security_level_id"`
 	SecurityLevel   *string `json:"security_level"`
+	// URL is items.url — the origin's own page for the row, exactly as the
+	// sync stored it: Jira writes <site>/browse/KEY, Linear the url its API
+	// minted (workspace slug and title slug included), the built-in tracker
+	// a relative /browse/KEY. It is the deep-link source for every origin
+	// (GDK-1149): a Linear workspace has no site to join a key onto, and
+	// sources.base_url carries no workspace slug. Clients accept only an
+	// absolute http(s) value here — the same rule as `gadak open`.
+	URL string `json:"url,omitempty"`
 }
 
 // MarshalJSON adds `key` as an alias of `issue_key` so JSON surfaces and
@@ -141,7 +149,7 @@ const issueLiteSelect = `
 	       COALESCE(i.reopen_reason, ''), COALESCE(i.cloned_from, ''), i.comment_count,
 	       COALESCE(i.custom, '{}'), COALESCE(it.source_id, ''),
 	       i.sprint_id, i.sprint_name, i.sprint_state,
-	       i.security_level_id, i.security_level
+	       i.security_level_id, i.security_level, COALESCE(it.url, '')
 	FROM issues i JOIN items it ON it.id = i.item_id`
 
 // ErrKeyAmbiguous means one key exists under more than one source (a Jira
@@ -323,7 +331,7 @@ func (db *DB) issueLites(ctx context.Context, query string, args ...any) ([]Issu
 			&reopenReason, &clonedFrom, &v.CommentCount,
 			&custom, &v.Source,
 			&v.SprintID, &v.SprintName, &v.SprintState,
-			&v.SecurityLevelID, &v.SecurityLevel,
+			&v.SecurityLevelID, &v.SecurityLevel, &v.URL,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/read_keys_test.go
+++ b/internal/store/read_keys_test.go
@@ -12,6 +12,67 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 )
 
+// GDK-1149: IssueLite carries items.url verbatim, per origin shape — the
+// Jira /browse/ page, the Linear page its API minted (slug and title
+// included), and the built-in tracker's relative /browse/KEY, which clients
+// must not treat as an origin page. The web resolves every "open in
+// origin" affordance from this field, so a Linear workspace (no site) gets
+// the same deep links as Jira.
+func TestIssueLitesCarryOriginURL(t *testing.T) {
+	db := openTemp(t)
+	ctx := context.Background()
+	for _, src := range []Source{
+		{ID: "jira", Kind: "jira", BaseURL: "https://example.invalid"},
+		{ID: "linear", Kind: "linear", BaseURL: "https://linear.app"},
+		{ID: "gadak", Kind: "gadak", BaseURL: ""},
+	} {
+		if err := db.UpsertSource(ctx, src); err != nil {
+			t.Fatal(err)
+		}
+	}
+	item := func(src, key, url string) IssueRecord {
+		return IssueRecord{
+			Item: Item{
+				ID: src + ":" + key, SourceID: src, Kind: "issue", ExternalID: key, Key: key,
+				Title: key, URL: url,
+				CreatedAt: "2026-08-01T00:00:00.000Z", UpdatedAt: "2026-08-01T00:00:00.000Z",
+			},
+			Issue: Issue{ProjectKey: strings.SplitN(key, "-", 2)[0], StatusCategory: "new"},
+		}
+	}
+	want := map[string]string{
+		"JIR-1": "https://example.invalid/browse/JIR-1",
+		"MID-1": "https://linear.app/midagedev/issue/MID-1/get-familiar-with-linear",
+		"GDK-1": "/browse/GDK-1",
+	}
+	if _, err := db.UpsertIssues(ctx, Batch{Records: []IssueRecord{
+		item("jira", "JIR-1", want["JIR-1"]),
+		item("linear", "MID-1", want["MID-1"]),
+		item("gadak", "GDK-1", want["GDK-1"]),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	lites, err := db.IssueLites(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, l := range lites {
+		got[l.IssueKey] = l.URL
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("IssueLite.URL = %v, want %v", got, want)
+	}
+	// The wire name is `url` (web/src/lib/types.ts IssueLite.url).
+	raw, err := lites[0].MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"url":"`) {
+		t.Fatalf("JSON lacks url: %s", raw)
+	}
+}
+
 func TestIssueLitesByKeys(t *testing.T) {
 	db := openTemp(t)
 	seed(t, db)

--- a/skills/gadak/SKILL.md
+++ b/skills/gadak/SKILL.md
@@ -51,7 +51,7 @@ header row first — skip it with `--no-header` (or `tail -n +2`) or that header
 becomes a key.
 `--keys` cannot be combined with `--jql` or a view name.
 
-`gadak open <KEY>` is the Jira escape hatch (system browser to `/browse/KEY`).
+`gadak open <KEY>` is the origin escape hatch (system browser to the issue's page on Jira or Linear).
 `gadak views open` is the "open in gadak" verb (focus the running app or serve
 tab). The names collide; the verbs do not.
 
@@ -374,8 +374,8 @@ gadak views save "Night triage" --jql '…'   # keep a named view in local.db (s
 listening, and focuses Gadak.app on macOS (the `--workspace` is passed through
 so the window and the file match). `--no-open` writes the hash only. `--json`
 prints the hash and where it was sent. Confirm you named `--workspace` if the
-user has more than one mirror. `gadak open` is the Jira-site escape hatch;
-`gadak views open` is open-in-gadak.
+user has more than one mirror. `gadak open` is the origin (Jira/Linear) escape
+hatch; `gadak views open` is open-in-gadak.
 
 ## A tracker of your own: a backlog you may create and own
 

--- a/web/src/components/detail/DetailHeader.svelte
+++ b/web/src/components/detail/DetailHeader.svelte
@@ -7,13 +7,19 @@
    */
   import { t } from '../../lib/i18n'
   import type { IssueLite } from '../../lib/types'
-  import { config, isDesktop, ORIGIN_LINEAR, profileName, workspaceName } from '../../lib/config'
+  import {
+    config,
+    isDesktop,
+    originTrackerName,
+    profileName,
+    workspaceName,
+  } from '../../lib/config'
   import { copyText } from '../../lib/copy-text'
   import { selection } from '../../stores/selection.svelte'
   import { favorites } from '../../stores/favorites.svelte'
   import { write } from '../../stores/write.svelte'
   import { openIssueOrigin } from '../../lib/desktop-links'
-  import { jiraUrl } from './format'
+  import { issueOriginUrl } from '../../lib/issue-origin'
   import { formatSpan } from '../../lib/format'
   import { typeChipTint } from '../../stores/ui-tokens.svelte'
   import { shouldMarkUnattended } from '../../lib/issue-shells'
@@ -73,23 +79,14 @@
     return `${location.origin}${prefix}/#/?issue=${key}`
   }
 
-  // The tracker whose page is the paste's first line, for the toast. A brand
-  // name, not a translation. Jira is the default because a non-null jiraUrl
-  // is always a Jira /browse/ URL — '' (older server) and 'jira' both mean
-  // it. Linear arrives here only once a Linear URL resolution exists; 'gadak'
-  // never does (no site → no origin URL → no origin toast).
-  function originTrackerName(): string {
-    return config().originType === ORIGIN_LINEAR ? 'Linear' : 'Jira'
-  }
-
   async function copyLink(): Promise<void> {
     const key = issue.issue_key
     const gadak = gadakIssueLink(key)
     // The origin's page for this key — the address that survives a paste into
-    // chat. Same resolution as the key anchor above (jiraUrl →
-    // jiraBrowseUrl); null on the built-in tracker and any site-less
-    // workspace, where the app links below are the only shareable address.
-    const originUrl = jiraUrl(key)
+    // chat. Same resolution as the key anchor above (issueOriginUrl: the
+    // row's stored url, else the site's /browse/KEY); null on the built-in
+    // tracker, where the app links below are the only shareable address.
+    const originUrl = issueOriginUrl(key)
     // Desktop has no shareable http origin (in-process webview). Serve/hosted
     // copy both lines so a paste into Slack still works without the app.
     const appText = isDesktop() ? gadak : `${gadak}\n${httpIssueLink(key)}`
@@ -108,7 +105,7 @@
 </script>
 
 <header class="border-b border-border-strong/70 px-5 pt-4 pb-4">
-  <!-- Top row: issue key (Jira link) + close -->
+  <!-- Top row: issue key (origin link) + close -->
   <div class="mb-2 flex items-center justify-between gap-2">
     <div class="flex min-w-0 items-center gap-2">
       {#if overlay}
@@ -126,11 +123,11 @@
         </button>
       {/if}
       <a
-        href={jiraUrl(issue.issue_key) ?? undefined}
+        href={issueOriginUrl(issue.issue_key) ?? undefined}
         target="_blank"
         rel="noopener noreferrer"
         class="flex-none font-mono text-micro font-medium text-accent-text hover:underline"
-        title={t('detail.openJira')}
+        title={t('detail.openJira', { tracker: originTrackerName() })}
         onclick={(e) => {
           if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
           e.preventDefault()

--- a/web/src/components/detail/DetailPanel.svelte
+++ b/web/src/components/detail/DetailPanel.svelte
@@ -33,7 +33,7 @@
   import { createSkeletonGrace } from '../../lib/skeleton-grace.svelte'
   import { onEscape } from '../../lib/dom-actions'
   import { shells } from '../../lib/issue-shells.svelte'
-  import { jiraUrl } from './format'
+  import { issueOriginUrl } from '../../lib/issue-origin'
   import DetailHeader from './DetailHeader.svelte'
   import IssueFields from './IssueFields.svelte'
   import QaImpact from './QaImpact.svelte'
@@ -198,7 +198,7 @@
               </button>
             {/if}
             <a
-              href={jiraUrl(key)}
+              href={issueOriginUrl(key)}
               target="_blank"
               rel="noopener noreferrer"
               class="font-mono text-micro font-medium text-accent-text hover:underline"

--- a/web/src/components/detail/format.ts
+++ b/web/src/components/detail/format.ts
@@ -1,9 +1,9 @@
 /*
  * Shared format helpers for the detail panel ([detail]).
- * Pure functions only: relative time, browse URL, etc.
+ * Pure functions only: relative time, etc. The origin page for a key is
+ * lib/issue-origin.ts (`issueOriginUrl`), shared with the `o` command.
  */
 
-import { jiraBrowseUrl } from '../../lib/config'
 import { absTime as i18nAbsTime, relativeTime as i18nRelativeTime } from '../../lib/i18n'
 
 /** ISO8601 → relative time (long style: "3m ago"). On parse fail, return raw. */
@@ -14,9 +14,4 @@ export function relativeTime(iso: string | null | undefined): string {
 /** ISO8601 → absolute time label (for tooltips). */
 export function absoluteTime(iso: string | null | undefined): string {
   return i18nAbsTime(iso)
-}
-
-/** Canonical Jira issue URL. null if no site configured (omit href). */
-export function jiraUrl(issueKey: string): string | null {
-  return jiraBrowseUrl(issueKey)
 }

--- a/web/src/components/shell/ShortcutsDialog.svelte
+++ b/web/src/components/shell/ShortcutsDialog.svelte
@@ -8,13 +8,17 @@
   import { trapFocus } from '../../lib/focus-trap'
   import { helpSections } from '../../lib/commands'
   import { modifierSymbol } from '../../lib/unified-search'
+  import { originTrackerName } from '../../lib/config'
   import DialogShell from '../ui/DialogShell.svelte'
 
   let { onclose }: { onclose: () => void } = $props()
 
+  // The origin rows name the tracker ("Open the issue in {tracker}"); the
+  // placeholder is inert on every other row.
+  const params = { tracker: originTrackerName() }
   const sections = helpSections(modifierSymbol()).map((section) => ({
     title: t(section.titleKey),
-    rows: section.rows.map((row) => [row.kbd, t(row.labelKey)] as [string, string]),
+    rows: section.rows.map((row) => [row.kbd, t(row.labelKey, params)] as [string, string]),
   }))
 
   function onKeydown(e: KeyboardEvent) {

--- a/web/src/lib/command-palette.ts
+++ b/web/src/lib/command-palette.ts
@@ -8,6 +8,7 @@ import { locale, setLocale, t } from './i18n'
 import type { Locale, MessageKey } from './i18n/catalog'
 import { LOCALES } from './i18n/types'
 import { persistThemePreference, THEME_MODES } from './theme'
+import { originTrackerName } from './config'
 import { COMMANDS, type PaletteSpec, type TriageMenuKey } from './commands'
 
 export interface PaletteActionHost {
@@ -181,7 +182,7 @@ function itemsFor(spec: PaletteSpec, input: PaletteActionInput): PaletteActionIt
       return [
         {
           id: spec.id,
-          label: t('detail.openJira'),
+          label: t('detail.openJira', { tracker: originTrackerName() }),
           kbd: spec.kbd,
           run: () => host.openIssueOrigin(key),
         },

--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -12,6 +12,7 @@
 
 import {
   isLocalOrigin,
+  ORIGIN_LINEAR,
   parseOriginType,
   parseTransport,
   parseWorkspaceKind,
@@ -323,6 +324,18 @@ export function serverVerbReport(): Record<ServerVerb, boolean> {
 export function jiraBrowseUrl(issueKey: string): string | null {
   const base = config().jiraBaseUrl.replace(/\/+$/, '')
   return base ? `${base}/browse/${encodeURIComponent(issueKey)}` : null
+}
+
+/**
+ * The tracker whose page the origin affordances open, for copy that names
+ * it ("Open in {tracker}", "{tracker} link copied"). A brand name, not a
+ * translation. Jira is the default: '' (older server) and 'jira' both mean
+ * a /browse/ URL, and the built-in tracker never yields an origin page, so
+ * its copy is never shown. Lives here (not lib/issue-origin.ts) because
+ * store-free modules such as command-palette.ts need it.
+ */
+export function originTrackerName(): string {
+  return config().originType === ORIGIN_LINEAR ? 'Linear' : 'Jira'
 }
 
 /**

--- a/web/src/lib/db.test.ts
+++ b/web/src/lib/db.test.ts
@@ -62,13 +62,13 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('issue cache upgrade (v1 → v2)', () => {
+describe('issue cache upgrade (v1 → v2 → v3)', () => {
   test('legacy v1 rows and the sync cursor are dropped; write meta stays', async () => {
     const name = uniqueName()
     await seedV1(name)
     const db2 = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
     try {
-      expect(db2.version).toBe(2)
+      expect(db2.version).toBe(ISSUE_CACHE_DB_VERSION)
       const issues = await db2.getAll('issues')
       expect(issues.some((row) => row.issue_key === 'LEGACY-1')).toBe(false)
       expect(issues).toEqual([])
@@ -80,7 +80,34 @@ describe('issue cache upgrade (v1 → v2)', () => {
     }
   })
 
-  test('a later v2 reopen does not clear a fresh snapshot', async () => {
+  // GDK-1149: v2 rows predate `url`; a cache that hydrates then polls delta
+  // would otherwise keep url-less rows for as long as they stay unchanged —
+  // on Linear that is every deep link. The v3 open drops them the way v2
+  // dropped reporter_id-less rows; the sync cursor goes with them.
+  test('v2 rows without url and the sync cursor are dropped on the v3 open', async () => {
+    const name = uniqueName()
+    const v2 = await openDB(name, 2, { upgrade: upgradeIssueCache })
+    await v2.put('issues', { issue_key: 'LIN-1', reporter_id: 'x' } as import('./types').IssueLite)
+    await v2.put('meta', {
+      key: 'sync',
+      sync_version: 5,
+      server_time: '2026-08-01T00:00:00.000Z',
+      members: [],
+    } as import('./types').CacheMeta)
+    v2.close()
+
+    const db3 = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
+    try {
+      expect(db3.version).toBe(3)
+      expect(await db3.getAll('issues')).toEqual([])
+      expect(await db3.get('meta', 'sync')).toBeUndefined()
+    } finally {
+      db3.close()
+      await deleteDb(name)
+    }
+  })
+
+  test('a later same-version reopen does not clear a fresh snapshot', async () => {
     const name = uniqueName()
     const first = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
     try {
@@ -100,7 +127,7 @@ describe('issue cache upgrade (v1 → v2)', () => {
 
     const second = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
     try {
-      expect(second.version).toBe(2)
+      expect(second.version).toBe(ISSUE_CACHE_DB_VERSION)
       expect(await second.get('issues', 'NMB-1')).toMatchObject({ reporter_id: 'demo-alex' })
       expect(await second.get('meta', 'sync')).toMatchObject({ sync_version: 7 })
     } finally {
@@ -109,11 +136,11 @@ describe('issue cache upgrade (v1 → v2)', () => {
     }
   })
 
-  test('fresh install creates the v2 stores', async () => {
+  test('fresh install creates the current stores', async () => {
     const name = uniqueName()
     const db2 = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
     try {
-      expect(db2.version).toBe(2)
+      expect(db2.version).toBe(ISSUE_CACHE_DB_VERSION)
       expect([...db2.objectStoreNames].sort()).toEqual(['issues', 'meta'])
       expect(await db2.getAll('issues')).toEqual([])
     } finally {
@@ -123,13 +150,13 @@ describe('issue cache upgrade (v1 → v2)', () => {
   })
 })
 
-describe('getAllIssues row contract (v2, wipe does not run)', () => {
-  test('a legacy v2 row missing labels hydrates with empty arrays', async () => {
+describe('getAllIssues row contract (current version, wipe does not run)', () => {
+  test('a cached row missing labels hydrates with empty arrays', async () => {
     const name = issueCacheDbName()
     await deleteDb(name)
     const conn = await openDB(name, ISSUE_CACHE_DB_VERSION, { upgrade: upgradeIssueCache })
     try {
-      expect(conn.version).toBe(2)
+      expect(conn.version).toBe(ISSUE_CACHE_DB_VERSION)
       await conn.put(
         'issues',
         { issue_key: 'LEGACY-2', summary: 'cached v2 row' } as import('./types').IssueLite,

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -21,7 +21,10 @@ export function issueCacheDbName(scope = cacheScopeId()): string {
 // v2 invalidates IssueLite rows written before reporter_id joined the row
 // contract. SQLite already has the IDs, so one fresh bootstrap is sufficient;
 // write metadata is independent and remains warm.
-export const ISSUE_CACHE_DB_VERSION = 2
+// v3 does the same for `url` (GDK-1149): a cache hydrates then polls delta,
+// so rows that never change would keep no origin page — on Linear that is
+// every deep link, silently, until the row happens to move.
+export const ISSUE_CACHE_DB_VERSION = 3
 
 interface IssueDB extends DBSchema {
   issues: {
@@ -60,11 +63,11 @@ export const upgradeIssueCache: NonNullable<OpenDBCallbacks<IssueDB>['upgrade']>
   if (!database.objectStoreNames.contains('meta')) {
     database.createObjectStore('meta', { keyPath: 'key' })
   }
-  // Existing v1 rows may not carry reporter_id. Clear only that legacy
-  // issue snapshot and its sync cursor: keeping the cursor could make an
-  // empty cache send If-None-Match and accept a 304. Fresh v2 databases
-  // and every later v2 reopen skip this branch entirely.
-  if (oldVersion > 0 && oldVersion < 2) {
+  // Existing v1 rows may not carry reporter_id, v2 rows not `url`. Clear
+  // only that legacy issue snapshot and its sync cursor: keeping the cursor
+  // could make an empty cache send If-None-Match and accept a 304. Fresh
+  // databases and every later same-version reopen skip this branch entirely.
+  if (oldVersion > 0 && oldVersion < ISSUE_CACHE_DB_VERSION) {
     void transaction.objectStore('issues').clear()
     void transaction.objectStore('meta').delete('sync')
   }

--- a/web/src/lib/desktop-links.ts
+++ b/web/src/lib/desktop-links.ts
@@ -16,8 +16,9 @@
  * — the app has no TCP listener — so they are left to their own story.
  */
 
-import { config, isDesktop, jiraBrowseUrl } from './config'
+import { config, isDesktop } from './config'
 import { browse } from './browse.svelte'
+import { issueOriginUrl } from './issue-origin'
 import {
   classifyAtlassianLink,
   extractBrowseKey,
@@ -98,9 +99,9 @@ export function openOriginUrl(url: string | null | undefined): boolean {
   return true
 }
 
-/** Issue-key header link (`detail.openJira`). No-op when `jiraBrowseUrl` is null. */
+/** Issue-key header link (`detail.openJira`). No-op when `issueOriginUrl` is null. */
 export function openIssueOrigin(issueKey: string): boolean {
-  return openOriginUrl(jiraBrowseUrl(issueKey))
+  return openOriginUrl(issueOriginUrl(issueKey))
 }
 
 // GitHub tabs ride the pane as kind 'other': nothing in the mirror to resync

--- a/web/src/lib/i18n/messages/detail.ts
+++ b/web/src/lib/i18n/messages/detail.ts
@@ -170,10 +170,13 @@ export const detail = {
     ko: '상세를 불러오지 못했습니다.',
     ja: '詳細を読み込めませんでした。',
   },
+  // {tracker} is the origin's brand name (Jira/Linear, `originTrackerName`)
+  // and passes through untranslated (GDK-1149). The key keeps its name: it
+  // is referenced by the command registry and tests as a wire id.
   'detail.openJira': {
-    en: 'Open in Jira',
-    ko: 'Jira 원본 열기',
-    ja: 'Jira で開く',
+    en: 'Open in {tracker}',
+    ko: '{tracker} 원본 열기',
+    ja: '{tracker} で開く',
   },
   'detail.copyLink': {
     en: 'Copy link',

--- a/web/src/lib/i18n/messages/shell.ts
+++ b/web/src/lib/i18n/messages/shell.ts
@@ -702,10 +702,11 @@ export const shell = {
     ko: '문서·히스토리·피드·대시보드 닫기',
     ja: 'ドキュメント・履歴・フィード・ダッシュボードを閉じる',
   },
+  // {tracker}: the origin's brand name (Jira/Linear), see detail.openJira.
   'shortcuts.detailOpenJira': {
-    en: 'Open the issue in Jira',
-    ko: '이슈를 Jira에서 열기',
-    ja: '課題を Jira で開く',
+    en: 'Open the issue in {tracker}',
+    ko: '이슈를 {tracker}에서 열기',
+    ja: '課題を {tracker} で開く',
   },
   'shortcuts.focusStatus': {
     en: 'Change status (when detail is open)',

--- a/web/src/lib/issue-origin.test.ts
+++ b/web/src/lib/issue-origin.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+/*
+ * GDK-1149: the origin page for a key comes from the row's stored url
+ * first (what makes Linear work — no site, no slug in base_url), then the
+ * site's /browse/KEY. A relative url (the built-in tracker's /browse/KEY)
+ * is not an origin page. The store is mocked the way omnibox.test.ts does.
+ */
+
+const harness = vi.hoisted(() => ({
+  pool: new Map<string, { url?: string }>(),
+  cfg: { jiraBaseUrl: '', originType: '' },
+}))
+
+vi.mock('../stores/issues.svelte', () => ({
+  issues: { pool: harness.pool },
+}))
+vi.mock('./config', () => ({
+  config: () => harness.cfg,
+  jiraBrowseUrl: (key: string) =>
+    harness.cfg.jiraBaseUrl ? `${harness.cfg.jiraBaseUrl}/browse/${key}` : null,
+}))
+
+import { issueOriginUrl } from './issue-origin'
+
+const LINEAR = 'https://linear.app/midagedev/issue/MID-1/get-familiar-with-linear'
+
+beforeEach(() => {
+  harness.pool.clear()
+  harness.cfg.jiraBaseUrl = ''
+})
+
+describe('issueOriginUrl', () => {
+  test('Linear: the stored url wins with no site configured', () => {
+    harness.pool.set('MID-1', { url: LINEAR })
+    expect(issueOriginUrl('MID-1')).toBe(LINEAR)
+  })
+
+  test('Jira: a stored /browse/ url and the site fallback agree; older rows fall back', () => {
+    harness.cfg.jiraBaseUrl = 'https://nimbus.example.com'
+    harness.pool.set('NMB-1', { url: 'https://nimbus.example.com/browse/NMB-1' })
+    harness.pool.set('NMB-2', {})
+    expect(issueOriginUrl('NMB-1')).toBe('https://nimbus.example.com/browse/NMB-1')
+    expect(issueOriginUrl('NMB-2')).toBe('https://nimbus.example.com/browse/NMB-2')
+    expect(issueOriginUrl('NMB-3')).toBe('https://nimbus.example.com/browse/NMB-3')
+  })
+
+  test('built-in tracker: a relative /browse/KEY is not an origin page', () => {
+    harness.pool.set('GDK-1', { url: '/browse/GDK-1' })
+    expect(issueOriginUrl('GDK-1')).toBeNull()
+    expect(issueOriginUrl('GDK-404')).toBeNull()
+  })
+
+  test('only http(s) counts', () => {
+    harness.pool.set('X-1', { url: 'javascript:alert(1)' })
+    harness.pool.set('X-2', { url: '  HTTPS://linear.app/w/issue/X-2  ' })
+    expect(issueOriginUrl('X-1')).toBeNull()
+    expect(issueOriginUrl('X-2')).toBe('HTTPS://linear.app/w/issue/X-2')
+  })
+})

--- a/web/src/lib/issue-origin.ts
+++ b/web/src/lib/issue-origin.ts
@@ -1,0 +1,28 @@
+/*
+ * The origin's page for an issue key — one resolver for every "open in
+ * origin" affordance (key anchor, copy-link's first line, the `o` command,
+ * the palette entry, the 400-refusal toast hatch).
+ *
+ * Source order is the same as `gadak open` (cmd/gadak/agent.go): the row's
+ * stored `items.url` first, then the site's /browse/KEY. The stored url is
+ * what makes Linear work (GDK-1149) — a Linear workspace has no site, and
+ * sources.base_url carries no workspace slug, but every mirrored row holds
+ * the page Linear itself minted. The built-in tracker stores a relative
+ * `/browse/KEY`, which is not an origin page, so only absolute http(s)
+ * values count.
+ *
+ * Reads the issues store, so store-free modules (command-palette.ts) take
+ * the tracker's name from config.ts (`originTrackerName`) instead.
+ */
+
+import { jiraBrowseUrl } from './config'
+import { issues } from '../stores/issues.svelte'
+
+const ABSOLUTE_HTTP = /^https?:\/\//i
+
+/** Origin page for `issueKey`, or null when this workspace has none. */
+export function issueOriginUrl(issueKey: string): string | null {
+  const stored = issues.pool.get(issueKey)?.url?.trim() ?? ''
+  if (ABSOLUTE_HTTP.test(stored)) return stored
+  return jiraBrowseUrl(issueKey)
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -87,6 +87,11 @@ export interface IssueLite {
   source_project: string | null
   /** Origin that owns the row (`jira` / `linear`). Older caches omit it. */
   source?: string
+  /** The origin's own page for the row (items.url), verbatim: Jira
+   *  `<site>/browse/KEY`, Linear the url its API minted, the built-in tracker
+   *  a relative `/browse/KEY`. Resolve deep links through `issueOriginUrl`,
+   *  which accepts only an absolute http(s) value. Older caches omit it. */
+  url?: string
 
   created_at: string | null // ISO8601
   updated_at: string | null

--- a/web/src/stores/write.svelte.ts
+++ b/web/src/stores/write.svelte.ts
@@ -24,7 +24,8 @@ import { me } from './me.svelte'
 import { appendComment, invalidate } from '../lib/detail-cache.svelte'
 import { externalMoves } from '../lib/board-moves.svelte'
 import { recordRecent } from '../lib/recency'
-import { isHostedDemo, jiraBrowseUrl } from '../lib/config'
+import { isHostedDemo, originTrackerName } from '../lib/config'
+import { issueOriginUrl } from '../lib/issue-origin'
 import type {
   CommentMention,
   CreateIssuePayload,
@@ -936,8 +937,8 @@ function compactCreatePayload(input: CreateIssuePayload): CreateIssuePayload {
 
 /** GDK-83 / GDK-52: 400 screen refusals offer the origin hatch only when it can open. */
 function originAction(key: string): ToastAction | undefined {
-  if (!jiraBrowseUrl(key)) return undefined
-  return { label: t('detail.openJira'), openIssueKey: key }
+  if (!issueOriginUrl(key)) return undefined
+  return { label: t('detail.openJira', { tracker: originTrackerName() }), openIssueKey: key }
 }
 
 /** Jira's Message() plus any jira_errors the message did not already carry. */


### PR DESCRIPTION
Fixes the Linear half of GitHub discussion #80: on a Linear workspace, "open in tracker" (detail header, command palette, `gadak open`, desktop deep links) built a Jira `/browse/KEY` URL from a site the workspace does not have.

- `web/src/lib/issue-origin.ts`: `issueOriginUrl(key)` prefers the item's stored origin URL (`items.url`, absolute http(s) only) and falls back to the Jira browse URL.
- `IssueLite` carries `url`; the browser issue cache bumps to v3 so stale rows refresh.
- `gadak open KEY` reads the same column.
- e2e: `e2e/detail.spec.ts` and `e2e/cache-upgrade.spec.ts` cover the Linear case; unit tests for the URL choice.

Backlog: GDK-1149 (public backlog: https://gadak.dev/backlog/#/?ks=GDK-1149).

Gates run locally: go build/vet/test (one unrelated flaky test, tracked separately), gofmt, typecheck, vitest 1054, doc-checks, mobile, Playwright 413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)