### PR TITLE
router: every place change goes through history, so back works everywhere (GDK-1296)

### DIFF
--- a/e2e/history-nav.spec.ts
+++ b/e2e/history-nav.spec.ts
@@ -1,0 +1,284 @@
+/*
+ * Back and forward, pressed for real (GDK-1296, GitHub discussion #80).
+ *
+ * The hash is the one source of where you are, and the rule for what a state
+ * change does to history is three lines (lib/router.svelte.ts):
+ *
+ *   1. a place — the open issue, the filters, the layout, a committed query —
+ *      pushes, so back is the previous place;
+ *   2. a dialog opening pushes one entry and closing it is the same as back,
+ *      so forward reopens it and back never lands on a dead press;
+ *   3. continuous input inside a place — typing, a dialog's tabs — replaces,
+ *      so one back closes the dialog however many tabs were visited.
+ *
+ * Every spec here drives the app from its own controls (not the address bar)
+ * and then presses the browser's buttons — the URL alone is not the claim.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { attachConsoleErrors, forceLocale, gotoApp, openServerSettings, searchInput } from './helpers'
+import { en } from '../web/src/lib/i18n/en'
+
+// An open fixture pair — both in the default "All open" view, so the first is
+// reachable from the list: NMA-26 blocks NMS-7.
+const BLOCKER = 'NMA-26'
+const BLOCKED = 'NMS-7'
+
+const historyLength = (page: Page) => page.evaluate(() => history.length)
+
+/** The sidebar view rows lit as "the list you are on" (url-state.spec.ts). */
+const activeViews = (page: Page) =>
+  page.locator('aside nav button[aria-current="true"]:not([data-testid^="docs-"])').allInnerTexts()
+
+const row = (page: Page, key: string) =>
+  page
+    .locator('[data-testid="issue-list-scroller"] [role="button"]')
+    .filter({ hasText: new RegExp(`\\b${key}\\b`) })
+    .first()
+
+test.describe('history: places push (rule 1)', () => {
+  test('list → issue → linked issue → back → back; a typed query is one entry', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    const listUrl = page.url()
+
+    // Typing a query is one entry however many characters land (empty → text).
+    await searchInput(page).fill(BLOCKER)
+    await expect(page).toHaveURL(/[?&]q=NMA-26(?![0-9])/)
+    const afterQuery = await historyLength(page)
+    await searchInput(page).fill(BLOCKER.slice(0, -1))
+    await searchInput(page).fill(BLOCKER)
+    await expect(page).toHaveURL(/[?&]q=NMA-26(?![0-9])/)
+    expect(await historyLength(page)).toBe(afterQuery)
+
+    await row(page, BLOCKER).click()
+    const panel = page.getByTestId('issue-detail-panel')
+    await expect(panel).toHaveClass(/is-open/)
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}(?![0-9])`))
+
+    await panel.getByTestId('linked-issues').getByRole('button').filter({ hasText: BLOCKED }).click()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKED}(?![0-9])`))
+    await expect(panel.getByRole('link', { name: BLOCKED, exact: true })).toBeVisible()
+
+    await page.goBack()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}(?![0-9])`))
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toBeVisible()
+
+    await page.goBack()
+    await expect(page).not.toHaveURL(/issue=/)
+    await expect(panel).not.toHaveClass(/is-open/)
+    await expect(page).toHaveURL(/[?&]q=NMA-26(?![0-9])/)
+
+    // Back past the query: the URL drops it and so does the box.
+    await page.goBack()
+    await expect(page).not.toHaveURL(/[?&]q=/)
+    await expect(searchInput(page)).toHaveValue('')
+    expect(page.url()).toBe(listUrl)
+
+    await page.goForward()
+    await expect(page).toHaveURL(/[?&]q=NMA-26(?![0-9])/)
+    await expect(searchInput(page)).toHaveValue(BLOCKER)
+    await page.goForward()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}(?![0-9])`))
+    await expect(panel).toHaveClass(/is-open/)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('a view change and a layout change each leave one entry', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    const allOpen = page.url()
+    const bootViews = await activeViews(page)
+    expect(bootViews.length).toBeGreaterThan(0)
+    const len0 = await historyLength(page)
+
+    await page.getByRole('button', { name: en['view.unassignedNew.name'] }).click()
+    await expect(page).not.toHaveURL(allOpen)
+    const unassigned = page.url()
+    expect(await activeViews(page)).not.toEqual(bootViews)
+    expect(await historyLength(page)).toBe(len0 + 1)
+
+    await page.getByTestId('layout-board').click()
+    await expect(page.getByTestId('board')).toBeVisible()
+    await expect(page).not.toHaveURL(unassigned)
+    expect(await historyLength(page)).toBe(len0 + 2)
+
+    await page.goBack()
+    await expect(page).toHaveURL(unassigned)
+    await expect(page.getByTestId('issue-list-scroller')).toBeVisible()
+    await expect(page.getByTestId('layout-list')).toHaveAttribute('aria-pressed', 'true')
+
+    await page.goBack()
+    await expect(page).toHaveURL(allOpen)
+    await expect.poll(() => activeViews(page)).toEqual(bootViews)
+
+    await page.goForward()
+    await expect(page).toHaveURL(unassigned)
+    await page.goForward()
+    await expect(page.getByTestId('board')).toBeVisible()
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('the right panel is one place: person → issue → back is the person again', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+
+    await page.keyboard.press('ControlOrMeta+k')
+    await page.keyboard.type('alex', { delay: 20 })
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('person-panel')).toBeVisible()
+    await expect(page).toHaveURL(/person=/)
+    const withPerson = page.url()
+    const len0 = await historyLength(page)
+
+    // Opening an issue over the person moves two params in one flush
+    // (`person=` leaves, `issue=` arrives) — and is still one entry.
+    await searchInput(page).fill(BLOCKER)
+    // Let the query's own entry land first — otherwise its (debounced) push
+    // and the click's fall into one flush and the count below reads one short.
+    await expect(page).toHaveURL(/[?&]q=NMA-26(?![0-9])/)
+    await row(page, BLOCKER).click()
+    const panel = page.getByTestId('issue-detail-panel')
+    await expect(panel).toHaveClass(/is-open/)
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}(?![0-9])`))
+    await expect(page).not.toHaveURL(/person=/)
+    await expect(page.getByTestId('person-panel')).toHaveCount(0)
+    // query + issue open = two entries, no more
+    expect(await historyLength(page)).toBe(len0 + 2)
+
+    await page.goBack()
+    await page.goBack()
+    await expect(page).toHaveURL(withPerson)
+    await expect(page.getByTestId('person-panel')).toBeVisible()
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toHaveCount(0)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})
+
+test.describe('history: dialogs (rules 2 and 3)', () => {
+  test('opening settings is one entry; back closes it; closing is the same as back', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    const listUrl = page.url()
+    const len0 = await historyLength(page)
+    const dialog = page.getByTestId('settings-dialog')
+
+    await openServerSettings(page)
+    await expect(page).toHaveURL(/settings=sync/)
+    expect(await historyLength(page)).toBe(len0 + 1)
+
+    // Back closes the dialog.
+    await page.goBack()
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(listUrl)
+
+    // The close button is the same move as back: forward reopens the dialog,
+    // and a back after closing never re-opens it.
+    await openServerSettings(page)
+    await expect(page).toHaveURL(/settings=sync/)
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(listUrl)
+
+    await page.goForward()
+    await expect(dialog).toBeVisible()
+    await expect(page).toHaveURL(/settings=sync/)
+
+    await dialog.getByRole('button', { name: en['common.cancel'], exact: true }).first().click()
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(listUrl)
+    await page.goBack()
+    await expect(dialog).toHaveCount(0)
+    await expect(page).not.toHaveURL(/settings=/)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('three tab switches inside settings, one back: the dialog is closed', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    const listUrl = page.url()
+    const len0 = await historyLength(page)
+    const dialog = page.getByTestId('settings-dialog')
+
+    await openServerSettings(page)
+    for (const key of ['settings.tabMembers', 'settings.tabFeatures', 'settings.tabAbout'] as const) {
+      await dialog.getByRole('button', { name: en[key], exact: true }).click()
+    }
+    await expect(page).toHaveURL(/settings=about/)
+    // Tabs are continuous input: the entry the dialog opened on is rewritten.
+    expect(await historyLength(page)).toBe(len0 + 1)
+
+    await page.goBack()
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(listUrl)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('the sidebar door into Settings → Workspaces closes like the gear does', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await gotoApp(page)
+    const listUrl = page.url()
+    const dialog = page.getByTestId('settings-dialog')
+
+    await page.getByTestId('workspace-new').click()
+    await expect(dialog).toBeVisible()
+    await expect(page).toHaveURL(/settings=workspaces/)
+
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(listUrl)
+    await page.goForward()
+    await expect(dialog).toBeVisible()
+    await expect(page).toHaveURL(/settings=workspaces/)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})
+
+test.describe('history: arriving by link', () => {
+  test('a deep link adds no entry of its own, whatever the app promotes or normalizes', async ({
+    page,
+    request,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    const res = await request.get('/api/v1/issues/pages/')
+    const body = (await res.json()) as { pages: { key: string }[] }
+    const doc = [...body.pages].sort((a, b) => a.key.localeCompare(b.key))[0]
+
+    // `doc=` alone lands on the documents screen (App promotes `docs=1`).
+    await forceLocale(page, 'en')
+    await page.goto(`/#/?doc=${encodeURIComponent(doc.key)}`)
+    const len0 = await historyLength(page)
+    await expect(page.getByTestId('doc-panel')).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByTestId('docs-view')).toBeVisible()
+    await expect(page).toHaveURL(/docs=1/)
+    expect(await historyLength(page)).toBe(len0)
+
+    // An unknown settings tab is normalized to sync — in place.
+    await page.goto('/#/?settings=bogus')
+    const len1 = await historyLength(page)
+    await expect(page.getByTestId('settings-dialog')).toBeVisible({ timeout: 30_000 })
+    await expect(page).toHaveURL(/settings=sync/)
+    expect(await historyLength(page)).toBe(len1)
+
+    // The default view at boot is written in place too: back from the first
+    // screen does not land on an unfiltered pool.
+    await gotoApp(page)
+    const len2 = await historyLength(page)
+    expect(len2).toBe(len1 + 1)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+})

--- a/e2e/linked-issues.spec.ts
+++ b/e2e/linked-issues.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page, type Route } from '@playwright/test'
-import { attachConsoleErrors, gotoApp, searchInput } from './helpers'
+import { apiURL, attachConsoleErrors, forceLocale, gotoApp, searchInput } from './helpers'
 
 /**
  * Issue-link write-through from the detail panel (GDK-85).
@@ -11,6 +11,11 @@ import { attachConsoleErrors, gotoApp, searchInput } from './helpers'
  *
  * Delete is not on origin.IssueLinker (IssueLinkTypes + LinkIssues only);
  * this spec covers add → appears.
+ *
+ * GitHub discussion #80 (GDK-1292 / GDK-1293): the label of a linked row is
+ * the catalog phrase for its direction ("is blocked by"), never the mirror's
+ * raw `inward`/`outward` token; and following a link is a navigation, so the
+ * back button returns to the issue it was followed from.
  */
 
 const KEY = 'NMB-110'
@@ -64,7 +69,142 @@ async function openIssue(page: Page) {
   return panel
 }
 
+// A fixture pair linked both ways: NMA-104 blocks NMB-104 (outward), so
+// NMB-104's row for NMA-104 is the inward side.
+const BLOCKED = 'NMB-104'
+const BLOCKER = 'NMA-104'
+
+async function gotoIssue(page: Page, key: string) {
+  await forceLocale(page, 'en')
+  await page.goto(`/#/?issue=${key}`)
+  const panel = page.getByTestId('issue-detail-panel')
+  await expect(panel).toHaveClass(/is-open/, { timeout: 30_000 })
+  await expect(panel.getByRole('link', { name: key, exact: true })).toBeVisible()
+  return panel
+}
+
 test.describe('linked issues', () => {
+  test('label is the catalog phrase for the direction, not the raw token (GDK-1293)', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await page.route(`**/api/v1/issues/${BLOCKED}/linktypes/`, async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      await fulfillJSON(route, CATALOG)
+    })
+    const panel = await gotoIssue(page, BLOCKED)
+    const links = panel.getByTestId('linked-issues')
+    const row = links.getByRole('button').filter({ hasText: BLOCKER })
+    await expect(row).toContainText('is blocked by')
+    await expect(links.getByText('inward', { exact: true })).toHaveCount(0)
+    await expect(links.getByText('outward', { exact: true })).toHaveCount(0)
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('without a catalog the label falls back to the type name, never the token', async ({
+    page,
+  }) => {
+    const errors = attachConsoleErrors(page)
+    await page.route(`**/api/v1/issues/${BLOCKED}/linktypes/`, async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      await fulfillJSON(route, { link_types: [] })
+    })
+    const panel = await gotoIssue(page, BLOCKED)
+    const links = panel.getByTestId('linked-issues')
+    const row = links.getByRole('button').filter({ hasText: BLOCKER })
+    await expect(row).toContainText('Blocks')
+    await expect(links.getByText('inward', { exact: true })).toHaveCount(0)
+    await expect(links.getByText('outward', { exact: true })).toHaveCount(0)
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('back returns to the issue the link was followed from (GDK-1292)', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    await page.route('**/api/v1/issues/*/linktypes/', async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      await fulfillJSON(route, CATALOG)
+    })
+    const panel = await gotoIssue(page, BLOCKER)
+
+    await panel.getByTestId('linked-issues').getByRole('button').filter({ hasText: BLOCKED }).click()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKED}`))
+    await expect(panel.getByRole('link', { name: BLOCKED, exact: true })).toBeVisible()
+
+    // Following a link left an entry, so back reopens the issue it came from.
+    await page.goBack()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}`), { timeout: 5_000 })
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toBeVisible()
+
+    // Closing is a move too: back after close reopens what was closed.
+    await panel.getByTestId('issue-detail-close').click()
+    await expect(page).not.toHaveURL(/issue=/)
+    await expect(panel).not.toHaveClass(/is-open/)
+    await page.goBack()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}`), { timeout: 5_000 })
+    await expect(panel).toHaveClass(/is-open/)
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toBeVisible()
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('an issue opened over a document takes the panel, and back gives the document back', async ({
+    page,
+    request,
+  }) => {
+    // The right panel is one union: opening the issue pushes `issue=` while the
+    // document's binding drops `doc=` in the same flush. The second write must
+    // build on the first (setParams syncs the router on push), or the queued
+    // hashchange reads a hash with no `issue=` and closes the panel it just
+    // opened — which is what the full suite showed, and this spec alone did not.
+    const errors = attachConsoleErrors(page)
+    const res = await request.get(apiURL('/api/v1/issues/pages/'))
+    const body = (await res.json()) as { pages: { key: string }[] }
+    const doc = [...body.pages].sort((a, b) => a.key.localeCompare(b.key))[0]
+
+    await forceLocale(page, 'en')
+    await page.goto(`/#/?doc=${encodeURIComponent(doc.key)}`)
+    await expect(page.getByTestId('doc-panel')).toBeVisible({ timeout: 30_000 })
+    // The document link restores the documents screen in the main column; the
+    // issue list comes back through the sidebar, with the panel still open.
+    await page.getByRole('button', { name: /All open/ }).click()
+    await expect(page.getByTestId('issue-list-scroller')).toBeVisible()
+    await expect(page.getByTestId('doc-panel')).toBeVisible()
+
+    // From the list, not the address bar: it is the state moving first that
+    // makes the two bindings write in one flush.
+    await searchInput(page).fill(BLOCKER)
+    await searchInput(page).press('Enter')
+    const panel = page.getByTestId('issue-detail-panel')
+    await expect(panel).toHaveClass(/is-open/)
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toBeVisible()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}`))
+    await expect(page).not.toHaveURL(/doc=/)
+    await expect(page.getByTestId('doc-panel')).toHaveCount(0)
+
+    // And the other way round: a document opened over the issue, from the
+    // sidebar's recent list.
+    await page.getByTestId(`recent-doc-${doc.key}`).getByRole('button').first().click()
+    await expect(page.getByTestId('doc-panel')).toBeVisible()
+    await expect(page).toHaveURL(/doc=/)
+    await expect(page).not.toHaveURL(/issue=/)
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toHaveCount(0)
+
+    // Each open was a move, so back walks them in reverse.
+    await page.goBack()
+    await expect(page).toHaveURL(new RegExp(`issue=${BLOCKER}`), { timeout: 5_000 })
+    await expect(page).not.toHaveURL(/doc=/)
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toBeVisible()
+    await expect(page.getByTestId('doc-panel')).toHaveCount(0)
+
+    await page.goBack()
+    await expect(page).toHaveURL(/doc=/, { timeout: 5_000 })
+    await expect(page).not.toHaveURL(/issue=/)
+    await expect(page.getByTestId('doc-panel')).toBeVisible()
+    await expect(panel.getByRole('link', { name: BLOCKER, exact: true })).toHaveCount(0)
+
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
   test('add: request carries type+key; list shows the refreshed link, not the typed guess', async ({
     page,
   }) => {

--- a/e2e/url-state.spec.ts
+++ b/e2e/url-state.spec.ts
@@ -161,10 +161,11 @@ test.describe('place params', () => {
     await dialog.getByRole('button', { name: en['settings.tabMembers'], exact: true }).click()
     await expect(page).toHaveURL(/settings=members/)
 
-    // Esc closes through the dialog's own handler; the param goes with it.
+    // Esc closes through the dialog's own handler; the param goes with it —
+    // closing is a history.back() (GDK-1296), so the URL follows on popstate.
     await page.keyboard.press('Escape')
     await expect(dialog).toHaveCount(0)
-    expect(page.url()).not.toContain('settings=')
+    await expect(page).not.toHaveURL(/settings=/)
 
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -18,7 +18,7 @@
   import { bulk } from './stores/bulk.svelte'
   import { triage } from './stores/triage.svelte'
   import { dashboards } from './stores/dashboards.svelte'
-  import { router } from './lib/router.svelte'
+  import { pushHash, router } from './lib/router.svelte'
   import { bindParam, bindParams } from './lib/url-sync.svelte'
   import { createGlobalKeyHandler } from './lib/keymap.svelte'
   import { applyStartupView, readLastViewKey } from './lib/startup-view'
@@ -311,19 +311,18 @@
           // Taking the column is dashboards.open's own move (GDK-821 union) —
           // whatever full-column surface was up, feed included, is released.
           dashboards.open(dashId)
-          const nextDash = q ? `#/?${q}` : '#/'
-          if (location.hash !== nextDash) location.hash = nextDash
+          pushHash(q ? `#/?${q}` : '#/')
           return
         }
-        // Column latches first (showIssueList → applyConfig replaceState).
-        // Then the CLI's literal hash, so ks=A,B stays unescaped. Do not
-        // replaceState+hashchange here: that re-parses location.hash before
-        // applyConfig's router write and can drop the focus view.
+        // Column latches first (showIssueList → applyConfig). Then the CLI's
+        // literal hash, so ks=A,B stays unescaped — through the router, which
+        // syncs its own state on the spot (a raw `location.hash =` left it a
+        // task stale, and the column binding's flush rebuilt the hash from
+        // that) and folds this push into applyConfig's: one arrival, one entry.
         const focused = parseView(new URLSearchParams(q))
         showIssueList(focused.config)
         filters.notifyKeysCapped(focused.keys)
-        const next = q ? `#/?${q}` : '#/'
-        if (location.hash !== next) location.hash = next
+        pushHash(q ? `#/?${q}` : '#/')
       } catch {
         /* serve without the endpoint, or offline */
       }
@@ -495,7 +494,9 @@
       group: me.group,
     }
     applyStartupView(startupInput, (c) => {
-      filters.applyConfig(c)
+      // Boot, not a move: the default view rewrites the entry the tab opened
+      // on, so back from the first screen does not land on the unfiltered pool.
+      filters.applyConfig(c, true)
       filters.setViewOrigin(c.filters)
     })
     filters.latchOriginFromBuiltins()
@@ -545,6 +546,10 @@
    * once in lib/url-sync, where it also owns the last-synced value it needs.
    */
 
+  // Every place binding pushes (lib/url-sync): opening, switching or closing
+  // an issue is a move, so back reopens the issue a link was followed from,
+  // or the one just closed (GDK-1292). The settings dialog below is the one
+  // binding with its own history mode.
   bindParam({
     param: 'issue',
     read: () => selection.selectedKey,
@@ -566,7 +571,9 @@
     read: () => ({
       space: pages.spaceView,
       docs: pages.docsView ? '1' : null,
-      dview: pages.spaceTree ? 'tree' : null,
+      // Only inside a space: the flag outlives one (openDocs leaves it), and
+      // an address carrying `dview` alone would say nothing.
+      dview: pages.spaceView && pages.spaceTree ? 'tree' : null,
       hist: pages.historyView ? '1' : null,
     }),
     write: ({ space, docs, dview, hist }) => {
@@ -648,9 +655,13 @@
   // the tab list will grow, and a link from before a rename must keep opening
   // something real. Registered only where the settings verb exists, so the
   // hosted snapshot neither opens nor rewrites a `settings=` param.
+  // History: opening pushes one entry, a tab switch rewrites it, and closing
+  // is the same move as back — so back never lands on a dead press and
+  // forward reopens what was closed (GDK-1296 rules 2 and 3).
   if (hasServerVerb('settings')) {
     bindParam({
       param: 'settings',
+      mode: (prev, next) => (prev === null ? 'push' : next === null ? 'back' : 'replace'),
       read: () => (serverSettingsOpen ? serverSettingsTab : null),
       write: (v) => {
         if (v === null) {
@@ -796,7 +807,12 @@
     >
       <Sidebar>
         {#snippet children()}
-          <SidebarNav onOpenSettings={() => (serverSettingsOpen = true)} />
+          <SidebarNav
+            onOpenSettings={(tab) => {
+              serverSettingsOpen = true
+              if (tab) serverSettingsTab = tab
+            }}
+          />
         {/snippet}
       </Sidebar>
 

--- a/web/src/components/detail/LinkedIssues.svelte
+++ b/web/src/components/detail/LinkedIssues.svelte
@@ -16,9 +16,18 @@
 
   let { linked }: { linked: LinkedIssue[] } = $props()
 
-  /** Human label from direction/type. Prefer backend direction text when present. */
+  /**
+   * Human label. The mirror stores `direction` as the bare token
+   * (`inward`/`outward`, sync.go) and `type` as the link type's name, so the
+   * phrase for this side ("is blocked by" / "blocks") is looked up in the
+   * catalog the add form already fetches; without a catalog, the type name.
+   * The token itself is never shown (GDK-1293).
+   */
   function label(l: LinkedIssue): string {
-    return (l.direction && l.direction.trim()) || l.type || t('detail.linked')
+    const dir = (l.direction ?? '').trim()
+    const row = types.find((r) => r.name.toLowerCase() === (l.type ?? '').toLowerCase())
+    const phrase = dir === 'inward' ? row?.inward : dir === 'outward' ? row?.outward : dir
+    return phrase?.trim() || l.type || t('detail.linked')
   }
 
   // Backend sometimes duplicates the same link (key+direction). Duplicate each keys

--- a/web/src/components/sidebar/SidebarNav.svelte
+++ b/web/src/components/sidebar/SidebarNav.svelte
@@ -15,6 +15,7 @@
   import { onboarding } from '../../stores/onboarding.svelte'
   import { pages } from '../../stores/pages.svelte'
   import { showIssueList } from '../../lib/show-issue-list'
+  import type { SettingsTab } from '../../lib/settings-tabs'
   import { write } from '../../stores/write.svelte'
   import { runSyncNow } from '../../lib/sync-now'
   import { copyText } from '../../lib/copy-text'
@@ -31,7 +32,6 @@
     workspaceName,
   } from '../../lib/config'
   import { isLocalOrigin, STANDALONE_INIT_COMMAND } from '../../lib/workspace'
-  import { setParams } from '../../lib/router.svelte'
   import { mirrorLabel } from '../../lib/mirror-status'
   import { docsEmptyClickAction, docsEmptyGlyph } from '../../lib/docs-empty'
   import { docsEmpty } from '../../stores/docs-empty.svelte'
@@ -50,7 +50,7 @@
   docsEmpty.bind()
 
   /** Open server settings dialog — App.svelte mounts the dialog itself. */
-  let { onOpenSettings }: { onOpenSettings: () => void } = $props()
+  let { onOpenSettings }: { onOpenSettings: (tab?: SettingsTab) => void } = $props()
 
   let draggingId = $state<SectionId | null>(null)
   let dropTargetId = $state<SectionId | null>(null)
@@ -901,7 +901,7 @@
                 type="button"
                 data-testid="workspace-new"
                 class="flex h-control w-full items-center gap-2 rounded-md px-3 text-left text-body text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary"
-                onclick={() => setParams({ settings: 'workspaces' })}
+                onclick={() => onOpenSettings('workspaces')}
               >
                 <span class="flex-none text-text-muted" aria-hidden="true">+</span>
                 <span class="min-w-0 flex-1 truncate">{t('sidebar.workspaceNew')}</span>
@@ -943,7 +943,7 @@
       <button
         type="button"
         class="mb-1 flex h-control-sm w-full items-center gap-1.5 rounded-md px-1 text-body text-text-muted transition-colors hover:bg-bg-hover hover:text-text-primary"
-        onclick={onOpenSettings}
+        onclick={() => onOpenSettings()}
         title={t('sidebar.serverSettings')}
       >
         <Icon name="settings" size={14} />

--- a/web/src/lib/router.svelte.ts
+++ b/web/src/lib/router.svelte.ts
@@ -40,32 +40,94 @@ export const router = {
   },
 }
 
+/*
+ * What a write does to history — the three rules every caller lives by:
+ *
+ *   1. a place (which issue, which filters, which screen) pushes, so back is
+ *      the previous place;
+ *   2. a dialog opening pushes one entry; closing it is `history.back()`
+ *      (the binding's job, see url-sync — the marker below is how it knows
+ *      the entry it is closing is the one it opened);
+ *   3. continuous input — typing, a dialog's tabs, scrolling — replaces.
+ *
+ * And one entry per user action: the stores that mirror the URL write from
+ * effects, which flush in a microtask, so opening an issue over a document
+ * (`doc=` leaves, `issue=` arrives) or applying a view that also releases the
+ * column reaches here as two pushes in one task. The second becomes a
+ * replace — back then walks actions, not the writes that made them up.
+ * A setTimeout(0) ends the task; a click, a key, a poll tick is the next one.
+ * The next input also ends it outright: Chromium runs input ahead of timers,
+ * so with the list still re-rendering after a typed query, the click that
+ * opened an issue arrived before the timer and its push fell to a replace
+ * (measured flaky in e2e/history-nav.spec.ts — back skipped the query).
+ */
+let pushedThisTask = false
+
+if (typeof window !== 'undefined') {
+  for (const type of ['pointerdown', 'keydown', 'input'] as const) {
+    window.addEventListener(
+      type,
+      () => {
+        pushedThisTask = false
+      },
+      { capture: true },
+    )
+  }
+}
+
+function commit(hash: string, replace: boolean, entry?: string): void {
+  if (replace || pushedThisTask) {
+    // A replace keeps the entry's marker: a dialog's tab switches must not
+    // erase the sign that its open pushed this entry.
+    history.replaceState(entry ? { entry } : history.state, '', hash)
+  } else if (hash !== location.hash) {
+    history.pushState(entry ? { entry } : null, '', hash)
+    pushedThisTask = true
+    setTimeout(() => {
+      pushedThisTask = false
+    }, 0)
+  }
+  // Neither fires hashchange — sync now, so a second write in the same flush
+  // builds on this one instead of on the hash before it (GDK-1292).
+  current = parseHash(hash)
+}
+
 /** Replace the whole hash (path + params). Pushes a new history entry. */
 export function navigate(path: string, params?: URLSearchParams | Record<string, string>): void {
   const sp =
     params instanceof URLSearchParams
       ? params
       : new URLSearchParams((params ?? {}) as Record<string, string>)
-  location.hash = serialize({ path, params: sp })
+  commit(serialize({ path, params: sp }), false)
+}
+
+/** Push a hash string as given — for a hash another process composed
+ *  (`views open`), whose spelling (`ks=A,B` unescaped) is kept verbatim. */
+export function pushHash(hash: string): void {
+  commit(hash, false)
 }
 
 /**
  * Merge-update several query params — preserve the rest.
  * `null` removes that key. Path stays. `replace=true` rewrites the current
- * history entry instead of pushing (useful while scrolling/typing).
+ * history entry instead of pushing (continuous input — rule 3 above).
+ * `entry` marks a pushed entry so its owner can recognise it (rule 2).
  */
-export function setParams(next: Record<string, string | null>, replace = false): void {
+export function setParams(
+  next: Record<string, string | null>,
+  replace = false,
+  entry?: string,
+): void {
   const sp = new URLSearchParams(current.params)
   for (const [k, v] of Object.entries(next)) {
     if (v === null) sp.delete(k)
     else sp.set(k, v)
   }
-  const hash = serialize({ path: current.path, params: sp })
-  if (replace) {
-    history.replaceState(null, '', hash)
-    // replaceState does not fire hashchange — sync manually
-    current = parseHash(hash)
-  } else {
-    location.hash = hash
-  }
+  commit(serialize({ path: current.path, params: sp }), replace, entry)
+}
+
+/** Is the current history entry one pushed under this marker? */
+export function atEntry(entry: string): boolean {
+  const s = history.state as { entry?: unknown } | null
+  return s !== null && typeof s === 'object' && s.entry === entry
 }

--- a/web/src/lib/url-sync.svelte.ts
+++ b/web/src/lib/url-sync.svelte.ts
@@ -21,13 +21,22 @@
  * state instead and the first pass reads that promotion as a param the URL has
  * dropped, and closes what it just opened.
  *
- * Writes are `replace`, so a selection does not fill the back stack; a real
- * navigation is still the user's own.
+ * A state-first move pushes (a place param names a place, and back is the
+ * previous place — GDK-1292/GDK-1296); a binding whose param is a dialog
+ * decides per move through `mode`: open pushes, tab switches replace, and
+ * close is `history.back()` when the entry being left is the one its open
+ * pushed (router `atEntry`), else a replace. Two exceptions are never pushes:
+ * the first pass (a deep link the app promotes or normalizes arrives as one
+ * entry), and a URL-first move — what the store makes of an arriving value
+ * (`settings=bogus` → `sync`, a `dview` outside any space) is written back in
+ * place, so back and forward never lose the entries ahead of them.
  */
 
 import { untrack } from 'svelte'
-import { router, setParams } from './router.svelte'
+import { atEntry, router, setParams } from './router.svelte'
 import type { PlaceParamKey } from './url-state'
+
+export type HistoryMode = 'push' | 'replace' | 'back'
 
 /** The value of each bound param — `null` meaning absent, both in the URL and
  *  in whatever state mirrors it. */
@@ -66,10 +75,15 @@ export function bindParams<K extends PlaceParamKey>(spec: {
   params: readonly K[]
   read: () => ParamValues<K>
   write: (next: ParamValues<K>) => void
+  /** What a state-first move does to history; default `push`. `back` is
+   *  honoured only on the entry this binding's own push left (else replace). */
+  mode?: (prev: ParamValues<K>, next: ParamValues<K>) => HistoryMode
 }): void {
-  const { params, read, write } = spec
+  const { params, read, write, mode } = spec
+  const entry = params.join('+')
   // Seeded from the URL, before the first pass — see the note above.
   let synced = readUrl(params)
+  let first = true
 
   $effect(() => {
     const url = readUrl(params)
@@ -79,15 +93,28 @@ export function bindParams<K extends PlaceParamKey>(spec: {
 
     if (differs(url, synced, params)) {
       synced = url
+      first = false
       // The write is a write, not a read: untracked so applying it cannot
       // subscribe this effect to whatever the setters happen to touch.
       untrack(() => write(url))
+      const after = untrack(read)
+      if (differs(after, url, params)) {
+        synced = after
+        setParams(after, true)
+      }
       return
     }
     if (differs(state, synced, params)) {
+      const how: HistoryMode = first ? 'replace' : (mode?.(synced, state) ?? 'push')
       synced = state
-      setParams(state, true)
+      if (how === 'back' && atEntry(entry)) {
+        // The hash follows on popstate; `synced` already says where it lands.
+        history.back()
+      } else {
+        setParams(state, how !== 'push', how === 'push' ? entry : undefined)
+      }
     }
+    first = false
   })
 }
 
@@ -97,11 +124,13 @@ export function bindParam(spec: {
   param: PlaceParamKey
   read: () => string | null
   write: (next: string | null) => void
+  mode?: (prev: string | null, next: string | null) => HistoryMode
 }): void {
-  const { param, read, write } = spec
+  const { param, read, write, mode } = spec
   bindParams({
     params: [param],
     read: () => ({ [param]: read() }) as ParamValues<typeof param>,
     write: (next) => write(next[param]),
+    mode: mode && ((prev, next) => mode(prev[param], next[param])),
   })
 }

--- a/web/src/stores/filters.svelte.ts
+++ b/web/src/stores/filters.svelte.ts
@@ -4,7 +4,8 @@
  * Design: **the URL hash is the single source of truth for the view**.
  *  - filters/display derive from router.params (parseConfig) → "view = URL" holds naturally.
  *  - Every change (chip add/remove · grouping · sort · query) updates the URL via
- *    setParams(replace) → derived values recompute.
+ *    setParams → derived values recompute. A change is a move and pushes
+ *    (back is the previous view); typing inside a query, and boot, replace.
  *  - Selecting an issue (?issue) must not refilter: an intermediate stable string
  *    (#viewKey) of view-only params blocks refilter (perf discipline).
  *
@@ -337,16 +338,16 @@ class FiltersStore {
   /** facet: value distribution over the full pool (add dropdowns). Includes member name labels. */
   facets = $derived.by(() => buildFacets(issues.allIssues, issues.members))
 
-  /* ── Mutations: all via URL update (replace, no history push) ── */
+  /* ── Mutations: all via URL update. Push unless told to replace. ── */
 
-  #apply(config: ViewConfig): void {
+  #apply(config: ViewConfig, replace = false): void {
     const params = configToParams(config)
     // A dynamic axis dropped from the config must clear its URL param too —
     // configToParams only emits keys for axes still present.
     for (const [k] of router.params) {
       if (k.startsWith(DYN_FIELD_PREFIX) && !(k in params)) params[k] = null
     }
-    setParams(params, true)
+    setParams(params, replace)
   }
 
   /** Independent copy of current config (arrays cloned). Starting point for mutations. */
@@ -426,10 +427,13 @@ class FiltersStore {
   }
 
   setQuery(q: string): void {
-    if (q === this.#config.filters.q) return
+    const prev = this.#config.filters.q
+    if (q === prev) return
     const c = this.snapshot()
     c.filters.q = q
-    this.#apply(c)
+    // Typing is continuous input: one entry for the query however many
+    // keystrokes land, pushed when the box goes empty → text or text → empty.
+    this.#apply(c, Boolean(prev.trim()) === Boolean(q.trim()))
     // Local query change invalidates prior server-search results
     if (!q.trim()) this.clearServerSearch()
   }
@@ -475,11 +479,12 @@ class FiltersStore {
     this.#apply(c)
   }
 
-  /** Apply a saved/default view wholesale. */
-  applyConfig(config: ViewConfig): void {
+  /** Apply a saved/default view wholesale. `replace` for boot writes (the
+   *  startup default), which are not a move the user made. */
+  applyConfig(config: ViewConfig, replace = false): void {
     this.clearServerSearch()
     this.notifyKeysCapped(normalizeKeys(config.filters?.keys ?? []))
-    this.#apply(mergeConfig(config))
+    this.#apply(mergeConfig(config), replace)
   }
 
   /**

--- a/web/src/stores/pages.test.ts
+++ b/web/src/stores/pages.test.ts
@@ -267,7 +267,11 @@ describe('GDK-815 the dashboard releases the main column', () => {
     // applyConfig writes the applied view into the hash; node has no history
     // API. Only that URL write is stubbed — the assertion is about the
     // store, not the hash.
-    ;(globalThis as { history?: Partial<History> }).history ??= { replaceState: () => {} }
+    ;(globalThis as { history?: Partial<History> }).history ??= {
+      replaceState: () => {},
+      pushState: () => {},
+    }
+    ;(globalThis as { location?: Partial<Location> }).location ??= { hash: '' }
     dashboards.open('e2e-gdk815')
     expect(dashboards.openId).toBe('e2e-gdk815')
     showIssueList(emptyConfig())


### PR DESCRIPTION
Fixes the back-button half of GitHub discussion #80: clicking a linked issue (and picking a person, applying a view, committing a query) changed the hash without a history entry, so back skipped or did nothing.

- `web/src/lib/router.svelte.ts` owns the rule: a place pushes; a dialog pushes one entry and closes with `history.back()`; continuous input replaces. Writes in one flush coalesce into one entry, and a new user input ends the window (Chromium runs input ahead of timers — without this a click could land before the `setTimeout(0)` and fall to a replace).
- `url-sync.svelte.ts` bindings declare push/replace/back per param; `LinkedIssues`, `SidebarNav`, `filters` route through it.
- `e2e/history-nav.spec.ts` presses back and forward for real on each surface.

Backlog: GDK-1296 (parent), GDK-1292, GDK-1293 — public backlog https://gadak.dev/backlog/#/?ks=GDK-1296,GDK-1292,GDK-1293.

Gates run locally: typecheck, vitest 1049, doc-checks, Playwright 423 (history-nav spec 42/42 across repeats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
