### PR TITLE
ci: staticcheck becomes a gate (--warn-only dropped)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           echo "snapshot portable: fts_hits=$hits epic_rows=$rows"
 
   staticcheck:
-    name: Staticcheck (warning-only)
+    name: Staticcheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -292,8 +292,8 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      # --warn-only while the existing findings are triaged (GDK-1463): this
-      # job reports and never fails. Dropping the flag is what makes it a gate.
+      # A gate since the cross-platform list reached zero (GDK-1463 triage,
+      # closed 2026-09-09): a finding every GOOS agrees on fails the job.
       #
       # GTK4/WebKitGTK is deliberately not installed. Without it the desktop
       # module cannot be analysed under GOOS=linux or darwin, and the script
@@ -301,7 +301,7 @@ jobs:
       # second copy of the mirror-flaky apt step in this file for a job that
       # cannot fail. The root module gets all three either way.
       - name: staticcheck over the GOOS matrix
-        run: bash tools/staticcheck.sh --warn-only
+        run: bash tools/staticcheck.sh
 
   e2e:
     name: Playwright E2E

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,8 @@ hard-won 목록)와 `AGENTS.md`(스키마·쿼리)가 원본이다.
   U1000 죽은 코드로 오탐한다(`parseProcStartTime`·`protocolDefaultIcon`
   실측). 세 GOOS가 모두 동의한 것만 실패이고 나머지는 informational로
   인쇄된다. ST1005는 제외(한국어 에러 문장·의도된 다중행 프로토콜 에코).
-  CI 잡 `Staticcheck (warning-only)`은 `--warn-only`라 아직 게이트가 아니다
-  — 남은 cross-platform 12건을 정리한 뒤 플래그를 떼는 것이 게이트화다.
+  CI 잡 `Staticcheck`은 게이트다(2026-09-09, 잔여 14건을 0으로 만든 뒤
+  `--warn-only`를 뗐다) — cross-platform 발견 하나가 CI를 빨갛게 만든다.
 - **OS별 경로·카탈로그를 만드는 Go 코드는 `goos`를 인자로 받고 세 GOOS를
   테스트로 잰다** (2026-09-08, 런 34233540027). `integrations.listFor(goos)`
   가 goos 카탈로그를 약속하는데 Claude Desktop 행만 런타임 바인딩 helper를


### PR DESCRIPTION
The staticcheck job ran \`--warn-only\` while the cross-platform findings were triaged (GDK-1463). That list reached zero on main in b5bf3b8e, so this drops the flag: a finding every GOOS agrees on now fails CI. Job renamed from "Staticcheck (warning-only)" to "Staticcheck"; CLAUDE.md's clause updated to match.

Workflow-only change, so it goes through a PR for the branch verdict. Locally \`bash tools/staticcheck.sh\` on main prints \`summary: 0 cross-platform, 0 platform-only, ST1005 excluded\` and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)