### PR TITLE
desktop: pasteboard via the wails runtime binding; deeplink comment corrected (GDK-1470, GDK-1471)

### DIFF
--- a/desktop/deeplink.go
+++ b/desktop/deeplink.go
@@ -32,10 +32,12 @@ import (
 //
 // Nothing here is macOS-specific in Go terms. Which GOOS emits
 // ApplicationLaunchedWithUrl is owned by coldStartDecisionFor in main.go
-// (GDK-293): Windows does, when wails sees a single "://" argument
-// (pkg/application/application_windows.go in the pinned wails module);
-// GTK4 Linux never does, so argv is applied instead. The same split is
-// in the platform table in README.md.
+// (GDK-293): Windows and GTK4 Linux both do, when wails sees a single
+// "://" argument (pkg/application/application_windows.go and
+// application_linux.go in the pinned wails module — the Linux emit landed
+// in beta.10 via wailsapp/wails#6000 and this module pins beta.12). Any
+// other argv shape gets no event, so argv is applied instead. The same
+// split is in the platform table in README.md.
 
 // errUnsupportedAction reports a well-formed link naming something this build
 // does not implement. It is deliberately distinct from a malformed link: the

--- a/desktop/handler_test.go
+++ b/desktop/handler_test.go
@@ -50,14 +50,10 @@ func TestFallbackHandler(t *testing.T) {
 	browse := newBrowseTabs()
 	emb := &fakeEmbedder{}
 	browse.bind(emb)
-	var clipboardWrites []string
 	h := fallbackHandler(server.New(db, cfg), ui, reg, func(u string) error {
 		openedURLs = append(openedURLs, u)
 		return nil
-	}, browse, func(text string) bool {
-		clipboardWrites = append(clipboardWrites, text)
-		return true
-	})
+	}, browse)
 
 	t.Run("config.json", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/config.json", nil)
@@ -139,32 +135,6 @@ func TestFallbackHandler(t *testing.T) {
 		}
 		if len(openedURLs) != 1 {
 			t.Fatalf("refused URL leaked to the browser: %v", openedURLs)
-		}
-	})
-
-	// navigator.clipboard is dead in the wails webview (GDK-178) — the web
-	// bundle posts here instead. The write must be observable, and an empty
-	// or malformed body refused, so a caller can toast honestly off the code.
-	t.Run("desktop clipboard writes the pasteboard through the app", func(t *testing.T) {
-		post := func(body string) *httptest.ResponseRecorder {
-			req := httptest.NewRequest("POST", "/desktop/clipboard", strings.NewReader(body))
-			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
-			return rec
-		}
-		if rec := post(`{"text":"gadak://view?issue=NMB-1"}`); rec.Code != 204 {
-			t.Fatalf("write: got %d body %s", rec.Code, rec.Body.String())
-		}
-		if len(clipboardWrites) != 1 || clipboardWrites[0] != "gadak://view?issue=NMB-1" {
-			t.Fatalf("clipboard writes = %v", clipboardWrites)
-		}
-		for _, bad := range []string{`{"text":""}`, `not json`} {
-			if rec := post(bad); rec.Code != 400 {
-				t.Fatalf("%s: got %d, want 400", bad, rec.Code)
-			}
-		}
-		if len(clipboardWrites) != 1 {
-			t.Fatalf("refused body reached the pasteboard: %v", clipboardWrites)
 		}
 	})
 
@@ -407,7 +377,7 @@ func TestDesktopWorkspaceRoutes(t *testing.T) {
 	t.Cleanup(func() { reg.Close() })
 	// Unbound browse: the routes exist but answer 503 until bind() — the same
 	// state the app is in before application.New returns.
-	h := fallbackHandler(server.New(db, primaryCfg), ui, reg, nil, newBrowseTabs(), nil)
+	h := fallbackHandler(server.New(db, primaryCfg), ui, reg, nil, newBrowseTabs())
 
 	t.Run("workspace config.json is JSON", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/w/work/config.json", nil)

--- a/desktop/integrations_test.go
+++ b/desktop/integrations_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func integrationsMux() http.Handler {
-	return fallbackHandler(http.NotFoundHandler(), nil, nil, nil, newBrowseTabs(), nil)
+	return fallbackHandler(http.NotFoundHandler(), nil, nil, nil, newBrowseTabs())
 }
 
 func TestIntegrationsGETOrderAndDetect(t *testing.T) {

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -263,9 +263,7 @@ func run() error {
 					return fmt.Errorf("browser not ready")
 				}
 				return openURL(u)
-			}, browse, func(text string) bool {
-				return application.Get().Clipboard.SetText(text)
-			})),
+			}, browse)),
 		},
 		SingleInstance: &application.SingleInstanceOptions{
 			// Per profile, not global: one window per mirror, and a second
@@ -826,7 +824,14 @@ func normalizeWebviewPeer(r *http.Request) {
 // the route (503) — it is bound to app.Browser.OpenURL after the application
 // exists. browse is the in-app browser pane registry; before bind() its routes
 // answer 503 the same way.
-func fallbackHandler(api http.Handler, ui fs.FS, reg *workspace.Registry, openURL func(string) error, browse *browseTabs, setClipboard func(string) bool) http.Handler {
+//
+// There is no clipboard route: the pasteboard is the wails runtime's own
+// binding. Every index.html this handler serves carries /wails/runtime.js
+// (injectWailsRuntime), so the desktop branch of web/src/lib/copy-text.ts
+// imports it and calls Clipboard.SetText — the same message this process
+// would have received (GDK-1470). navigator.clipboard stays dead in the
+// webview (GDK-178); it is the transport, not the route, that was needed.
+func fallbackHandler(api http.Handler, ui fs.FS, reg *workspace.Registry, openURL func(string) error, browse *browseTabs) http.Handler {
 	mux := http.NewServeMux()
 	// The v3 webview has no new-window delegate, so target="_blank" clicks die
 	// inside it (upstream tracker: wailsapp/wails#5043). The web bundle (in
@@ -857,31 +862,6 @@ func fallbackHandler(api http.Handler, ui fs.FS, reg *workspace.Registry, openUR
 		if err := openURL(u.String()); err != nil {
 			log.Printf("open in browser: %v", err)
 			http.Error(w, `{"error":"open_failed"}`, http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
-	// navigator.clipboard is dead inside the wails webview — measured on the
-	// installed 0.15 build: writeText rejected while the UI's old
-	// catch-and-confirm toast still said "copied" (GDK-178). The web bundle
-	// (desktop mode only, lib/copy-text.ts) posts the text here and the app
-	// writes the system pasteboard, the same call install_cli.go uses. Only
-	// the webview can reach this — there is no TCP listener.
-	mux.HandleFunc("POST /desktop/clipboard", func(w http.ResponseWriter, r *http.Request) {
-		if setClipboard == nil {
-			http.Error(w, `{"error":"unavailable"}`, http.StatusServiceUnavailable)
-			return
-		}
-		var body struct {
-			Text string `json:"text"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Text == "" {
-			http.Error(w, `{"error":"bad_request"}`, http.StatusBadRequest)
-			return
-		}
-		if !setClipboard(body.Text) {
-			log.Printf("clipboard: SetText refused %d bytes", len(body.Text))
-			http.Error(w, `{"error":"clipboard_failed"}`, http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/desktop/pairing_test.go
+++ b/desktop/pairing_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func pairingMuxForTest() http.Handler {
-	return fallbackHandler(http.NotFoundHandler(), nil, nil, nil, newBrowseTabs(), nil)
+	return fallbackHandler(http.NotFoundHandler(), nil, nil, nil, newBrowseTabs())
 }
 
 // localOriginDesktopHome stands up a temp GADAK_HOME holding a local-origin

--- a/desktop/platforms_test.go
+++ b/desktop/platforms_test.go
@@ -173,7 +173,7 @@ func TestDesktopCommentsDoNotRestateStalePlatformFacts(t *testing.T) {
 		path    string
 		phrases []string
 	}{
-		{"deeplink.go", []string{"on other platforms the events", "simply never fire"}},
+		{"deeplink.go", []string{"on other platforms the events", "simply never fire", "GTK4 Linux never does"}},
 		{"embed_other.go", []string{"The desktop app ships for macOS only today"}},
 		{"fatal_windows.go", []string{"wails has no dialog helper"}},
 		{"README.md", []string{"does not set an `ErrorHandler`", "No workspace switcher"}},

--- a/desktop/runtime_test.go
+++ b/desktop/runtime_test.go
@@ -44,7 +44,7 @@ func TestServedIndexHasOneRuntimeJS(t *testing.T) {
 	ui := fstest.MapFS{
 		"index.html": &fstest.MapFile{Data: []byte("<!doctype html><html><head></head><body>spa</body></html>")},
 	}
-	h := assetHandler(ui, fallbackHandler(http.NotFoundHandler(), ui, nil, nil, newBrowseTabs(), nil))
+	h := assetHandler(ui, fallbackHandler(http.NotFoundHandler(), ui, nil, nil, newBrowseTabs()))
 	for _, p := range []string{"/", "/index.html", "/issues/NMA-1"} {
 		rec := httptest.NewRecorder()
 		h.ServeHTTP(rec, httptest.NewRequest("GET", p, nil))

--- a/desktop/terminal_stream_test.go
+++ b/desktop/terminal_stream_test.go
@@ -47,7 +47,7 @@ func TestWebviewRequestsReachTheAPIAsInProcess(t *testing.T) {
 		got = append(got, r)
 		w.WriteHeader(http.StatusNoContent)
 	})
-	h := fallbackHandler(api, nil, nil, nil, newBrowseTabs(), nil)
+	h := fallbackHandler(api, nil, nil, nil, newBrowseTabs())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/terminal/sessions/", nil)
 	// What the webview really sends, both parts of it.

--- a/docs/decisions/0008-cli-first-parity.md
+++ b/docs/decisions/0008-cli-first-parity.md
@@ -139,3 +139,16 @@ The census row at `:83` ("`gadak edit` does not send `fields/` … No CLI verb")
 is superseded: the CLI now PATCHes `{key}/fields/` through the origin. REST
 still has no issue-link endpoint (`internal/server/server.go` has no
 `…/link/` route); `gadak link` is CLI-only.
+
+## Addendum (2026-09-07) — pasteboard through the wails runtime, not a route
+
+The Pasteboard row above names `POST /desktop/clipboard`. That route is gone
+(GDK-1470): the desktop branch of `web/src/lib/copy-text.ts` imports the
+`/wails/runtime.js` module the app already injects into every page it serves
+and calls `Clipboard.SetText`, which is the same Go call the route used to
+make. The row's verdict — **justified desktop**, a terminal already has a
+clipboard — is unchanged; only the transport moved from a hand-rolled HTTP
+handler to the framework's own binding. One narrowing rides along and is
+written at the top of `copy-text.ts`: the runtime binding discards the
+pasteboard's own bool, so `false` on desktop now means the bridge refused,
+not that the pasteboard did.

--- a/web/src/lib/copy-text.ts
+++ b/web/src/lib/copy-text.ts
@@ -3,25 +3,43 @@
  *
  * Desktop: navigator.clipboard is dead inside the wails webview — measured
  * on the installed build: writeText rejected while the old catch-and-confirm
- * idiom still toasted "copied". The webview posts to /desktop/clipboard
- * (desktop/main.go) and the app writes the system pasteboard.
+ * idiom still toasted "copied". The pasteboard is reached through wails' own
+ * runtime binding instead (GDK-1470). The app injects /wails/runtime.js into
+ * every index.html it serves (desktop/main.go injectWailsRuntime), so the
+ * module resolves on this same custom-scheme origin, and Clipboard.SetText
+ * crosses the bridge the framework already owns — the same message a
+ * hand-rolled HTTP route would have delivered to the same Go call.
+ *
+ * The dynamic import carries @vite-ignore so Vite neither bundles nor
+ * rewrites the path: one built bundle serves `gadak serve` in a browser
+ * (where the module does not exist and this branch never runs) and the app.
  *
  * Everywhere: the boolean is the truth. Callers toast success or failure
  * from the return value — never before it. A copy affordance that lies is
- * worse than one that fails aloud.
+ * worse than one that fails aloud. Note what the boolean now means on
+ * desktop: the runtime binding resolves once the message is delivered and
+ * discards the pasteboard's own bool (wails messageprocessor_clipboard.go),
+ * so false here is "the bridge refused", not "the pasteboard refused".
  */
 
 import { isDesktop } from './config'
+import { WAILS_RUNTIME_URL } from './terminal/wails-stream'
 
 export async function copyText(text: string): Promise<boolean> {
   if (isDesktop()) {
     try {
-      const res = await fetch('/desktop/clipboard', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text }),
-      })
-      return res.status === 204
+      // Widened to `string` for the same reason loadWailsStreamFactory does
+      // it: as a literal, TypeScript tries to resolve a module this
+      // repository does not contain — the running app produces it.
+      const url: string = WAILS_RUNTIME_URL
+      const mod = (await import(/* @vite-ignore */ url)) as {
+        Clipboard?: { SetText?: (text: string) => Promise<void> }
+      }
+      if (typeof mod.Clipboard?.SetText !== 'function') {
+        throw new Error('wails runtime: no Clipboard.SetText export')
+      }
+      await mod.Clipboard.SetText(text)
+      return true
     } catch {
       return false
     }


### PR DESCRIPTION
Via PR because `desktop/` changes only get their verdict from the Desktop Windows/Linux CI jobs.

**GDK-1470.** `POST /desktop/clipboard` duplicated a message wails already delivers. The desktop branch of `web/src/lib/copy-text.ts` now imports the injected `/wails/runtime.js` and calls `Clipboard.SetText`; the route, its `setClipboard` plumbing and its subtest are deleted (25 lines), five test call sites drop a trailing `nil`. The built bundle keeps the import as a runtime `import()` (checked in the output); the module exports `Clipboard.SetText` in the pinned wails runtime. One narrowing is documented in the file header and as an addendum to decisions/0008: the runtime binding discards the pasteboard's own bool, so `false` now means "bridge refused", not "pasteboard refused".

**GDK-1471.** `deeplink.go` claimed "GTK4 Linux never does" emit `ApplicationLaunchedWithUrl`; since beta.10 (wails#6000) Windows and GTK4 Linux both do for a single `://` argument. `platforms_test.go` lists the stale phrase (red before the fix).

Not verified: the runtime call inside a running app (no desktop e2e). Local gates green: desktop gofmt/build/vet/test, root build, typecheck, vitest, Playwright 476 (port 7889), doc-checks, check-desktop-tidy, scan-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)