### PR TITLE
GDK-1697: a dev build lives in ~/.gadak-dev

### DIFF
--- a/cmd/gadak/doctor.go
+++ b/cmd/gadak/doctor.go
@@ -43,7 +43,12 @@ type doctorReport struct {
 	WorkspaceKind   string `json:"workspace_kind"`
 	Origin          string `json:"origin"`
 	OriginOwner     string `json:"origin_owner,omitempty"`
-	MirrorPath      string `json:"mirror_path"`
+	// Home is the directory the default profile lives in, and HomeReason says
+	// why it is that one when it is not ~/.gadak: "dev build" (GDK-1697) or
+	// "GADAK_HOME".
+	Home       string `json:"home"`
+	HomeReason string `json:"home_reason,omitempty"`
+	MirrorPath string `json:"mirror_path"`
 	// HomeLeftover is the abandoned legacy home (~/.scry) when it still exists
 	// beside ~/.gadak. The stderr warning fires once per machine (GDK-1072);
 	// this is the standing report.
@@ -329,6 +334,17 @@ func collectDoctor() doctorReport {
 		},
 	}
 
+	if home, err := config.HomeRoot(); err == nil {
+		rep.Home = tildeHome(home)
+		switch {
+		case config.Env("HOME") != "":
+			rep.HomeReason = "GADAK_HOME"
+		case config.DevHome():
+			rep.HomeReason = "dev build"
+		}
+	} else {
+		rep.Home = "unknown"
+	}
 	if path, err := config.DBPath(); err == nil {
 		rep.MirrorPath = tildeHome(path)
 	} else {
@@ -969,6 +985,11 @@ func formatDoctorText(r doctorReport) string {
 		line("origin owner", r.OriginOwner)
 	}
 	line("workspace", formatDoctorWorkspace(r.Workspace))
+	if r.HomeReason != "" {
+		line("home", r.Home+" ("+r.HomeReason+")")
+	} else {
+		line("home", r.Home)
+	}
 	line("mirror_path", r.MirrorPath)
 	if r.HomeLeftover != "" {
 		line("home_leftover", r.HomeLeftover+" (ignored legacy home — delete it, or move anything you still need into the active home)")

--- a/cmd/gadak/main.go
+++ b/cmd/gadak/main.go
@@ -259,7 +259,10 @@ Workspaces keep separate credentials and mirrors (e.g. work and demo):
 
 func main() {
 	log.SetFlags(0)
-	// Installed first: every store.Open below — the workspace registry serve
+	// A checkout build lives in ~/.gadak-dev unless GADAK_HOME says
+	// otherwise (GDK-1697) — before anything resolves a path.
+	config.SetDevBuild(skillinstall.IsDevBuild(version))
+	// Installed next: every store.Open below — the workspace registry serve
 	// builds, the MCP server, originbind — inherits the dev-lockout policy.
 	store.SetDefaultOpenOptions(storeOpenOptions())
 	apprun.SelectWorkspace()

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/midagedev/gadak/internal/config"
 	"github.com/midagedev/gadak/internal/integrations"
 	"github.com/midagedev/gadak/internal/server"
+	"github.com/midagedev/gadak/internal/skillinstall"
 	gadaksync "github.com/midagedev/gadak/internal/sync"
 	"github.com/midagedev/gadak/internal/workspace"
 )
@@ -49,6 +50,9 @@ func main() {
 	// Importing internal/config no longer selects a workspace (GDK-644);
 	// each main reads GADAK_WORKSPACE/GADAK_PROFILE/SCRY_PROFILE itself —
 	// this is what makes `GADAK_PROFILE=work open -a Gadak` work.
+	// A local build lives in ~/.gadak-dev unless GADAK_HOME says otherwise
+	// (GDK-1697); decided before the log dir below resolves a path.
+	config.SetDevBuild(skillinstall.IsDevBuild(appVersion))
 	apprun.SelectWorkspace()
 	if dir, err := config.DirFor(""); err != nil {
 		fmt.Fprintf(os.Stderr, "gadak: logs: %v\n", err)

--- a/docs/MIRROR.md
+++ b/docs/MIRROR.md
@@ -20,7 +20,10 @@ it refuses, naming both schema versions and both ways out in the error
 release working. To migrate anyway, set `GADAK_DEV_MIGRATE=1`; to experiment
 without deciding for the release, work on a copy of the profile directory as
 the error's one-liner shows. Release builds migrate on open as they always
-did.
+did. Sharing is the exception now, not the default: with `GADAK_HOME` unset
+a dev build lives in `~/.gadak-dev`, the release in `~/.gadak`, and
+`gadak doctor` prints `home` with the reason (`dev build` or `GADAK_HOME`).
+Point a dev build at the real home only on purpose, with `GADAK_HOME`.
 
 Four layers. Use the lowest one that answers the question:
 

--- a/internal/apprun/apprun.go
+++ b/internal/apprun/apprun.go
@@ -111,7 +111,10 @@ func (rt *Runtime) boot(opts Options) error {
 	}
 	// Desktop boot: the workspace registry opens every workspace through
 	// plain store.Open, so the dev-lockout policy must be the process default
-	// before the first one (GDK-1687). Same rule as openDB below.
+	// before the first one (GDK-1687). Same rule as openDB below. The dev
+	// home (GDK-1697) is set here too for a main that skipped it; desktop's
+	// main sets it first because it resolves the log dir before Open.
+	config.SetDevBuild(skillinstall.IsDevBuild(opts.Version))
 	store.SetDefaultOpenOptions(storeOpenOptionsFor(opts.Version))
 
 	cfg, err := config.Load()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/midagedev/gadak/internal/atomicfile"
 	"github.com/midagedev/gadak/internal/fsperm"
@@ -540,9 +541,31 @@ func ReloadWorkspaceFromEnv() {
 	workspaceEnvName = ""
 }
 
-// homeRoot is GADAK_HOME, else SCRY_HOME, else ~/.gadak. An existing ~/.scry
-// directory is renamed to ~/.gadak on first use so a pre-rename install keeps
-// its mirror. Shared by DirFor and Profiles.
+// devBuild is set once at boot by each main (SetDevBuild) from
+// skillinstall.IsDevBuild — config must not own the version. Off by default,
+// so tests and tools that never call it keep ~/.gadak.
+var devBuild atomic.Bool
+
+// SetDevBuild tells config whether this binary is a checkout build. A dev
+// build's default home is ~/.gadak-dev (DevDirName), not ~/.gadak, so the
+// installed release and the checkout never open the same workspace files
+// unless GADAK_HOME says so explicitly (GDK-1697; the in-place forward
+// migration of GDK-1687 was the incident). Call it before the first
+// homeRoot — in practice the first line of main.
+func SetDevBuild(dev bool) { devBuild.Store(dev) }
+
+// DevHome reports whether the default home is the dev one (SetDevBuild was
+// called with true and GADAK_HOME is unset). doctor prints it.
+func DevHome() bool { return devBuild.Load() && Env("HOME") == "" }
+
+// HomeRoot is the directory the default profile lives in: GADAK_HOME, else
+// ~/.gadak-dev for a dev build, else ~/.gadak.
+func HomeRoot() (string, error) { return homeRoot() }
+
+// homeRoot is GADAK_HOME, else SCRY_HOME, else ~/.gadak-dev on a dev build,
+// else ~/.gadak. An existing ~/.scry directory is renamed to ~/.gadak on
+// first use so a pre-rename install keeps its mirror — the dev home has no
+// legacy to migrate and skips that. Shared by DirFor and Profiles.
 func homeRoot() (string, error) {
 	if base := Env("HOME"); base != "" {
 		return base, nil
@@ -550,6 +573,9 @@ func homeRoot() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
+	}
+	if devBuild.Load() {
+		return filepath.Join(home, DevDirName), nil
 	}
 	next := filepath.Join(home, DirName)
 	prev := filepath.Join(home, LegacyDirName)

--- a/internal/config/dev_home_test.go
+++ b/internal/config/dev_home_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// GDK-1697: a dev build's default home is ~/.gadak-dev, so a checkout build
+// and the installed release never share workspace files unless GADAK_HOME
+// says so. Off by default — nothing else in this package's tests calls
+// SetDevBuild, and they keep ~/.gadak.
+func TestDevBuildHomeIsGadakDev(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("GADAK_HOME", "")
+	t.Setenv("SCRY_HOME", "")
+	t.Cleanup(func() { SetDevBuild(false) })
+
+	SetDevBuild(true)
+	got, err := homeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(root, DevDirName); got != want {
+		t.Fatalf("dev build homeRoot() = %q, want %q", got, want)
+	}
+	if !DevHome() {
+		t.Fatal("DevHome() = false under a dev build with no GADAK_HOME")
+	}
+
+	// GADAK_HOME wins for both builds — that is how a dev build is pointed
+	// at a real home on purpose, and GDK-1687's refusal covers that case.
+	override := filepath.Join(root, "elsewhere")
+	t.Setenv("GADAK_HOME", override)
+	got, err = homeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != override {
+		t.Fatalf("dev build with GADAK_HOME: homeRoot() = %q, want %q", got, override)
+	}
+	if DevHome() {
+		t.Fatal("DevHome() = true with GADAK_HOME set — the reason doctor prints would be wrong")
+	}
+
+	SetDevBuild(false)
+	t.Setenv("GADAK_HOME", "")
+	got, err = homeRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(root, DirName); got != want {
+		t.Fatalf("release homeRoot() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/identity.go
+++ b/internal/config/identity.go
@@ -13,6 +13,10 @@ const (
 	Name = "gadak"
 	// DirName is the directory under $HOME that holds the default profile.
 	DirName = ".gadak"
+	// DevDirName is the home a dev build uses instead of DirName when
+	// GADAK_HOME is unset (GDK-1697): a checkout build and the installed
+	// release never share workspace files by accident. SetDevBuild flips it.
+	DevDirName = ".gadak-dev"
 	// DBFile is the SQLite filename inside a profile directory.
 	DBFile = "gadak.db"
 	// EnvPrefix is prepended to HOME, PROFILE, WORKSPACE, TOKEN, SITE, EMAIL, PROJECTS.

--- a/internal/skillinstall/provenance.go
+++ b/internal/skillinstall/provenance.go
@@ -48,7 +48,10 @@ const (
 // exactly the incident this closes.
 func IsDevBuild(version string) bool {
 	v := strings.TrimSpace(version)
-	return v == "" || v == DevVersion
+	// "dev" is desktop/main.go's unstamped default (build-app.sh stamps
+	// -X main.appVersion on a cut release); without it a local desktop build
+	// counted as a release and skipped every dev-build rule (GDK-1697).
+	return v == "" || v == DevVersion || v == "dev"
 }
 
 // SourceFor is the receipt word for a version string.

--- a/internal/skillinstall/provenance_test.go
+++ b/internal/skillinstall/provenance_test.go
@@ -15,8 +15,9 @@ func TestIsDevBuild(t *testing.T) {
 	}{
 		{DevVersion, true},
 		{" 0.0.0-dev\n", true},
-		{"", true},   // no build information at all is not trustworthy
-		{"  ", true}, // ditto
+		{"", true},    // no build information at all is not trustworthy
+		{"  ", true},  // ditto
+		{"dev", true}, // desktop/main.go's unstamped appVersion (GDK-1697)
 		{"0.20.2", false},
 		{"1.0.0-rc.1", false},
 		{"v0.19.3", false},


### PR DESCRIPTION
Follow-up to GDK-1687 (user decision 2026-09-09): with `GADAK_HOME` unset a dev build resolves its home to `~/.gadak-dev`, the installed release keeps `~/.gadak`, so the two never share workspace files by accident. `GADAK_HOME` wins for both builds; a dev build pointed at a real home on purpose still gets GDK-1687's forward-migration refusal. `skillinstall.IsDevBuild` now also recognises `"dev"`, desktop's unstamped default, which had been counting as a release build. `gadak doctor` prints `home` with the reason.

Touches `desktop/main.go` (one line before the log dir resolves), hence the PR.

Measured with a fresh HOME: dev build → `~/.gadak-dev (dev build)`; `GADAK_HOME=…` → that path `(GADAK_HOME)`; `-X main.version=0.21.0` → `~/.gadak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)