### PR TITLE
gates: staticcheck over the GOOS matrix, warning-only in CI (GDK-1463)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,44 @@ jobs:
           [ "$rows" -gt 0 ] || { echo "epic GROUP BY (the linked demo query) returned 0 rows" >&2; exit 1; }
           echo "snapshot portable: fts_hits=$hits epic_rows=$rows"
 
+  staticcheck:
+    name: Staticcheck (warning-only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # What decides whether a finding fails the run or is a build-tag
+      # artefact is the script's classifier, not staticcheck. It runs over
+      # fixtures, needs no toolchain, and takes a second.
+      - name: staticcheck.sh self-test
+        run: bash tools/staticcheck.sh --self-test
+
+      # Pinned on purpose: staticcheck gains checks between releases, and
+      # @latest would turn a new check into a CI change nobody made.
+      - name: Install staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      # --warn-only while the existing findings are triaged (GDK-1463): this
+      # job reports and never fails. Dropping the flag is what makes it a gate.
+      #
+      # GTK4/WebKitGTK is deliberately not installed. Without it the desktop
+      # module cannot be analysed under GOOS=linux or darwin, and the script
+      # skips both with a note and analyses GOOS=windows — worth more than a
+      # second copy of the mirror-flaky apt step in this file for a job that
+      # cannot fail. The root module gets all three either way.
+      - name: staticcheck over the GOOS matrix
+        run: bash tools/staticcheck.sh --warn-only
+
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ hard-won 목록)와 `AGENTS.md`(스키마·쿼리)가 원본이다.
   게이트다**: `cd desktop && go mod tidy && go build ./...`. 2026-08-23
   GDK-635에서 internal/ 신규 패키지의 runewidth import가 desktop go.sum에
   없어 데스크톱 CI 3개 잡이 빨갛게 됐다 — 로컬 go 전체는 초록이었다.
+- **Go 정적 분석은 `bash tools/staticcheck.sh`이고 반드시 GOOS 매트릭스다**
+  (GDK-1463). darwin 단독 실행은 `//go:build` 반대편에서만 호출되는 함수를
+  U1000 죽은 코드로 오탐한다(`parseProcStartTime`·`protocolDefaultIcon`
+  실측). 세 GOOS가 모두 동의한 것만 실패이고 나머지는 informational로
+  인쇄된다. ST1005는 제외(한국어 에러 문장·의도된 다중행 프로토콜 에코).
+  CI 잡 `Staticcheck (warning-only)`은 `--warn-only`라 아직 게이트가 아니다
+  — 남은 cross-platform 12건을 정리한 뒤 플래그를 떼는 것이 게이트화다.
 - 웹: `make typecheck` (svelte-check). e2e: Playwright, CI 세트는
   `e2e/*.spec.ts`(demo/·hosted/·perf/ 제외 — `e2e/playwright.config.ts`).
 - **`mobile/`은 루트 게이트가 보지 않는다** — 자기 tsconfig·자기 lockfile을

--- a/tools/README.md
+++ b/tools/README.md
@@ -206,3 +206,40 @@ as the system ANSI page).
 # After desktop/build-windows.ps1 has written the portable directory:
 tools/winsmoke.ps1 -BundleDir desktop\\build\\Gadak-<ver>-x64 -OutDir $env:TEMP\\gadak-winsmoke\\out
 ```
+
+## `staticcheck.sh`
+
+Runs [staticcheck](https://staticcheck.dev) over both Go modules (root and
+`desktop/`, which has its own `go.mod`) under GOOS darwin, linux and windows,
+and reports only what every analysed GOOS agrees on (GDK-1463).
+
+The matrix is the point. staticcheck analyses one GOOS at a time, so a function
+whose only caller sits behind a `//go:build <other-goos>` tag looks like dead
+code: a darwin-only run calls `parseProcStartTime` (`internal/term/`, called
+from `members_linux.go`) and `protocolDefaultIcon` (`desktop/`, called from
+`protocol_windows.go`) unused, and both are false. Findings that appear under
+some but not all GOOS are printed under a **platform-only (informational)**
+heading with the GOOS they came from, and never fail the run.
+
+`ST1005` is excluded: gadak's error strings are Korean sentences that start
+with a Latin word, and `internal/mcp/tools.go` echoes a multi-line protocol
+string on purpose.
+
+A `(module, GOOS)` pair that the host cannot cross-compile is skipped with a
+note rather than reported — `desktop/` pulls wails, whose linux backend is cgo,
+so `GOOS=linux` cannot be analysed from macOS and `GOOS=darwin` cannot be from
+the linux CI runner. A compile error in a path **inside** this repo is a real
+break and fails; one in the module cache is the skip. Either way the run
+contributes no findings, because an incomplete package set would demote real
+ones by accident.
+
+```bash
+tools/staticcheck.sh               # exit 1 on cross-platform findings
+tools/staticcheck.sh --warn-only   # always exit 0 — what CI runs today
+tools/staticcheck.sh --goos darwin # one GOOS, to reproduce a single finding
+tools/staticcheck.sh --self-test   # classifier vs fixtures; no toolchain needed
+```
+
+Requires `go install honnef.co/go/tools/cmd/staticcheck@latest` (the script
+prints that line and exits 2 if the binary is missing). CI pins the version and
+runs `--warn-only` in the `Staticcheck (warning-only)` job.

--- a/tools/staticcheck.sh
+++ b/tools/staticcheck.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# staticcheck over the GOOS matrix, for both Go modules (GDK-1463).
+#
+# Why a matrix and not a single run: staticcheck analyses one GOOS at a time,
+# so every function whose only caller sits behind a `//go:build <other-goos>`
+# tag is dead code from where it stands. On this repo a darwin-only run reports
+# `parseProcStartTime` (internal/term/members_stat.go, called from
+# members_linux.go) and `protocolDefaultIcon` (desktop/protocol.go, called from
+# protocol_windows.go) as U1000 — both false. Running darwin, linux and windows
+# and keeping only what every run agrees on removes that whole class, and the
+# per-GOOS leftovers are printed separately as information rather than dropped.
+#
+# ST1005 (error strings should not be capitalized / end in punctuation) is
+# excluded: gadak's user-facing error strings are Korean sentences that begin
+# with a Latin word (cmd/gadak/raycast.go) and internal/mcp/tools.go echoes a
+# multi-line protocol string on purpose. The check has no way to tell those from
+# the style problem it is looking for.
+#
+# Some (module, GOOS) pairs cannot be analysed on a given host: desktop/ pulls
+# wails, whose linux backend is cgo, so GOOS=linux fails to build from macOS
+# (and GOOS=darwin fails from the linux CI runner). The script tells that apart
+# from a real break by where the compile error lives — a path inside this repo
+# is a failure and is reported; a path in the module cache means the host cannot
+# cross-compile that pair, so the pair is skipped with a note and left out of
+# the matrix. A run that does not compile never contributes findings, because
+# its package set is incomplete and would demote real findings by accident.
+#
+# Usage:
+#   tools/staticcheck.sh                 # exit 1 on cross-platform findings
+#   tools/staticcheck.sh --warn-only     # always exit 0 (what CI runs today)
+#   tools/staticcheck.sh --goos darwin   # one GOOS, for reproducing a finding
+#   tools/staticcheck.sh --self-test     # check the classifier against fixtures
+#
+# Exit 0 = no cross-platform findings (or --warn-only).
+#      1 = cross-platform findings, or the repo does not compile for some GOOS.
+#      2 = staticcheck is not installed, or bad arguments.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+WARN_ONLY=0
+SELF_TEST=0
+GOOSES=(darwin linux windows)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --warn-only) WARN_ONLY=1; shift ;;
+    --self-test) SELF_TEST=1; shift ;;
+    --goos) IFS=',' read -r -a GOOSES <<< "$2"; shift 2 ;;
+    -h|--help) sed -n '2,38p' "$0"; exit 0 ;;
+    *) echo "staticcheck.sh: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# The report half is a variable rather than a heredoc so that --self-test can
+# drive it over fixtures — the classification rules below (in-repo break vs
+# host cannot cross-compile, and the all-GOOS intersection) are the part of
+# this script that is worth testing, and breaking the tree to test them is not
+# an option in a shared checkout.
+PY_REPORT="$(cat <<'PY'
+import collections
+import json
+import os
+import re
+import sys
+
+root, manifest = sys.argv[1], sys.argv[2]
+warn_only = os.environ.get("WARN_ONLY") == "1"
+
+# See the header comment: gadak's error strings are Korean sentences and one
+# deliberate multi-line protocol echo, which ST1005 cannot tell from the style
+# problem it looks for.
+EXCLUDED = {"ST1005"}
+
+# `<path>:<line>:<col>:` inside a compile error's message body.
+COMPILE_PATH = re.compile(r"^(\S+\.go):\d+:\d+:", re.M)
+
+runs = []
+with open(manifest) as fh:
+    for line in fh:
+        module, moddir, goos, stem = line.rstrip("\n").split("\t")
+        runs.append((module, moddir, goos, stem))
+
+status = {}       # (module, goos) -> "ok" | "broken" | "skipped" | "error"
+detail = {}       # (module, goos) -> text explaining a non-ok status
+found = {}        # (module, goos) -> {key: record}
+modules = []
+gooses = []
+
+for module, moddir, goos, stem in runs:
+    if module not in modules:
+        modules.append(module)
+    if goos not in gooses:
+        gooses.append(goos)
+
+    objs, junk = [], []
+    with open(stem + ".json") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                objs.append(json.loads(line))
+            except json.JSONDecodeError:
+                junk.append(line)
+    with open(stem + ".err") as fh:
+        stderr = fh.read().strip()
+
+    compile_msgs = [o.get("message", "") for o in objs if o.get("code") == "compile"]
+
+    if compile_msgs:
+        # Where the broken file lives decides what this means. Inside the repo
+        # it is a real break and the gate has to say so; in the module cache it
+        # means this host cannot build that pair, which is not the repo's fault.
+        in_repo = []
+        for msg in compile_msgs:
+            for rel in COMPILE_PATH.findall(msg):
+                path = os.path.normpath(os.path.join(moddir, rel))
+                if path.startswith(root + os.sep):
+                    in_repo.append(os.path.relpath(path, root))
+        body = "\n".join("    " + ln for m in compile_msgs for ln in m.splitlines())
+        if in_repo:
+            status[(module, goos)] = "broken"
+            detail[(module, goos)] = body
+        else:
+            status[(module, goos)] = "skipped"
+            first = COMPILE_PATH.findall(compile_msgs[0])
+            detail[(module, goos)] = (
+                "does not cross-compile on this host (the failing files are "
+                "dependencies, not this repo): " + (first[0] if first else "?"))
+        found[(module, goos)] = {}
+        continue
+
+    if not objs and (stderr or junk):
+        status[(module, goos)] = "error"
+        detail[(module, goos)] = "\n".join(
+            "    " + ln for ln in (stderr.splitlines() + junk))
+        found[(module, goos)] = {}
+        continue
+
+    records = {}
+    for o in objs:
+        code = o.get("code", "")
+        loc = o.get("location") or {}
+        path = loc.get("file") or ""
+        if not path:
+            continue
+        rel = os.path.relpath(path, root) if path.startswith(root + os.sep) else path
+        # Key on file:line:code, as the finding's column can move between GOOS
+        # runs without the finding being a different one.
+        records["%s:%s:%s" % (rel, loc.get("line"), code)] = (
+            rel, loc.get("line"), loc.get("column"), code, o.get("message", ""))
+    status[(module, goos)] = "ok"
+    found[(module, goos)] = records
+
+fail = False
+cross_total = 0
+platform_total = 0
+out = []
+
+for module in modules:
+    ok = [g for g in gooses if status.get((module, g)) == "ok"]
+    out.append("== module %s ==" % module)
+    for goos in gooses:
+        st = status.get((module, goos))
+        if st is None:
+            continue
+        if st == "ok":
+            out.append("  GOOS=%-8s analysed (%d finding(s) before matrix)"
+                       % (goos, len(found[(module, goos)])))
+        elif st == "skipped":
+            out.append("  GOOS=%-8s SKIPPED — %s" % (goos, detail[(module, goos)]))
+        elif st == "broken":
+            out.append("  GOOS=%-8s DOES NOT COMPILE — this repo's own files:" % goos)
+            out.append(detail[(module, goos)])
+            fail = True
+        else:
+            out.append("  GOOS=%-8s staticcheck failed to run:" % goos)
+            out.append(detail[(module, goos)])
+            fail = True
+
+    if not ok:
+        out.append("  no GOOS could be analysed for this module.")
+        out.append("")
+        continue
+    if len(ok) == 1:
+        out.append("  NOTE: only GOOS=%s could be analysed, so nothing can be "
+                   "demoted — a U1000 here may be a build-tag false positive." % ok[0])
+
+    counts = collections.Counter()
+    record = {}
+    seen_in = collections.defaultdict(list)
+    for goos in ok:
+        for key, rec in found[(module, goos)].items():
+            counts[key] += 1
+            record.setdefault(key, rec)
+            seen_in[key].append(goos)
+
+    def sort_key(k):
+        rel, line, _col, code, _msg = record[k]
+        return (rel, line or 0, code)
+
+    cross, partial = [], []
+    for key, n in counts.items():
+        if record[key][3] in EXCLUDED:
+            continue
+        (cross if n == len(ok) else partial).append(key)
+
+    out.append("")
+    out.append("  cross-platform (%d) — present under every analysed GOOS:" % len(cross))
+    for key in sorted(cross, key=sort_key):
+        rel, line, col, code, msg = record[key]
+        out.append("    %s:%s:%s: %s (%s)" % (rel, line, col, msg, code))
+    if not cross:
+        out.append("    (none)")
+
+    out.append("")
+    out.append("  platform-only (%d, informational) — a build-tag artefact unless "
+               "the file itself is platform-specific:" % len(partial))
+    for key in sorted(partial, key=sort_key):
+        rel, line, col, code, msg = record[key]
+        out.append("    [%s] %s:%s:%s: %s (%s)"
+                   % (",".join(seen_in[key]), rel, line, col, msg, code))
+    if not partial:
+        out.append("    (none)")
+    out.append("")
+
+    cross_total += len(cross)
+    platform_total += len(partial)
+    if cross:
+        fail = True
+
+print("\n".join(out))
+print("summary: %d cross-platform, %d platform-only, ST1005 excluded"
+      % (cross_total, platform_total))
+
+if fail and warn_only:
+    print("--warn-only: reporting without failing.")
+    sys.exit(0)
+if fail:
+    print("FAIL: fix the cross-platform findings above, or exclude the check in "
+          "tools/staticcheck.sh with a reason.")
+    sys.exit(1)
+print("OK")
+sys.exit(0)
+PY
+)"
+
+report() {  # $1 = manifest path
+  WARN_ONLY="$WARN_ONLY" python3 -c "$PY_REPORT" "$ROOT" "$1"
+}
+
+# --- self-test -------------------------------------------------------------
+# Fixtures stand in for six staticcheck runs. They cover the three decisions
+# this script makes that a plain "does it run" check would not: ST1005 dropped,
+# a finding seen under one GOOS of two demoted to platform-only, and the two
+# kinds of compile error told apart by path.
+if [[ "$SELF_TEST" == 1 ]]; then
+  W="$(mktemp -d)"
+  trap 'rm -rf "$W"' EXIT
+  : > "$W/manifest"
+  fixture() {  # module goos json-lines
+    local module="$1" goos="$2" dir="$ROOT"
+    [[ "$module" == desktop ]] && dir="$ROOT/desktop"
+    printf '%s' "$3" > "$W/$module.$goos.json"
+    : > "$W/$module.$goos.err"
+    printf '%s\t%s\t%s\t%s\n' "$module" "$dir" "$goos" "$W/$module.$goos" >> "$W/manifest"
+  }
+  fixture root darwin \
+'{"code":"U1000","location":{"file":"'"$ROOT"'/internal/term/members_stat.go","line":45,"column":6},"message":"func parseProcStartTime is unused"}
+{"code":"ST1005","location":{"file":"'"$ROOT"'/cmd/gadak/raycast.go","line":252,"column":11},"message":"error strings should not be capitalized"}
+{"code":"S1016","location":{"file":"'"$ROOT"'/internal/server/jql.go","line":52,"column":62},"message":"should convert me"}
+'
+  fixture root linux \
+'{"code":"S1016","location":{"file":"'"$ROOT"'/internal/server/jql.go","line":52,"column":62},"message":"should convert me"}
+'
+  fixture root windows \
+'{"code":"compile","location":{"file":"","line":0,"column":0},"message":"# github.com/midagedev/gadak/internal/sync\ninternal/sync/linear.go:6:2: \"fmt\" imported and not used"}
+'
+  fixture desktop darwin \
+'{"code":"compile","location":{"file":"","line":0,"column":0},"message":"# github.com/wailsapp/wails/v3/pkg/application\n../../../go/pkg/mod/wails/pkg/application/menu_linux.go:7:12: undefined: pointer"}
+'
+  fixture desktop linux ''
+  fixture desktop windows ''
+
+  rc=0
+  WARN_ONLY=0 report "$W/manifest" > "$W/out" 2>&1 || rc=$?
+  cat "$W/out"
+  echo "--- self-test assertions (exit was $rc) ---"
+
+  fails=0
+  want() {  # description, expected-present(1)/absent(0), pattern
+    if grep -qF -- "$3" "$W/out"; then got=1; else got=0; fi
+    if [[ "$got" == "$2" ]]; then echo "  ok   $1"; else echo "  FAIL $1"; fails=1; fi
+  }
+  [[ "$rc" == 1 ]] && echo "  ok   exits 1 when something is wrong" \
+                   || { echo "  FAIL expected exit 1, got $rc"; fails=1; }
+  want "S1016 seen under both GOOS is cross-platform" 1 "cross-platform (1)"
+  want "  ...and it is the jql.go one" 1 "internal/server/jql.go:52:62"
+  want "U1000 seen under one GOOS of two is demoted" 1 "platform-only (1"
+  want "  ...and it names the GOOS it came from" 1 "[darwin] internal/term/members_stat.go:45"
+  want "ST1005 is excluded entirely" 0 "raycast.go"
+  want "an in-repo compile error fails the run" 1 "DOES NOT COMPILE"
+  want "  ...and names the file" 1 "internal/sync/linear.go"
+  want "a dependency-only compile error is a skip, not a failure" 1 "SKIPPED"
+
+  rc=0
+  WARN_ONLY=1 report "$W/manifest" > "$W/warn" 2>&1 || rc=$?
+  [[ "$rc" == 0 ]] && echo "  ok   --warn-only exits 0 on the same input" \
+                   || { echo "  FAIL --warn-only should exit 0, got $rc"; fails=1; }
+
+  [[ "$fails" == 0 ]] && { echo "self-test: OK"; exit 0; }
+  echo "self-test: FAILED" >&2
+  exit 1
+fi
+
+# --- real run --------------------------------------------------------------
+if ! command -v staticcheck >/dev/null 2>&1; then
+  echo "staticcheck.sh: staticcheck is not on PATH." >&2
+  echo "  go install honnef.co/go/tools/cmd/staticcheck@latest" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+MANIFEST="$WORK/manifest"
+: > "$MANIFEST"
+
+# module name, module directory (relative to ROOT), package patterns.
+# desktop/ is a separate go.mod (replace github.com/midagedev/gadak => ../), so
+# it needs its own invocation from its own directory.
+run_module() {
+  local name="$1" dir="$2"; shift 2
+  local goos out
+  for goos in "${GOOSES[@]}"; do
+    out="$WORK/$name.$goos"
+    echo "  $name  GOOS=$goos" >&2
+    # CGO_ENABLED is left at its default on purpose: the native GOOS analyses
+    # what `go vet` and the desktop build see, and the cross ones are CGO-off
+    # the same way `go build` makes them. No in-repo Go file is cgo-guarded, so
+    # the two modes do not disagree about this repo's own code.
+    ( cd "$ROOT/$dir" && GOOS="$goos" staticcheck -f json "$@" ) \
+      > "$out.json" 2> "$out.err" || true
+    printf '%s\t%s\t%s\t%s\n' "$name" "$ROOT/$dir" "$goos" "$out" >> "$MANIFEST"
+  done
+}
+
+echo "staticcheck $(staticcheck -version | sed 's/^staticcheck //') over GOOS: ${GOOSES[*]}" >&2
+run_module root . ./cmd/... ./internal/... ./tools/...
+run_module desktop desktop ./...
+echo >&2
+
+report "$MANIFEST"


### PR DESCRIPTION
Adds \`tools/staticcheck.sh\` and a \`Staticcheck (warning-only)\` CI job. Goes through a PR because \`.github/workflows/\` cannot be exercised locally.

**Why a matrix.** A darwin-only staticcheck reported \`parseProcStartTime\` (internal/term, called from \`members_linux.go\`) and \`protocolDefaultIcon\` (desktop, called from \`protocol_windows.go\`) as U1000 dead code. Both are false: their callers sit behind \`//go:build\` tags. The script runs both modules under darwin/linux/windows and fails only on findings every analysed GOOS agrees on; the rest prints as platform-only (informational).

**What the job does.** \`--self-test\` (classifier vs fixtures, no toolchain), then \`staticcheck@v0.7.0\` pinned, then \`--warn-only\` over the matrix. GTK4/WebKitGTK is not installed, so \`desktop/\` is analysed under windows only on the runner (the script says so in the log); the root module gets all three GOOS.

**Remaining findings (12 cross-platform)** stay reported, not failing: S1016 ×2 in \`internal/server/jql.go\`, SA4006 ×7 / S1009 ×2 / S1034 ×1 in test files. Dropping \`--warn-only\` after that triage is the gate flip. CLAUDE.md gets the gate line.

Local: \`bash tools/staticcheck.sh --self-test\` 10/10, \`--warn-only\` exit 0 with 12 cross-platform / 2 platform-only, doc-checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)