### PR TITLE
GDK-1702: a cheaper CI run — the static-analysis gate skips Go-free pushes, browser shards are dealt by measured seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,56 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # GDK-1702: this job billed ~5 min of setup+install per push while
+      # the census measured most pushes touching no Go at all. It is a gate
+      # (the cross-platform list is empty since 90e27bdf), so the skip must
+      # never hide a Go change — hence the fail-open rules below. GitHub Actions has no
+      # per-job paths filter (`on:` filters are workflow-level and would
+      # skip every job), so the first step diffs the change and every step
+      # below is gated on its output.
+      #
+      # It fails OPEN, and that is the contract: a forced push whose before
+      # is unreachable, a first push (all-zero before), workflow_dispatch,
+      # an empty event base, or any diff error runs the job. A gate skipped
+      # by mistake is the failure mode that matters; a gate run for nothing
+      # is five minutes.
+      #
+      # The path list is the Go surface plus the job's own inputs: the
+      # script it runs, and this workflow (a change here can rewrite the
+      # gate itself). `git diff A B` compares trees without needing shared
+      # history, so two depth-1 objects are enough.
+      - name: Did this change touch Go?
+        id: gofilter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SHA: ${{ github.sha }}
+        run: |
+          run_job() { echo "go=true" >> "$GITHUB_OUTPUT"; echo "staticcheck: $1"; exit 0; }
+          skip_job() { echo "go=false" >> "$GITHUB_OUTPUT"; echo "staticcheck: $1"; exit 0; }
+          case "$EVENT_NAME" in
+            pull_request) base="$BASE_SHA" ;;
+            push) base="$BEFORE" ;;
+            *) run_job "event '$EVENT_NAME' has no before — running (fail open)" ;;
+          esac
+          if [ -z "$base" ] || printf '%s' "$base" | grep -Eq '^0+$'; then
+            run_job "no usable base sha (first push or forced push) — running (fail open)"
+          fi
+          if ! git fetch --no-tags --depth=1 origin "$base" 2>/dev/null; then
+            run_job "base $base not fetchable — running (fail open)"
+          fi
+          if ! changed="$(git diff --name-only "$base" "$SHA")"; then
+            run_job "git diff failed — running (fail open)"
+          fi
+          n=$(printf '%s\n' "$changed" | grep -c . || true)
+          if printf '%s\n' "$changed" | grep -Eq '\.go$|^go\.mod$|^go\.sum$|^desktop/|^tools/staticcheck\.sh$|^\.github/workflows/ci\.yml$'; then
+            run_job "Go-touching change in ${n} changed path(s)"
+          fi
+          skip_job "no Go-touching change in ${n} changed path(s)"
+
       - name: Set up Go
+        if: steps.gofilter.outputs.go == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -283,11 +332,13 @@ jobs:
       # artefact is the script's classifier, not staticcheck. It runs over
       # fixtures, needs no toolchain, and takes a second.
       - name: staticcheck.sh self-test
+        if: steps.gofilter.outputs.go == 'true'
         run: bash tools/staticcheck.sh --self-test
 
       # Pinned on purpose: staticcheck gains checks between releases, and
       # @latest would turn a new check into a CI change nobody made.
       - name: Install staticcheck
+        if: steps.gofilter.outputs.go == 'true'
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
@@ -301,6 +352,7 @@ jobs:
       # second copy of the mirror-flaky apt step in this file for a job that
       # cannot fail. The root module gets all three either way.
       - name: staticcheck over the GOOS matrix
+        if: steps.gofilter.outputs.go == 'true'
         run: bash tools/staticcheck.sh
 
   e2e:
@@ -312,6 +364,15 @@ jobs:
     # seeded home, so e2e/playwright.config.ts keeps workers: 1 and
     # fullyParallel: false — raising workers inside one runner is the
     # unsafe variant (single shared served instance) and stays out.
+    #
+    # GDK-1702: which files land on which shard is owned by
+    # tools/e2e-partition.sh — dealt by the measured table
+    # (e2e/shard-weights.tsv), because --shard's count-based split sent
+    # 220/297/261 s of test time to the three runners and the longest
+    # shard is the job's wall clock. --check runs in every shard before
+    # the run: a spec that escaped the deal (new file outside the table,
+    # stale weight row, glob drifting from what playwright collects)
+    # fails the job that would otherwise have skipped it silently.
     strategy:
       fail-fast: false
       matrix:
@@ -478,8 +539,14 @@ jobs:
           echo "::error::playwright chromium download failed three times — browser cache, not apt, not the tests"
           exit 1
 
+      # Positional e2e/-prefixed paths on purpose: --shard=N/3 splits by
+      # count (balanced only if every file costs the same), while the
+      # partitioner deals files by measured seconds.
+      - name: E2E partition check
+        run: bash tools/e2e-partition.sh --check 3
+
       - name: Run browser E2E
-        run: npx playwright test --config e2e/playwright.config.ts --shard=${{ matrix.shard }}/3
+        run: npx playwright test --config e2e/playwright.config.ts $(bash tools/e2e-partition.sh ${{ matrix.shard }} 3)
 
   # Nested module (desktop/go.mod). package main imports wails v3, which does
   # not compile on Linux with CGO_ENABLED=0 (undefined pointer in the linux

--- a/e2e/docs-ux.spec.ts
+++ b/e2e/docs-ux.spec.ts
@@ -835,6 +835,14 @@ test.describe('docs empty states', () => {
  * ("Fetching documents") — at the same moment, about the same pass. Read
  * together, issue sync and document sync looked like two systems. These pin
  * that every surface renders the same string, and that the count is in it.
+ *
+ * The issues-pass wording and the announce threshold moved to vitest by the
+ * GDK-1702 cost ladder: the sentence is web/src/lib/mirror-status.test.ts
+ * (busyLabel's issues branch, the 4-digit comma, and the GDK-460 scans of
+ * which surface may render it), and the elapsed-time rule is
+ * web/src/stores/issues-activity-visibility.test.ts (ACTIVITY_MIN_VISIBLE_MS
+ * and the `a.running && old` gate). The browser keeps the running half —
+ * the document pass below crosses chip, CTA and sidebar end to end.
  */
 test.describe('sync status is one sentence', () => {
   const API = apiURL('/api/v1/issues/')
@@ -889,35 +897,6 @@ test.describe('sync status is one sentence', () => {
     await expect(page.getByTestId('docs-empty-cta')).toContainText(expected)
     await expect(page.getByTestId('sidebar-sync-now')).toContainText('Sync log')
     await expect(page.getByTestId('sidebar-sync-now')).not.toContainText(expected)
-  })
-
-  test('an issue pass says issues, not documents', async ({ page }) => {
-    await activity(page, { running: true, source: 'issues', fetched: 6932 })
-    await gotoApp(page)
-
-    // GDK-460: busy wording is the chip's. The sidebar keeps its own name.
-    await expect(page.getByTestId('freshness-chip')).toContainText('Syncing issues · 6,932', {
-      timeout: 20_000,
-    })
-    await expect(page.getByTestId('sidebar-sync-now')).toContainText('Sync log')
-    await expect(page.getByTestId('sidebar-sync-now')).not.toContainText('Syncing issues')
-  })
-
-  test('a pass is announced only once it has run long enough to wonder about', async ({ page }) => {
-    // The watch loop finishes an incremental in a second or two, every minute.
-    // Narrating those would put a blinking status in front of someone all day;
-    // the six-minute backfill is what needed saying. So the rule is elapsed
-    // time, and this asserts both halves of it rather than the quiet first
-    // instant, which would pass with no rule at all.
-    await activity(page, { running: true, source: 'issues', fetched: 2 }, 500)
-    await gotoApp(page)
-
-    const chip = page.getByTestId('freshness-chip')
-    await page.waitForTimeout(1_500) // two polls in, still young
-    await expect(chip).not.toContainText('Syncing')
-    // Same stubbed pass, now old enough: the wording appears without anything
-    // else changing, which is the threshold and not a coincidence of timing.
-    await expect(chip).toContainText('Syncing issues', { timeout: 15_000 })
   })
 })
 

--- a/e2e/menu-loading.spec.ts
+++ b/e2e/menu-loading.spec.ts
@@ -20,6 +20,13 @@ import { MENU_ORIGIN_TIMEOUT_MS } from '../web/src/lib/menu-loading'
  *    note) when one exists, otherwise the catalog's failure sentence and a
  *    Retry.
  *
+ * The detail-picker half of the contract moved to vitest (GDK-1702 cost
+ * ladder): withMenuTimeout's timing and the picker's cached-catalog
+ * fallback are web/src/lib/menu-loading.test.ts — the fallback is pinned
+ * as a source scan there, because the picker cannot mount in the unit
+ * project and the fallback's claims are its source. This spec keeps the
+ * real path: one menu opened against a stalled origin, end to end.
+ *
  * The stalled routes fulfill after 60 s — far past every assertion — so the
  * pre-fix tree hangs exactly like the unreachable origin did, and the
  * post-fix fallback state stays put for the assertions (no late-arriving
@@ -91,65 +98,6 @@ test.describe('menu origin wait is capped (GDK-1566)', () => {
     // capped wait, not a dead menu.
     await retry.click()
     await expect(menu.getByText(en['common.loading'])).toBeVisible()
-
-    expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
-  })
-
-  test('detail priority picker: timeout falls back to the site catalog with the offline note', async ({
-    page,
-  }) => {
-    const errors = attachConsoleErrors(page)
-    // Prime the site catalog first: the bulk menu loads it instantly.
-    await page.route('**/api/v1/issues/priorities/', async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        json: { priorities: [{ id: '1', name: 'Highest' }, { id: '3', name: 'Medium' }] },
-      })
-    })
-    await gotoApp(page)
-    await selectBulkRows(page, 1)
-
-    await page.getByRole('button', { name: en['bulk.changePriority'], exact: true }).click()
-    const bulkMenu = page.getByTestId('bulk-priority-menu')
-    await expect(bulkMenu.getByText('Highest')).toBeVisible()
-    await page.keyboard.press('Escape')
-    await expect(bulkMenu).toBeHidden()
-    // Clear the bulk selection so the detail panel is the only surface.
-    await page.keyboard.press('Escape')
-    await expect(page.getByTestId('bulk-bar')).toBeHidden()
-
-    // Open the first issue; stall only its per-key catalog.
-    const row = page.locator('[data-testid="issue-list-scroller"] [data-issue-key]').first()
-    const key = await row.getAttribute('data-issue-key')
-    expect(key).toBeTruthy()
-    await page.route(`**/api/v1/issues/${key}/priorities/`, async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      await stall()
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        json: { priorities: [{ id: '9', name: 'Per-key Only' }] },
-      })
-    })
-    await row.click()
-    const panel = page.getByTestId('issue-detail-panel')
-    await expect(panel).toHaveClass(/is-open/)
-
-    await page.keyboard.press('p')
-    const menu = page.getByRole('listbox', { name: en['common.priority'] })
-    await expect(menu).toBeVisible()
-    await expect(menu.getByText(en['common.loading'])).toBeVisible()
-
-    await expect(menu.getByText(en['common.loading'])).toBeHidden({
-      timeout: MENU_ORIGIN_TIMEOUT_MS + 4_000,
-    })
-    // The per-key answer never came, so the rows are the cached site catalog
-    // (not "Per-key Only"), and the note says so.
-    await expect(menu.getByText('Highest')).toBeVisible()
-    await expect(menu.getByText('Per-key Only')).toHaveCount(0)
-    await expect(menu.getByTestId('menu-cached-note')).toHaveText(en['app.offlineBanner'])
 
     expect(appConsoleErrors(errors), `console errors:\n${errors.join('\n')}`).toEqual([])
   })

--- a/e2e/mirror-instant.spec.ts
+++ b/e2e/mirror-instant.spec.ts
@@ -22,8 +22,17 @@ import {
  * value moves when and only when the mirror does, WAL included — is pinned in
  * Go (internal/store/version_test.go, internal/server/focus_test.go).
  *
+ * One test, both halves of the contract (GDK-1702 cost ladder merged the
+ * two: each paid a full boot + anchor to drive the same rig, and the
+ * windows combine cleanly):
+ *  - a still mirror must not pull (the control window before the burst);
+ *  - moves reach the pool within INSTANT_MS — not on the backstop;
+ *  - moves inside one 500ms tick coalesce into exactly one pull, and a
+ *    mirror that settles does not pull again (the settle window doubles
+ *    as the still-mirror control on the post-pull state).
+ *
  * FAIL-first: with the client ignoring mirrorVersion, the injected issue
- * appears only on the backstop tick, and this stopped on
+ * appears only on the backstop tick, and this stops on
  * 'the board must pull within 3s of the mirror moving'.
  */
 
@@ -99,7 +108,9 @@ async function installRig(page: Page): Promise<Rig> {
 }
 
 test.describe('GDK-1170 a write elsewhere reaches an open board', () => {
-  test('the board pulls when mirrorVersion moves, not on the 15s backstop', async ({ page }) => {
+  test('the board pulls on a move, within the instant window, exactly once — never on ticks or stacked', async ({
+    page,
+  }) => {
     const errors = attachConsoleErrors(page)
     const rig = await installRig(page)
     await gotoApp(page)
@@ -119,32 +130,11 @@ test.describe('GDK-1170 a write elsewhere reaches an open board', () => {
     await page.waitForTimeout(INSTANT_MS) // duration is the contract: no pull while the mirror sits still
     expect(rig.deltas(), 'a still mirror must not pull a delta on the 500ms tick').toBe(anchored)
 
-    rig.arm()
-    rig.bump()
-
-    // The assertion waits on the state itself: the injected issue is in the
-    // pool, which is only true after a delta landed and was applied.
-    await expect(
-      page.getByText(new RegExp(`${DEMO_ISSUE_COUNT + 1} issues`)).first(),
-      'the board must pull within 3s of the mirror moving',
-    ).toBeVisible({ timeout: INSTANT_MS })
-
-    expect(rig.deltas(), 'exactly one delta for one move').toBe(anchored + 1)
-    expect(appConsoleErrors(errors)).toEqual([])
-  })
-
-  test('a mirror that keeps moving pulls once per move, never stacked', async ({ page }) => {
-    const errors = attachConsoleErrors(page)
-    const rig = await installRig(page)
-    await gotoApp(page)
-    await expect(page.getByText(new RegExp(`${DEMO_ISSUE_COUNT} issues`)).first()).toBeVisible({
-      timeout: 30_000,
-    })
-    await page.waitForResponse((r) => r.url().includes('/delta/'), { timeout: 30_000 })
-    const anchored = rig.deltas()
-
     // Three moves inside one 500ms tick. The tab must not fire three deltas —
-    // a poll that stacks requests is a new defect, not a fixed one.
+    // a poll that stacks requests is a new defect, not a fixed one — and it
+    // must not fire zero either (the pre-fix client ignored the version and
+    // waited for the backstop).
+    rig.arm()
     rig.bump()
     rig.bump()
     rig.bump()
@@ -152,9 +142,21 @@ test.describe('GDK-1170 a write elsewhere reaches an open board', () => {
     await expect
       .poll(() => rig.deltas(), { timeout: INSTANT_MS })
       .toBeGreaterThan(anchored)
-    // Settle, then count. Still short of the backstop at anchored + 15s.
+
+    // Settle, then count. Still short of the backstop at anchored + 15s:
+    // the burst coalesced into one pull, and a mirror that went still again
+    // does not pull a follow-up — the same still-mirror control, on the
+    // post-pull state.
     await page.waitForTimeout(INSTANT_MS) // duration is the contract: no follow-up pull after the burst settles
     expect(rig.deltas(), 'three moves inside one tick are one pull').toBe(anchored + 1)
+
+    // The assertion waits on the state itself: the injected issue is in the
+    // pool, which is only true after a delta landed and was applied.
+    await expect(
+      page.getByText(new RegExp(`${DEMO_ISSUE_COUNT + 1} issues`)).first(),
+      'the move must reach the pool within 3s',
+    ).toBeVisible({ timeout: INSTANT_MS })
+
     expect(BACKSTOP_MS).toBeGreaterThan(2 * INSTANT_MS)
     expect(appConsoleErrors(errors)).toEqual([])
   })

--- a/e2e/palette.spec.ts
+++ b/e2e/palette.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test'
 import { apiURL, attachConsoleErrors, gotoApp, searchInput, DEMO_ISSUE_COUNT_EN_RE } from './helpers'
-import { en } from '../web/src/lib/i18n/en'
 
 test.describe('command palette', () => {
   test('Cmd+K opens it, typing stays local, Enter opens the issue detail', async ({ page }) => {
@@ -445,23 +444,10 @@ test.describe('command palette', () => {
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })
 
-  test('GDK-472: palette entry names its scope; empty palette is one phrase', async ({
-    page,
-  }) => {
-    const errors = attachConsoleErrors(page)
-    await gotoApp(page)
-
-    const entry = page.getByTestId('palette-open')
-    await expect(entry).toContainText('Search everything')
-    await expect(entry.locator('kbd')).toBeVisible()
-
-    await entry.click()
-    const palette = page.getByRole('dialog', { name: 'Command palette' })
-    await expect(palette).toBeVisible()
-    const box = palette.getByRole('combobox')
-    await expect(box).toHaveAttribute('placeholder', en['palette.placeholder'])
-    await expect(palette.getByTestId('palette-empty-hint')).toHaveCount(0)
-
-    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
-  })
+  // GDK-472 (entry names its scope; empty palette is one phrase) moved to
+  // web/src/components/palette/palette-entry.test.ts by the GDK-1702 cost
+  // ladder: every assertion read source or catalog strings, and opening
+  // the palette to read them back cost a boot. Entry click-through — open,
+  // type, Enter — is the real path this spec keeps (above and in
+  // usearch.spec.ts).
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -148,87 +148,16 @@ test.describe('settings dialog', () => {
 })
 
 /*
- * Settings-audit contracts (false copy / dead toggle). These two assertions
- * failed against the pre-fix catalogs and Features tab (FAIL-first 2026-08-15):
- * sourcesNoProjects said "no issue is mirrored" / "미러링되는 이슈가 없습니다",
- * and Features rendered a "Web push" checkbox that saved a flag whose
- * endpoints 404. The web-push toggle is a source-scan now
- * (web/src/components/settings/FeaturesTab.test.ts) — it cannot fail in a
- * browser once the checkbox is gone from the source.
+ * Settings-audit contracts (false copy / dead toggle) moved off the browser
+ * by the GDK-1702 cost ladder: the empty-project-picker label, the GDK-476
+ * settings lead and the About-tab hrefs were three app boots asserting
+ * strings that live in the catalogs and the components — they are
+ * web/src/components/settings/settings-copy.test.ts now (source-scan, the
+ * FeaturesTab.test.ts idiom that took the web-push toggle before them).
+ * The audit they came from failed pre-fix on: sourcesNoProjects said "no
+ * issue is mirrored" / "미러링되는 이슈가 없습니다", and Features rendered a
+ * "Web push" checkbox that saved a flag whose endpoints 404.
  */
-test.describe('settings copy contracts', () => {
-  test('empty project picker label includes every project', async ({ page }) => {
-    const API = apiURL('/api/v1/issues/')
-    await page.route(`${API}settings/`, (route) =>
-      route.fulfill({
-        json: { projects: [], staleThresholdHours: 72 },
-      }),
-    )
-    await page.route(`${API}projects/available/`, (route) =>
-      route.fulfill({
-        json: {
-          projects: [{ key: 'NMB', name: 'Nimbus Backend', projectTypeKey: 'software' }],
-          truncated: false,
-        },
-      }),
-    )
-    await page.route(`${API}settings/spaces/`, (route) =>
-      route.fulfill({
-        json: { spaces: [], all_global_when_empty: false, enabled: false },
-      }),
-    )
-
-    await gotoApp(page)
-    await openServerSettings(page)
-    const dialog = page.getByRole('dialog', { name: 'Settings' })
-    await dialog.getByRole('button', { name: 'Sources', exact: true }).click()
-
-    const projects = dialog.getByTestId('scope-projects')
-    await expect(projects).toBeVisible()
-    await expect(projects.getByTestId('scope-empty')).toContainText('every project')
-  })
-
-  // Moved from ux-f12.spec.ts (v0.21 audit ladder round); its /tmp capture
-  // was deleted with the move.
-  test('GDK-476: settings lead names the job, not a file path', async ({ page }) => {
-    const errors = attachConsoleErrors(page)
-    await page.setViewportSize({ width: 1280, height: 800 })
-    await gotoApp(page)
-    await openServerSettings(page)
-
-    const dialog = page.getByRole('dialog', { name: 'Settings' })
-    const lead = dialog.getByTestId('settings-intro')
-    await expect(lead).toBeVisible()
-    await expect(lead).toHaveText(en['settings.intro'])
-    await expect(lead).not.toContainText('config.json')
-    await expect(lead).not.toContainText('~/.gadak')
-
-    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
-  })
-})
-
-test.describe('settings about tab', () => {
-  test('lists the four feedback channel hrefs', async ({ page }) => {
-    await gotoApp(page)
-    await openServerSettings(page)
-    const dialog = page.getByRole('dialog', { name: 'Settings' })
-    await dialog.getByRole('button', { name: 'About', exact: true }).click()
-    await expect(page.getByTestId('settings-about')).toBeVisible()
-    await expect(page.getByTestId('about-link-github')).toHaveAttribute(
-      'href',
-      'https://github.com/midagedev/gadak',
-    )
-    await expect(page.getByTestId('about-link-issues')).toHaveAttribute(
-      'href',
-      'https://github.com/midagedev/gadak/issues',
-    )
-    await expect(page.getByTestId('about-link-email')).toHaveAttribute(
-      'href',
-      'mailto:midagedev@gmail.com',
-    )
-    await expect(page.getByTestId('about-link-x')).toHaveAttribute('href', 'https://x.com/midagedev')
-  })
-})
 
 /*
  * GDK-1061: the Sources-tab scope lists load once per dialog (the guard

--- a/e2e/shard-weights.tsv
+++ b/e2e/shard-weights.tsv
@@ -1,0 +1,133 @@
+# How long each spec file takes in CI — the weight table behind
+# tools/e2e-partition.sh's balanced split (GDK-1702, cut 1).
+#
+# Provenance: the CI cost census (GDK-1702 audit, run 34313848348) timed
+# every test in the e2e job; this table is that per-test list aggregated
+# per file. Five rows are adjusted to the post-cut-5 expectation, each by
+# a measured deletion (the moved case's own census seconds) except
+# mirror-instant, whose two tests merged into one (decomposed from the
+# census pair — the shared boot+anchor ≈13 s, two 3 s windows, the pull
+# and visibility budgets — and checked against a local measurement of the
+# merged test, 21.8 s):
+#
+#   mirror-instant  39.5 -> 23.0  (merge)
+#   menu-loading    15.5 ->  7.9  (picker fallback case -> vitest, -7.6)
+#   settings        18.6 -> 13.8  (3 copy cases -> source-scan, -4.8)
+#   docs-ux         32.6 -> 26.4  (2 sync-status cases -> source-scan, -6.2)
+#   palette         17.0 -> 15.8  (entry copy case -> source-scan, -1.2)
+#
+# A spec file absent from this table is dealt the table's median weight —
+# a new spec starts average-heavy until the next census refresh, it is
+# never silently free. A row naming a file that no longer exists fails
+# `tools/e2e-partition.sh --check`. Weights are seconds of test time; the
+# ~2 min of fixed per-shard cost (build, serve, browsers) is the same on
+# every shard and therefore not modelled here.
+#
+# format: <e2e/path> <TAB> <seconds>
+e2e/board-drag.spec.ts	7.9
+e2e/board-sprint-scope.spec.ts	3.8
+e2e/board.spec.ts	8.7
+e2e/boot.spec.ts	0.8
+e2e/bots.spec.ts	3.4
+e2e/breakdown-esc.spec.ts	1.3
+e2e/browse-pane.spec.ts	11.7
+e2e/built-in-attachments.spec.ts	2.7
+e2e/built-in.spec.ts	11.5
+e2e/bulk-edit.spec.ts	4.0
+e2e/cache-upgrade.spec.ts	1.8
+e2e/column-views.spec.ts	7.1
+e2e/create-fields.spec.ts	2.8
+e2e/cross-links.spec.ts	6.6
+e2e/dashboards.spec.ts	18.8
+e2e/dates.spec.ts	2.5
+e2e/deeplink-query.spec.ts	0.8
+e2e/demo-console.spec.ts	2.3
+e2e/desktop-chrome.spec.ts	1.9
+e2e/desktop-drag.spec.ts	2.1
+e2e/detail-coaching.spec.ts	11.3
+e2e/detail.spec.ts	13.0
+e2e/dialog-shell.spec.ts	7.7
+e2e/docs-deeplink.spec.ts	7.9
+e2e/docs-ux.spec.ts	26.4
+e2e/docs.spec.ts	12.7
+e2e/duedate.spec.ts	7.9
+e2e/edit-fields.spec.ts	5.9
+e2e/enrichment.spec.ts	1.1
+e2e/epics.spec.ts	6.7
+e2e/esc-negotiate.spec.ts	9.6
+e2e/feed-days.spec.ts	0.7
+e2e/feed-error.spec.ts	0.6
+e2e/filter-chips.spec.ts	4.3
+e2e/first-sync-band.spec.ts	6.4
+e2e/freshness.spec.ts	8.1
+e2e/history-nav.spec.ts	11.5
+e2e/history.spec.ts	8.6
+e2e/identity-web.spec.ts	2.8
+e2e/ime-composition.spec.ts	1.3
+e2e/integrations.spec.ts	22.8
+e2e/issue-command.spec.ts	27.2
+e2e/jira-credentials.spec.ts	4.2
+e2e/jql.spec.ts	3.7
+e2e/keys-focus.spec.ts	12.8
+e2e/keys-order.spec.ts	1.6
+e2e/last-view.spec.ts	0.6
+e2e/linked-issues.spec.ts	6.8
+e2e/list-column-header.spec.ts	4.0
+e2e/list-empty-state.spec.ts	2.9
+e2e/list-menus-esc.spec.ts	2.8
+e2e/list-row-columns.spec.ts	2.1
+e2e/list-row-overflow.spec.ts	11.9
+e2e/locale.spec.ts	2.8
+e2e/menu-loading.spec.ts	7.9
+e2e/mirror-instant.spec.ts	23.0
+e2e/motion.spec.ts	5.2
+e2e/my-work.spec.ts	5.6
+e2e/narrow-clip.spec.ts	8.1
+e2e/narrow-viewport.spec.ts	24.0
+e2e/nav-issue-list.spec.ts	6.5
+e2e/offline-banner.spec.ts	3.6
+e2e/omnibox.spec.ts	8.1
+e2e/onboarding-built-in.spec.ts	0.9
+e2e/onboarding-no-tracker.spec.ts	2.8
+e2e/onboarding.spec.ts	6.8
+e2e/page-comment-shortcut.spec.ts	1.3
+e2e/palette-create.spec.ts	2.9
+e2e/palette.spec.ts	15.8
+e2e/person.spec.ts	10.0
+e2e/picker-esc.spec.ts	4.5
+e2e/polish.spec.ts	2.9
+e2e/prose-readability.spec.ts	3.1
+e2e/resume-card.spec.ts	3.8
+e2e/retro.spec.ts	6.3
+e2e/row-narrow.spec.ts	1.2
+e2e/scroll-region.spec.ts	1.4
+e2e/search-entry.spec.ts	5.6
+e2e/search-placeholder.spec.ts	3.2
+e2e/search.spec.ts	8.6
+e2e/session-entry.spec.ts	10.1
+e2e/session-strip.spec.ts	7.7
+e2e/settings.spec.ts	13.8
+e2e/sidebar-active.spec.ts	2.4
+e2e/sidebar-sections.spec.ts	10.1
+e2e/stale-threshold.spec.ts	1.2
+e2e/team-flow.spec.ts	2.4
+e2e/team-groups.spec.ts	1.8
+e2e/terminal-burst.spec.ts	3.4
+e2e/terminal-link-focus.spec.ts	4.9
+e2e/terminal-modes.spec.ts	3.6
+e2e/terminal-settings.spec.ts	4.4
+e2e/terminal-strip.spec.ts	27.9
+e2e/terminal-theme.spec.ts	8.8
+e2e/terminal.spec.ts	16.7
+e2e/theme.spec.ts	11.6
+e2e/toast-kind.spec.ts	2.9
+e2e/triage.spec.ts	18.7
+e2e/url-state.spec.ts	10.1
+e2e/usearch.spec.ts	6.6
+e2e/user-tokens.spec.ts	4.5
+e2e/ux-p1.spec.ts	3.9
+e2e/view-cross-device.spec.ts	5.5
+e2e/view-delete.spec.ts	2.3
+e2e/visited-rows.spec.ts	2.4
+e2e/workspaces-manage.spec.ts	4.6
+e2e/write-through.spec.ts	13.8

--- a/tools/e2e-partition.sh
+++ b/tools/e2e-partition.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# The single owner of how the CI browser suite is split across shards
+# (GDK-1035, GDK-1702).
+#
+# .github/workflows/ci.yml never spells out a file list itself — it asks
+# this script which spec files belong to shard N of T. --shard=N/3 dealt
+# round-robin by test count, which is balance only if every file costs the
+# same: the cost census measured the three shards at 220/297/261 s of test
+# time, the longest shard being the job's wall clock. Here files are dealt
+# by the measured table (e2e/shard-weights.tsv) instead: longest-processing-
+# time-first onto the lightest shard.
+#
+# Why this must not quietly drop, double, or invent a file: each shard is a
+# separate runner (GDK-1035 — sharding at the runner level only, the config
+# keeps workers: 1 and fullyParallel: false), so a spec the partition loses
+# stops running anywhere. --check is what holds that: every spec in exactly
+# one shard, no empty shard, no stale weight row, and discovery cross-checked
+# against `playwright test --list` — the toolchain's own notion of the CI
+# set, which also catches a glob that disagrees with the config's testIgnore.
+#
+# Files print as e2e/-prefixed paths on purpose: playwright matches a
+# positional argument against the whole spec path, and a bare basename is a
+# substring match — `theme.spec.ts` would also select
+# terminal-theme.spec.ts (measured). The prefix makes it an exact pick.
+#
+# Usage:
+#   tools/e2e-partition.sh <shard> <total>   print the spec files for one shard
+#   tools/e2e-partition.sh --check <total>   verify the partition: every spec
+#                                            in exactly one shard, no empty
+#                                            shard, no stale weight row,
+#                                            discovery == playwright --list
+#   tools/e2e-partition.sh --list <total>    shard / files / seconds map
+#
+# Exit: 0 ok, 1 partition broken (--check), 2 usage error.
+set -euo pipefail
+export LC_ALL=C # byte-order sort, so every machine deals the same files
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+E2E_DIR="$ROOT/e2e"
+WEIGHTS="$E2E_DIR/shard-weights.tsv"
+SELF="e2e-partition"
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  tools/e2e-partition.sh <shard> <total>   print the spec files for one shard
+  tools/e2e-partition.sh --check <total>   verify the partition (exit 1 if broken)
+  tools/e2e-partition.sh --list <total>    shard / files / seconds map
+EOF
+  exit 2
+}
+
+# Every spec file the CI set runs: top-level e2e/*.spec.ts. The config's
+# testIgnore (demo/, hosted/, perf/) has no top-level spec, so this glob and
+# `playwright --list` agree — check (e) below holds them to it.
+spec_files() {
+  (cd "$ROOT" && ls e2e/*.spec.ts) | sort
+}
+
+# "weight<TAB>path" for every discovered spec. A file absent from the table
+# is dealt the table's median weight: a new spec starts average-heavy until
+# the next census refresh, never silently free and never skipped.
+weighted_specs() {
+  spec_files | awk -v weights="$WEIGHTS" '
+    BEGIN {
+      while ((getline line < weights) > 0) {
+        if (line ~ /^#/ || line ~ /^$/) continue
+        split(line, f, "\t")
+        w[f[1]] = f[2] + 0
+        n++
+        v[n] = f[2] + 0
+      }
+      close(weights)
+      if (n > 0) {
+        # insertion sort — n is a file count, and this stays awk-portable
+        for (i = 2; i <= n; i++) {
+          x = v[i]
+          for (j = i - 1; j >= 1 && v[j] > x; j--) v[j + 1] = v[j]
+          v[j + 1] = x
+        }
+        median = (n % 2) ? v[int((n + 1) / 2)] : (v[n / 2] + v[n / 2 + 1]) / 2
+      } else {
+        median = 0
+      }
+    }
+    { printf "%.1f\t%s\n", (($0 in w) ? w[$0] : median), $0 }
+  '
+}
+
+# LPT deal: heaviest file first, each onto the lightest shard; weight ties
+# break by path, load ties by the lower shard number, so the assignment is
+# a function of the table alone. stdout: "shard<TAB>path<TAB>weight",
+# nothing else.
+deal() { # $1 = total
+  weighted_specs |
+    sort -t"$(printf '\t')" -k1,1nr -k2,2 |
+    awk -F'\t' -v t="$1" '
+      {
+        b = 1
+        for (i = 2; i <= t; i++) if (load[i] < load[b]) b = i
+        load[b] += $1
+        printf "%d\t%s\t%.1f\n", b, $2, $1
+      }'
+}
+
+[[ $# -eq 2 ]] || usage
+mode=shard
+case "$1" in
+  --check) mode=check ;;
+  --list) mode=list ;;
+  -*) usage ;;
+  *) shard="$1" ;;
+esac
+total="$2"
+[[ "$total" =~ ^[1-9][0-9]*$ ]] || {
+  echo "$SELF: total must be a positive integer, got '$total'" >&2
+  exit 2
+}
+if [[ "$mode" = shard ]]; then
+  [[ "$shard" =~ ^[1-9][0-9]*$ ]] || {
+    echo "$SELF: shard must be a positive integer, got '$shard'" >&2
+    exit 2
+  }
+  [[ "$shard" -le "$total" ]] || {
+    echo "$SELF: shard $shard is out of range 1..$total" >&2
+    exit 2
+  }
+fi
+
+if [[ "$mode" = shard ]]; then
+  deal "$total" | awk -F'\t' -v s="$shard" '$1 == s { print $2 }' # stdout: paths only
+  exit 0
+fi
+
+names="$(spec_files)"
+if [[ -z "$names" ]]; then
+  echo "$SELF: no spec files found under $E2E_DIR/*.spec.ts" >&2
+  exit 1
+fi
+all=()
+while IFS= read -r n; do all+=("$n"); done <<<"$names"
+
+# (a) stale or malformed weight rows: a row naming a file that no longer
+# exists is the table rotting in place — the partition stays valid while
+# lying about what it balances. Non-numeric seconds make LPT sort garbage.
+bad_rows=()
+while IFS= read -r line; do
+  path="$(printf '%s\n' "$line" | cut -f1)"
+  secs="$(printf '%s\n' "$line" | cut -f2)"
+  if ! printf '%s' "$secs" | grep -Eq '^[0-9]+([.][0-9]+)?$'; then
+    bad_rows+=("$path (seconds '$secs' is not a number)")
+  elif ! printf '%s\n' "$names" | grep -qx "$path"; then
+    bad_rows+=("$path (no such spec in the CI set)")
+  fi
+done < <(grep -v -E '^(#|$)' "$WEIGHTS")
+
+# The deal under test is built by the same generator the workflow calls;
+# the assertions below interrogate its output, not the LPT arithmetic that
+# produced it, so a generator bug cannot pass its own check.
+assignment="$(deal "$total")"
+shard_files=()
+counts=()
+seconds=()
+s=1
+while [[ "$s" -le "$total" ]]; do
+  shard_files[s]="$(printf '%s\n' "$assignment" | awk -F'\t' -v s="$s" '$1 == s { print $2 }')"
+  counts[s]="$(printf '%s\n' "${shard_files[s]}" | grep -c .)"
+  seconds[s]="$(printf '%s\n' "$assignment" | awk -F'\t' -v s="$s" '$1 == s { sum += $3 } END { printf "%.1f", sum }')"
+  s=$((s + 1))
+done
+
+uncovered=()
+doubled=()
+covered=0
+for name in "${all[@]}"; do
+  hits=()
+  s=1
+  while [[ "$s" -le "$total" ]]; do
+    if printf '%s\n' "${shard_files[s]}" | grep -qx "$name"; then
+      hits+=("$s")
+    fi
+    s=$((s + 1))
+  done
+  case "${#hits[@]}" in
+    0) uncovered+=("$name") ;;
+    1) covered=$((covered + 1)) ;;
+    *)
+      hit_list="$(IFS=','; printf '%s' "${hits[*]}")"
+      doubled+=("$name (shards $hit_list)")
+      ;;
+  esac
+done
+
+empty=()
+s=1
+while [[ "$s" -le "$total" ]]; do
+  if [[ "${counts[s]}" -eq 0 ]]; then
+    empty+=("$s")
+  fi
+  s=$((s + 1))
+done
+
+# (e) discovery must agree with what the playwright toolchain actually
+# collects. `--list` applies the config's testMatch/testIgnore; a glob that
+# disagrees would partition files the runner never loads, or — the class
+# that matters — miss files it does. It lists test paths relative to the
+# config's testDir, i.e. bare spec basenames here. The extraction matches
+# the one "<name>.spec.ts:<line>" token per line: byte-anchored awk
+# match() under LC_ALL=C, deliberately not a multibyte separator split (a
+# space+›+space FS is three-plus bytes and BWK awk splits on each of them)
+# and not sed (s/:[0-9]+$// misbehaves under some sed builds).
+only_glob=() # in the glob, but the toolchain would not collect it
+only_pw=()   # collected by the toolchain, but the glob missed it
+if [[ "$mode" = check ]]; then
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "$SELF: npx is not on PATH; --check needs 'playwright test --list' to verify discovery" >&2
+    exit 1
+  fi
+  if ! pw_raw="$(cd "$ROOT" && npx playwright test --config e2e/playwright.config.ts --list 2>&1)"; then
+    echo "$SELF: playwright --list failed, cannot verify discovery against the toolchain:" >&2
+    printf '%s\n' "$pw_raw" | sed 's/^/  /' >&2
+    exit 1
+  fi
+  pw_files="$(printf '%s\n' "$pw_raw" |
+    LC_ALL=C awk '
+      match($0, /[A-Za-z0-9._-]+\.spec\.ts:[0-9]+/) {
+        f = substr($0, RSTART, RLENGTH)
+        sub(/:[0-9]+$/, "", f)
+        print f
+      }' | sort -u)"
+  base_names="$(printf '%s\n' "$names" | sed 's|^e2e/||')"
+  while IFS= read -r line; do only_glob+=("$line"); done \
+    < <(comm -23 <(printf '%s\n' "$base_names") <(printf '%s\n' "$pw_files"))
+  while IFS= read -r line; do only_pw+=("$line"); done \
+    < <(comm -13 <(printf '%s\n' "$base_names") <(printf '%s\n' "$pw_files"))
+fi
+
+if [[ "$mode" = check ]]; then
+  fail=0
+  if [[ ${#bad_rows[@]} -gt 0 ]]; then
+    echo "$SELF: weight rows that are stale or not numeric:" >&2
+    printf '  %s\n' "${bad_rows[@]}" >&2
+    fail=1
+  fi
+  if [[ ${#uncovered[@]} -gt 0 ]]; then
+    echo "$SELF: specs no shard would run:" >&2
+    printf '  %s\n' "${uncovered[@]}" >&2
+    fail=1
+  fi
+  if [[ ${#doubled[@]} -gt 0 ]]; then
+    echo "$SELF: specs dealt to more than one shard:" >&2
+    printf '  %s\n' "${doubled[@]}" >&2
+    fail=1
+  fi
+  if [[ ${#empty[@]} -gt 0 ]]; then
+    echo "$SELF: empty shards: ${empty[*]}" >&2
+    fail=1
+  fi
+  if [[ ${#only_glob[@]} -gt 0 || ${#only_pw[@]} -gt 0 ]]; then
+    echo "$SELF: discovery disagrees with 'playwright test --list':" >&2
+    if [[ ${#only_glob[@]} -gt 0 ]]; then
+      printf '  glob has, toolchain has not:\n  %s\n' "${only_glob[@]}" >&2
+    fi
+    if [[ ${#only_pw[@]} -gt 0 ]]; then
+      printf '  toolchain has, glob has not:\n  %s\n' "${only_pw[@]}" >&2
+    fi
+    fail=1
+  fi
+  if [[ "$fail" -ne 0 ]]; then
+    echo "$SELF: partition broken" >&2
+    exit 1
+  fi
+fi
+
+# grep -c exits 1 on a zero count — the every-file-measured case — so the
+# count is read with the exit status masked.
+median_fallback="$(comm -23 <(spec_files) <(grep -v -E '^(#|$)' "$WEIGHTS" | cut -f1) | grep -c . || true)"
+total_seconds="$(printf '%s\n' "$assignment" | awk -F'\t' '{ sum += $3 } END { printf "%.1f", sum }')"
+echo "$SELF: ${#all[@]} spec files across $total shards, ${total_seconds} s weighted; $median_fallback file(s) on median fallback; stale weight rows: ${#bad_rows[@]}"
+s=1
+while [[ "$s" -le "$total" ]]; do
+  printf 'shard %d of %d: %3d files  %6.1f s  %s ... %s\n' \
+    "$s" "$total" "${counts[s]}" "${seconds[s]}" \
+    "$(printf '%s\n' "${shard_files[s]}" | sed -n '1p' | sed 's|^e2e/||')" \
+    "$(printf '%s\n' "${shard_files[s]}" | sed -n '$p' | sed 's|^e2e/||')"
+  s=$((s + 1))
+done

--- a/web/src/components/palette/palette-entry.test.ts
+++ b/web/src/components/palette/palette-entry.test.ts
@@ -1,0 +1,50 @@
+/*
+ * GDK-472 palette entry copy, moved from e2e/palette.spec.ts by the
+ * GDK-1702 cost ladder: the case opened the palette to read three strings
+ * that live in the source and the catalog. Entry click-through (open,
+ * type, Enter) stays in e2e — usearch.spec.ts and the palette spec keep
+ * the real path.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { en } from '../../lib/i18n/en'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SEARCHBOX = join(HERE, '../list/SearchBox.svelte')
+const PALETTE = join(HERE, 'CommandPalette.svelte')
+
+describe('GDK-472: palette entry names its scope; empty palette is one phrase', () => {
+  const searchbox = readFileSync(SEARCHBOX, 'utf8')
+  const palette = readFileSync(PALETTE, 'utf8')
+
+  test('the entry button says what it searches and shows the shortcut', () => {
+    // Blocks: a button that is only an icon (scope unnamed) or that hides
+    // the kbd — the e2e asserted the entry contains 'Search everything'
+    // and a visible <kbd>.
+    const button = searchbox.slice(
+      searchbox.indexOf('data-testid="palette-open"'),
+      searchbox.indexOf('</button>', searchbox.indexOf('data-testid="palette-open"')),
+    )
+    expect(button, 'the entry button block').toBeTruthy()
+    expect(button).toMatch(/\{t\('palette\.entryLabel'\)\}/)
+    expect(button).toMatch(/<kbd/)
+    expect(en['palette.entryLabel']).toBe('Search everything')
+  })
+
+  test('the palette input placeholder is the catalog key, and the en sentence says what it does', () => {
+    // Blocks: a hand-written placeholder drifting from the catalog (ko/ja
+    // would silently keep the old sentence) — or the sentence forgetting
+    // it names two things: jump and search.
+    expect(palette).toMatch(/placeholder=\{t\('palette\.placeholder'\)\}/)
+    expect(en['palette.placeholder']).toBe('Jump to an issue, or search everything…')
+  })
+
+  test('an empty palette is one phrase — no empty-state hint element', () => {
+    // Blocks: the removed two-phrase empty state coming back. The e2e
+    // asserted palette-empty-hint count 0 on open; it is absent from the
+    // source, and this keeps it that way.
+    expect(palette).not.toMatch(/palette-empty-hint/)
+  })
+})

--- a/web/src/components/settings/settings-copy.test.ts
+++ b/web/src/components/settings/settings-copy.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Settings copy contracts, moved from e2e/settings.spec.ts by the GDK-1702
+ * cost ladder: three cases whose every assertion reads source or catalog
+ * text that a browser run can only mirror back — each one cost a full app
+ * boot in CI to assert a string. The FeaturesTab.test.ts idiom: scan the
+ * source the compiler emits and the catalog the strings live in. What
+ * stays in e2e is what needs the dialog open (Tabs rendering, runtime
+ * mirror, API round-trips).
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { en } from '../../lib/i18n/en'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const DIALOG = join(HERE, 'SettingsDialog.svelte')
+const SOURCES = join(HERE, 'SourcesTab.svelte')
+const SCOPE = join(HERE, 'ScopePicker.svelte')
+const ABOUT = join(HERE, 'AboutTab.svelte')
+
+describe('GDK-476: settings lead names the job, not a file path', () => {
+  const dialog = readFileSync(DIALOG, 'utf8')
+
+  test('the lead paragraph is the intro copy, not implementation vocabulary', () => {
+    // Blocks: the lead drifting back to "edit your config.json" — the
+    // audit's finding. The e2e asserted toHaveText(en['settings.intro'])
+    // plus no 'config.json' / '~/.gadak'; the binding plus the catalog
+    // sentence carry both halves here.
+    expect(dialog).toMatch(/data-testid="settings-intro"[\s\S]{0,200}\{t\('settings\.intro'\)\}/)
+    expect(en['settings.intro']).not.toMatch(/config\.json/)
+    expect(en['settings.intro']).not.toMatch(/~\/\.gadak/)
+  })
+})
+
+describe('empty project picker label includes every project', () => {
+  const sources = readFileSync(SOURCES, 'utf8')
+  const scope = readFileSync(SCOPE, 'utf8')
+
+  test('an empty selection renders the every-project sentence, which says so', () => {
+    // Blocks: the pre-fix catalog that said "no issue is mirrored" for an
+    // empty selection — which mirrors EVERYTHING. The e2e route-stubbed
+    // projects:[] and asserted the rendered label; the sentence and its
+    // binding are the whole contract, and "every project" is the exact
+    // phrase that case checked for.
+    expect(sources).toMatch(/emptyLabel=\{t\('settings\.sourcesNoProjects'\)\}/)
+    expect(scope).toMatch(/\{:else if emptyLabel\}[\s\S]{0,200}data-testid="scope-empty"[^>]*>\{emptyLabel\}/)
+    expect(en['settings.sourcesNoProjects']).toContain('every project')
+  })
+})
+
+describe('about tab lists the four feedback channels', () => {
+  const about = readFileSync(ABOUT, 'utf8')
+
+  test('github / issues / email / x hrefs and their testids stay paired', () => {
+    // Blocks: a channel silently pointing at the wrong URL (or losing its
+    // testid, which is how anything downstream finds it). The e2e asserted
+    // toHaveAttribute('href', …) on each of the four — the constants are
+    // where those hrefs live.
+    const pairs: [string, string][] = [
+      ['github', 'https://github.com/midagedev/gadak'],
+      ['issues', 'https://github.com/midagedev/gadak/issues'],
+      ['email', 'mailto:midagedev@gmail.com'],
+      ['x', 'https://x.com/midagedev'],
+    ]
+    for (const [id, href] of pairs) {
+      expect(about, `about-link-${id} href`).toMatch(new RegExp(`href=\\{(${id.toUpperCase()})\\}`))
+      expect(about, `the ${id.toUpperCase()} constant`).toMatch(
+        new RegExp(`const ${id.toUpperCase()} = '${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`),
+      )
+      expect(about).toMatch(new RegExp(`data-testid="about-link-${id}"`))
+    }
+  })
+})

--- a/web/src/lib/menu-loading.test.ts
+++ b/web/src/lib/menu-loading.test.ts
@@ -1,0 +1,162 @@
+/*
+ * GDK-1566: the shared cap on menu origin round-trips.
+ *
+ * Two halves, both ladder moves from e2e/menu-loading.spec.ts:
+ *
+ *  - the timing contract (withMenuTimeout resolves/rejects/passes through)
+ *    is a fake-timer unit here — in the browser it cost a 6 s stall per
+ *    case and could only ever assert the two ends of one wait;
+ *  - the picker's fallback structure — the detail priority picker falls
+ *    back to the cached site catalog with the offline note when the
+ *    per-key answer times out — is a source scan of PriorityPicker.svelte
+ *    (the FeaturesTab.test.ts idiom: vitest is environment:'node', the
+ *    unit project loads no svelte plugin, and copy/structure that cannot
+ *    drift apart from the source it lives in does not need a browser).
+ *
+ * The bulk-menu half of the spec (failure sentence + Retry, and a second
+ * capped wait after Retry) stays in e2e: it needs the real menu open.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { en } from './i18n/en'
+import { MENU_ORIGIN_TIMEOUT_MS, MenuOriginTimeout, withMenuTimeout } from './menu-loading'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PICKER = join(HERE, '../components/write/PriorityPicker.svelte')
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function deferred<T>(): { promise: Promise<T>; resolve(v: T): void; reject(e: unknown): void } {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/** Settled-event recorder: one entry per settlement, so a promise that
+ * settles twice — or never — is distinguishable from one that settles once. */
+function eventsOf<T>(p: Promise<T>): { calls: string[]; value: () => T | undefined; error: () => unknown } {
+  const calls: string[] = []
+  let val: T | undefined
+  let err: unknown
+  p.then(
+    (v) => {
+      val = v
+      calls.push('fulfilled')
+    },
+    (e) => {
+      err = e
+      calls.push('rejected')
+    },
+  )
+  return { calls, value: () => val, error: () => err }
+}
+
+describe('withMenuTimeout (GDK-1566)', () => {
+  test('an answer inside the cap is the call\'s own answer, and the timer is cleared', async () => {
+    // Blocks: a cap that swallows in-time answers, or leaks a timer that
+    // rejects an already-settled wait later in the menu's life.
+    const d = deferred<string>()
+    const events = eventsOf(withMenuTimeout(d.promise))
+
+    d.resolve('site catalog')
+    await vi.advanceTimersByTimeAsync(1)
+    expect(events.calls).toEqual(['fulfilled'])
+    expect(events.value()).toBe('site catalog')
+    expect(vi.getTimerCount(), 'the cap timer must be cleared on settle').toBe(0)
+
+    // Past the cap with no timer: nothing fires, the wait stays answered.
+    await vi.advanceTimersByTimeAsync(MENU_ORIGIN_TIMEOUT_MS * 2)
+    expect(events.calls).toEqual(['fulfilled'])
+  })
+
+  test('a silent origin rejects with MenuOriginTimeout at exactly the cap', async () => {
+    // Blocks: an uncapped wait (the unreachable-origin 15 s socket hold this
+    // cap exists for), or a cap that fires early/late.
+    const events = eventsOf(withMenuTimeout(deferred<string>().promise))
+
+    await vi.advanceTimersByTimeAsync(MENU_ORIGIN_TIMEOUT_MS - 1)
+    expect(events.calls, 'one ms before the cap the menu is still waiting').toEqual([])
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(events.calls).toEqual(['rejected'])
+    const e = events.error() as MenuOriginTimeout
+    expect(e).toBeInstanceOf(MenuOriginTimeout)
+    expect(e.name).toBe('MenuOriginTimeout')
+    expect(e.message).toBe(`origin did not answer within ${MENU_ORIGIN_TIMEOUT_MS} ms`)
+  })
+
+  test('the cap is the shared constant, not a per-menu number', () => {
+    // Blocks: the next copy of this menu reintroducing its own wait. The
+    // audit found the three loaders by their shared shape; the constant is
+    // the contract (e2e imports it so no spec re-derives it either).
+    expect(MENU_ORIGIN_TIMEOUT_MS).toBe(6_000)
+  })
+
+  test('a store error passes through unwrapped — credential refusals keep their dialog path', async () => {
+    // Blocks: MenuOriginTimeout swallowing an ApiError: the picker's catch
+    // only closes on the timeout; anything else must rethrow as itself.
+    const sentinel = new Error('refused')
+    const events = eventsOf(withMenuTimeout(Promise.reject(sentinel)))
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(events.calls).toEqual(['rejected'])
+    expect(events.error()).toBe(sentinel)
+    expect(events.error()).not.toBeInstanceOf(MenuOriginTimeout)
+    expect(vi.getTimerCount(), 'the cap timer must be cleared on settle').toBe(0)
+  })
+
+  test('a late success does not resurrect the wait', async () => {
+    // Blocks: a race that "un-rejects" when the origin finally answers —
+    // the menu already showed the fallback; flipping back mid-read is the
+    // defect. The request itself is not aborted and its answer still lands
+    // in the store for the next open; this promise settles once.
+    const d = deferred<string>()
+    const events = eventsOf(withMenuTimeout(d.promise))
+
+    await vi.advanceTimersByTimeAsync(MENU_ORIGIN_TIMEOUT_MS)
+    expect(events.calls).toEqual(['rejected'])
+
+    d.resolve('late per-key catalog')
+    await vi.advanceTimersByTimeAsync(1)
+    expect(events.calls, 'a settled race stays settled').toEqual(['rejected'])
+    expect(events.error()).toBeInstanceOf(MenuOriginTimeout)
+  })
+})
+
+describe('detail picker timeout fallback (moved from e2e menu-loading case 2)', () => {
+  const picker = readFileSync(PICKER, 'utf8')
+
+  test('the per-key load runs under the shared cap and only the timeout degrades', () => {
+    // Blocks: the picker waiting past the cap, or treating every failure as
+    // "use the cache" — a credential refusal must still throw.
+    expect(picker).toMatch(/withMenuTimeout\(write\.loadPrioritiesFor\(issue\.issue_key\)\)/)
+    expect(picker).toMatch(/if \(!\(e instanceof MenuOriginTimeout\)\) throw e/)
+  })
+
+  test('a timeout falls back to the site catalog when one is cached, else the error row', () => {
+    // Blocks: a timeout on a primed site catalog rendering the error row
+    // (or vice versa) — the cached rows ARE the answer the user can act on.
+    expect(picker).toMatch(/load = write\.priorities\.length \? 'cached' : 'error'/)
+  })
+
+  test('the cached rows carry the offline note, and only when they stand in', () => {
+    // Blocks: the note naming a cache the user is not looking at. The note
+    // renders only while the rows are the site catalog standing in for the
+    // per-key answer the origin never gave.
+    expect(picker).toMatch(/load === 'cached' && !write\.hasPrioritiesFor\(issue\.issue_key\)/)
+    expect(picker).toMatch(/data-testid="menu-cached-note"[\s\S]{0,120}\{t\('app\.offlineBanner'\)\}/)
+    expect(en['app.offlineBanner'], 'the note is real copy, not an empty key').toBeTruthy()
+  })
+})

--- a/web/src/lib/mirror-status.test.ts
+++ b/web/src/lib/mirror-status.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { SyncHealth, SyncSourceHealth } from './types'
 
@@ -113,6 +114,14 @@ describe('busyLabel', () => {
     expect(busyLabel()).toBe('Syncing issues · 40')
   })
 
+  test('a four-digit count is grouped: 6932 reads 6,932', () => {
+    // Blocks: a raw "Syncing issues · 6932" on the leg that actually runs
+    // long enough to reach four digits (moved from e2e/docs-ux.spec.ts,
+    // which asserted this exact chip sentence in a browser).
+    issues.mirrorActivity = { running: true, source: 'issues', fetched: 6932 }
+    expect(busyLabel()).toBe('Syncing issues · 6,932')
+  })
+
   test('tab-started pull with no phase yet is the generic busy sentence', () => {
     // Blocks: the first second of a pull this tab started reading as idle.
     issues.mirrorSyncing = true
@@ -180,5 +189,33 @@ describe('mirrorLabel', () => {
     idle()
     settle()
     expect(mirrorLabel()).toBe('Synced 3m ago')
+  })
+})
+
+/*
+ * GDK-460 ownership, moved from e2e/docs-ux.spec.ts's "sync status is one
+ * sentence" describe by the GDK-1702 cost ladder: the busy sentence
+ * belongs to the toolbar chip (and surfaces naming the same pass), and the
+ * sidebar row is the sync-history entry — it must not repeat the chip.
+ * The kept document-pass e2e case still proves this end to end against a
+ * running app; these scans pin where the sentence is allowed to render so
+ * a new surface cannot start borrowing it silently.
+ */
+describe('GDK-460: the busy sentence is the chip\'s, the sidebar row is sync history', () => {
+  test('the freshness chip renders mirrorLabel', () => {
+    const chip = readFileSync(new URL('../components/shell/FreshnessChip.svelte', import.meta.url), 'utf8')
+    expect(chip).toMatch(/mirrorLabel\(\)/)
+  })
+
+  test('the sidebar sync row names the log, not the pass', () => {
+    const nav = readFileSync(new URL('../components/sidebar/SidebarNav.svelte', import.meta.url), 'utf8')
+    const button = nav.slice(
+      nav.indexOf('data-testid="sidebar-sync-now"'),
+      nav.indexOf('</button>', nav.indexOf('data-testid="sidebar-sync-now"')),
+    )
+    // Visible text is the log entry; syncLabel may ride the tooltip only.
+    expect(button).toMatch(/\{t\('sidebar\.syncHistory'\)\}/)
+    expect(button).not.toMatch(/\{syncLabel\}/)
+    expect(button).not.toMatch(/\{mirrorLabel\(\)\}/)
   })
 })

--- a/web/src/stores/issues-activity-visibility.test.ts
+++ b/web/src/stores/issues-activity-visibility.test.ts
@@ -1,0 +1,52 @@
+/*
+ * The announce threshold for a running pass, moved from e2e/docs-ux.spec.ts
+ * by the GDK-1702 cost ladder. The browser case cost 5.2 s of CI wall clock
+ * (a 1.5 s young-pass window plus up to 15 s waiting for the same stubbed
+ * pass to cross 4 s) to observe one number the source states outright.
+ *
+ * What moved here is the rule: a pass is narrated only once it has run
+ * ACTIVITY_MIN_VISIBLE_MS, and an unparseable started_at errs toward
+ * showing the pass (a pass the clock cannot date must not be invisible).
+ * What stays in e2e is the running half — a real chip crossing from quiet
+ * to narrated — which the kept document-pass case covers end to end.
+ *
+ * Source scan, not import: the store is a runes module (*.svelte.ts) and
+ * the vitest unit project loads no svelte plugin (FeaturesTab.test.ts
+ * idiom). The assertions pin the gate's shape; rewording the comment
+ * around it stays green.
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const STORE = join(HERE, 'issues.svelte.ts')
+
+describe('a pass is announced only once it has run long enough to wonder about', () => {
+  const store = readFileSync(STORE, 'utf8')
+
+  test('the threshold is four seconds — past the every-minute incremental, under the backfill', () => {
+    // Blocks: the threshold being tuned away in either direction. The
+    // watch loop's incrementals finish in a second or two, every minute —
+    // narrating those puts a blinking status in front of someone all day;
+    // the six-minute backfill is what needed saying.
+    expect(store).toMatch(/ACTIVITY_MIN_VISIBLE_MS = 4_000/)
+  })
+
+  test('visibility is elapsed-time gated: running AND old enough', () => {
+    // Blocks: a pass announced in its first poll (no rule at all — the
+    // young half the e2e case asserted), which is the `a.running && old`
+    // shape: running alone must not reach the UI.
+    expect(store).toMatch(/running: a\.running && old/)
+    expect(store).toMatch(/Date\.now\(\) - startedMs >= ACTIVITY_MIN_VISIBLE_MS/)
+  })
+
+  test('a started_at the clock cannot parse errs toward showing the pass', () => {
+    // Blocks: a malformed date making `old` false and hiding a pass that
+    // is really running — Number.isFinite false ⇒ true is the fail-open
+    // branch of the ternary.
+    expect(store).toMatch(/Number\.isFinite\(startedMs\)/)
+    expect(store).toMatch(/: true/)
+  })
+})


### PR DESCRIPTION
Audit axis 9 of the v0.22 release audit ([GDK-1698]). The census measured the run growing across releases: since v0.19 the race job went 300 → 434 s, E2E 314 → 403 s, staticcheck 219 → 309 s, wall time 317 → 438 s, and billable minutes 2,241 → 3,358 across 60 runs — with 0 failures and 13 cancels in that window.

Three changes, none of which drops a gate.

**The static-analysis job runs only when a push touches Go.** A first step diffs the change and gates every step below on its output; the path list is the Go surface plus the job's own inputs (`tools/staticcheck.sh` and this workflow). It fails **open** — a forced push whose before is unreachable, a first push, `workflow_dispatch`, an empty base, or any diff error runs the job — because a gate skipped by mistake is the failure mode that matters, and a gate run for nothing is five minutes. The round was written when this job was warning-only; `--warn-only` was dropped in 90e27bdf and the resolved workflow keeps it dropped, so the skip logic now guards a real gate.

**Browser shards are dealt by measured time, not file order.** `tools/e2e-partition.sh` partitions the specs into N bins by longest-processing-time over `e2e/shard-weights.tsv` (measured seconds); the three bins come out at 247.6 / 247.1 / 247.7 s. `--check` verifies the partition against the spec list, so a new spec with no weight row is visible rather than silently dumped into one bin.

**Five assertions that never needed a browser moved to vitest** — menu loading, settings copy, palette entry, activity visibility, and mirror-status wording. Same claims, no page.

Gates on this branch:

```
e2e-partition --check 3   107 spec files, 3 shards, 742.4 s weighted, 0 median fallback, 0 stale rows
vitest                    129 files, 1306 tests, all passed
make typecheck            clean
playwright                483 passed, 3 skipped, 0 failed (8.2m)
yaml parse                ok
doc-checks                all passed
```

Opened as a PR rather than pushed to main because it edits `.github/workflows/ci.yml`, which no local gate can judge.

[GDK-1698]: https://gadak.dev/backlog/#/?ks=GDK-1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)