### PR TITLE
Store package: gadak.exe on PATH via app-execution alias, ja-JP resource (0.20.2 resubmission)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,8 +821,8 @@ jobs:
         run: go test ./... -run 'Protocol' -count=1
 
       # makeappx validates the manifest schema; only an install proves the
-      # identity, the full-trust entry point and the protocol declaration
-      # are accepted. The Store re-signs with its own certificate, so here
+      # identity, the full-trust entry point, the protocol declaration and the
+      # app-execution alias are accepted. The Store re-signs with its own certificate, so here
       # a throwaway self-signed certificate with the same Publisher CN
       # stands in — trusted by this runner only, for the length of the step.
       # Last in the job on purpose: deploying a package that declares
@@ -861,7 +861,20 @@ jobs:
           if ($pkg.Publisher -ne $publisher) { throw "publisher drifted: $($pkg.Publisher) vs manifest $publisher" }
           $installed = Join-Path $pkg.InstallLocation 'gadak-desktop.exe'
           if (-not (Test-Path -LiteralPath $installed)) { throw "package has no gadak-desktop.exe at $installed" }
+          # The Store install must put the CLI on PATH (GDK app-execution
+          # alias, 0.20.2): Windows materialises a declared alias as
+          # %LOCALAPPDATA%\Microsoft\WindowsApps\gadak.exe on install. The
+          # zip's gadak.exe never had this problem; the Store package did —
+          # its gadak.exe sat under WindowsApps\<identity>\ where no shell
+          # looks. Asking the alias for its version proves it points at the
+          # packaged CLI, not that a file merely exists.
+          $alias = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps\gadak.exe'
+          if (-not (Test-Path -LiteralPath $alias)) { throw "install created no app-execution alias at $alias (manifest declares no windows.appExecutionAlias for gadak.exe?)" }
+          $aliasOut = & $alias version 2>&1 | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "alias gadak.exe version exited ${LASTEXITCODE}: $aliasOut" }
+          Write-Host ("alias gadak.exe -> " + $aliasOut.Trim())
           Remove-AppxPackage -Package $pkg.PackageFullName
+          if (Test-Path -LiteralPath $alias) { throw "alias $alias survived Remove-AppxPackage" }
           Write-Host "msix install/uninstall — ok"
           exit 0
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -51,7 +51,11 @@ because Partner Center refuses a 0.x major — see the comment in the script;
 that mapping is a one-way door once the Store has accepted a package. The
 output is unsigned on purpose: the Store re-signs with a Microsoft
 certificate after certification, so the file is for Partner Center, not for
-users ([GDK-1380]).
+users ([GDK-1380]). The manifest also declares an app-execution alias for
+`gadak.exe`, so a Store install puts `gadak` on `PATH`
+(`%LOCALAPPDATA%\Microsoft\WindowsApps\gadak.exe`) — the zip never needed
+one — and the three UI languages (en-US, ko-KR, ja-JP), each of which needs a
+listing in Partner Center.
 
 The Windows directory name uses the Windows pack labels (`x64`, `arm64`), not
 the macOS dmg labels (`amd64`, `arm64`) or the AppImage / `uname -m` labels

--- a/desktop/msix/AppxManifest.xml
+++ b/desktop/msix/AppxManifest.xml
@@ -15,8 +15,10 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-  IgnorableNamespaces="uap rescap">
+  IgnorableNamespaces="uap uap3 desktop rescap">
 
   <Identity
     Name="midagedev.Gadak"
@@ -36,8 +38,13 @@
   </Dependencies>
 
   <Resources>
+    <!-- The three languages the UI speaks (web/src/lib/i18n, GDK-626). Each
+         declared language needs a Partner Center listing in that language;
+         the web layer picks the locale from the OS language itself, so these
+         rows are the Store's knowledge of it, not resource files. -->
     <Resource Language="en-US" />
     <Resource Language="ko-KR" />
+    <Resource Language="ja-JP" />
   </Resources>
 
   <Applications>
@@ -62,6 +69,19 @@
             <uap:DisplayName>Gadak</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
+        <!-- `gadak` on PATH for a Store install. The package carries the same
+             gadak.exe as the zip, but under WindowsApps\<identity>\ no shell
+             finds it; this alias makes Windows materialise
+             %LOCALAPPDATA%\Microsoft\WindowsApps\gadak.exe on install and
+             remove it on uninstall (the CI msix install step asks it for its
+             version). Executable here is the CLI, not the Application's
+             gadak-desktop.exe — the same shape Windows Terminal uses for wt.exe.
+             A zip gadak.exe already on PATH wins or loses by PATH order. -->
+        <uap3:Extension Category="windows.appExecutionAlias" Executable="gadak.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="gadak.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
       </Extensions>
     </Application>
   </Applications>


### PR DESCRIPTION
For the 0.20.2 Microsoft Store resubmission (product 9NZW91TXH36G, GDK-1380), two manifest changes that ride along with the console-window fix already on main (b086bb2a):

1. **`gadak.exe` app-execution alias.** The Store package carries the same `gadak.exe` as the zip, but it sits under `WindowsApps\<identity>\` where no shell looks — `docs/INSTALL.md` says so today. A `windows.appExecutionAlias` declaration makes Windows put `%LOCALAPPDATA%\Microsoft\WindowsApps\gadak.exe` on install, so a Store user gets the CLI without the zip.
2. **`ja-JP` resource.** The UI has spoken Japanese since GDK-626; declaring the language lets the listing carry a ja-JP page and the Japan market find it.

**Gate, FAIL-first.** The first commit extends the existing "msix installs under its declared identity" step: after `Add-AppxPackage` it asks the alias for its version, and asserts the alias is gone after removal. It is pushed *before* the manifest change so the Windows job's red is the gate's proof. The second commit adds the declaration and the job goes green.

**Verification boundary.** makeappx + a self-signed install on the CI runner prove the manifest is accepted and the alias resolves. WACK and the Store's own certification run at submission; a real-device check happens on the resubmitted package. `docs/INSTALL.md` keeps saying the Store package does not put `gadak.exe` on `PATH` until the 0.20.2 package is the live one — that sentence flips with the resubmission, not with this merge.

Why a PR: `.github/workflows/` and `desktop/` are the two surfaces whose gate cannot run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)