### PR TITLE
feat: add completed child issue visibility filter

### DIFF
--- a/e2e/epics.spec.ts
+++ b/e2e/epics.spec.ts
@@ -1,6 +1,7 @@
 import { type Page } from '@playwright/test'
 import { test, expect } from './helpers'
 import { attachConsoleErrors, gotoApp, searchInput } from './helpers'
+import type { IssueLite } from '../web/src/lib/types'
 
 /**
  * Epic hierarchy across the three surfaces that show it: the grouped list, the
@@ -125,11 +126,65 @@ test.describe('epic hierarchy', () => {
     // 12 fits under the collapse threshold, so nothing is hidden behind a toggle.
     await expect(panel.getByTestId('epic-children-toggle')).toHaveCount(0)
 
+    const showCompleted = panel.getByRole('checkbox', { name: 'Show completed', exact: true })
+    await expect(showCompleted).toBeChecked()
+    await expect(showCompleted).toHaveAttribute('data-testid', 'epic-show-completed')
+    await showCompleted.focus()
+    await page.keyboard.press('Space')
+    await expect(showCompleted).not.toBeChecked()
+    await expect(childRows).toHaveCount(8)
+    await expect(panel.getByTestId('epic-progress')).toContainText('4 of 12 done')
+    await expect(panel.getByTestId('epic-progress')).toContainText('33%')
+    await expect(panel.getByTestId('epic-children-toggle')).toHaveCount(0)
+    await page.keyboard.press('Space')
+    await expect(showCompleted).toBeChecked()
+    await expect(childRows).toHaveCount(12)
+
     await childRows.filter({ hasText: 'NMB-126' }).click()
     await expect(panel.getByRole('heading', { name: /tax twice/ })).toBeVisible()
     // The child is not an epic, so the rollup is gone with it.
     await expect(panel.getByTestId('epic-progress')).toHaveCount(0)
+    await expect(showCompleted).toHaveCount(0)
 
+    expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
+  })
+
+  test('all completed direct children remain recoverable and another parent starts unfiltered', async ({ page }) => {
+    const errors = attachConsoleErrors(page)
+    // Reuse mirrored issue identities; only their child relation/category is synthetic.
+    await page.route('**/api/v1/issues/bootstrap/', async (route) => {
+      const response = await route.fetch()
+      const body = await response.json() as { issues: IssueLite[] }
+      for (const issue of body.issues) {
+        if (issue.epic_key === 'NMB-195') {
+          issue.epic_key = null
+          issue.parent_key = 'NMB-195'
+          issue.status_category = 'done'
+          issue.status = '진행 중'
+        }
+      }
+      await route.fulfill({ response, json: body })
+    })
+    await gotoApp(page)
+    await openIssue(page, 'NMB-195')
+    const panel = page.getByTestId('issue-detail-panel')
+    const showCompleted = panel.getByRole('checkbox', { name: 'Show completed', exact: true })
+    await expect(panel.getByRole('heading', { name: 'Child issues 12', exact: true })).toBeVisible()
+    await expect(panel.getByTestId('epic-child-row')).toHaveCount(12)
+    await showCompleted.uncheck()
+    await expect(panel.getByTestId('epic-child-row')).toHaveCount(0)
+    await expect(panel.getByText('No incomplete child issues.', { exact: true })).toBeVisible()
+    await expect(panel.getByTestId('epic-progress')).toContainText('12 of 12 done')
+    await expect(panel.getByTestId('epic-progress')).toContainText('100%')
+    await expect(panel.getByTestId('epic-children-toggle')).toHaveCount(0)
+    await showCompleted.check()
+    await expect(panel.getByTestId('epic-child-row')).toHaveCount(12)
+    await expect(panel.getByText('No incomplete child issues.', { exact: true })).toHaveCount(0)
+    await showCompleted.uncheck()
+    await page.keyboard.press('Escape')
+    await openIssue(page, 'NMA-174')
+    await expect(showCompleted).toBeChecked()
+    await expect(panel.getByTestId('epic-child-row').first()).toBeVisible()
     expect(errors, `console errors:\n${errors.join('\n')}`).toEqual([])
   })
 

--- a/web/src/components/detail/EpicProgress.svelte
+++ b/web/src/components/detail/EpicProgress.svelte
@@ -43,10 +43,18 @@
   let expandedFor = $state<string | null>(null)
   const expanded = $derived(expandedFor === issueKey)
 
-  const shown = $derived<IssueLite[]>(
-    children.length > PREVIEW && !expanded ? children.slice(0, PREVIEW) : children,
+  let hideCompletedFor = $state<string | null>(null)
+  const showCompleted = $derived(hideCompletedFor !== issueKey)
+  const filteredChildren = $derived(
+    showCompleted ? children : children.filter((child) => categoryOf(child) !== 'done'),
   )
-  const hidden = $derived(children.length - shown.length)
+
+  const shown = $derived<IssueLite[]>(
+    filteredChildren.length > PREVIEW && !expanded
+      ? filteredChildren.slice(0, PREVIEW)
+      : filteredChildren,
+  )
+  const hidden = $derived(filteredChildren.length - shown.length)
 </script>
 
 {#if children.length > 0}
@@ -66,6 +74,23 @@
            to carry a bg-elevated track that vanished on its own ground. -->
       <MeterBar percent={percent} fill={categoryMetaOf('done').color} height="h-1" />
     </div>
+
+    <label class="mb-2 flex w-fit cursor-pointer items-center gap-2 text-micro text-text-secondary">
+      <input
+        type="checkbox"
+        data-testid="epic-show-completed"
+        class="accent-[var(--color-accent)]"
+        checked={showCompleted}
+        onchange={(event) => (hideCompletedFor = event.currentTarget.checked ? null : issueKey)}
+      />
+      {t('detail.showCompletedChildren')}
+    </label>
+
+    {#if filteredChildren.length === 0}
+      <p class="px-2 py-1.5 text-body text-text-muted">
+        {t('detail.noIncompleteChildren')}
+      </p>
+    {/if}
 
     <ul class="flex flex-col gap-1">
       {#each shown as child (child.issue_key)}
@@ -91,7 +116,7 @@
       {/each}
     </ul>
 
-    {#if hidden > 0 || expanded}
+    {#if filteredChildren.length > PREVIEW}
       <button
         type="button"
         data-testid="epic-children-toggle"

--- a/web/src/components/detail/EpicProgress.test.ts
+++ b/web/src/components/detail/EpicProgress.test.ts
@@ -22,6 +22,7 @@ import { parse } from 'svelte/compiler'
 import { describe, expect, test } from 'vitest'
 import { en } from '../../lib/i18n/en'
 import { ko } from '../../lib/i18n/ko'
+import { effectiveCategory } from '../../lib/view-config'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const SRC_PATH = join(HERE, 'EpicProgress.svelte')
@@ -204,5 +205,90 @@ describe('EpicProgress child selection (GDK-121)', () => {
     expect(source).toContain('data-testid="epic-child-row"')
     expect(source).toContain('data-testid="epic-children-toggle"')
     expect(source).toMatch(/const PREVIEW = 20/)
+  })
+})
+
+type Child = Lite & { status_category: string; status: string }
+
+function evalDisplay(
+  allIssues: Child[],
+  issueKey: string,
+  hideCompletedFor: string | null,
+  expandedFor: string | null = null,
+): {
+  children: Child[]
+  filteredChildren: Child[]
+  shown: Child[]
+  hidden: number
+  doneCount: number
+  percent: number
+  showCompleted: boolean
+} {
+  const body = derivedBindings().map((d) => `const ${d.name} = ${d.expr};`).join('\n')
+  const fn = new Function(
+    'issues', 'issueKey', 'hideCompletedFor', 'expandedFor', 'categoryOf', 'PREVIEW',
+    `${body}\nreturn { children, filteredChildren, shown, hidden, doneCount, percent, showCompleted };`,
+  )
+  return fn({ allIssues }, issueKey, hideCompletedFor, expandedFor, effectiveCategory, 20)
+}
+
+function child(index: number, done: boolean): Child {
+  return {
+    issue_key: `CHILD-${index}`,
+    parent_key: STORY,
+    epic_key: EPIC,
+    status_category: done ? 'done' : 'indeterminate',
+    // Deliberately contradict the category: display names never decide completion.
+    status: done ? '진행 중' : 'Done',
+  }
+}
+
+describe('child completion filtering', () => {
+  test.each([STORY, EPIC])('filters and restores %s children without changing progress', (key) => {
+    const children = [child(1, true), child(2, false), child(3, false)]
+    const initial = evalDisplay(children, key, null)
+    const filtered = evalDisplay(children, key, key)
+    const restored = evalDisplay(children, key, null)
+    expect(initial.shown).toEqual(children)
+    expect(filtered.shown).toEqual(children.slice(1))
+    expect(restored.shown).toEqual(initial.shown)
+    for (const state of [initial, filtered, restored]) {
+      expect(state.children).toHaveLength(3)
+      expect(state.doneCount).toBe(1)
+      expect(state.percent).toBe(33)
+    }
+  })
+
+  test('another parent starts with completed children visible', () => {
+    const children = [child(1, true)]
+    expect(evalDisplay(children, STORY, STORY).showCompleted).toBe(false)
+    const next = evalDisplay(children, EPIC, STORY)
+    expect(next.showCompleted).toBe(true)
+    expect(next.shown).toEqual(children)
+  })
+
+  test('all-hidden retains its complete set while genuinely childless stays empty', () => {
+    const children = [child(1, true), child(2, true)]
+    const filtered = evalDisplay(children, STORY, STORY)
+    expect(filtered.children).toHaveLength(2)
+    expect(filtered.shown).toEqual([])
+    expect(filtered.percent).toBe(100)
+    expect(filtered.hidden).toBe(0)
+    expect(evalDisplay(children, 'CHILD-1', null).children).toEqual([])
+    expect(source).toContain('{#if filteredChildren.length === 0}')
+    expect(source).toContain("t('detail.noIncompleteChildren')")
+  })
+
+  test.each([19, 20, 21])('previews after filtering with %i incomplete children', (count) => {
+    const done = Array.from({ length: 20 }, (_, i) => child(i, true))
+    const open = Array.from({ length: count }, (_, i) => child(i + 20, false))
+    const children = [...done, ...open]
+    const collapsed = evalDisplay(children, STORY, STORY)
+    expect(collapsed.shown).toEqual(open.slice(0, 20))
+    expect(collapsed.hidden).toBe(Math.max(0, count - 20))
+    const expanded = evalDisplay(children, STORY, STORY, STORY)
+    expect(expanded.shown).toEqual(open)
+    expect(expanded.hidden).toBe(0)
+    expect(source).toContain('{#if filteredChildren.length > PREVIEW}')
   })
 })

--- a/web/src/lib/i18n/messages/detail.ts
+++ b/web/src/lib/i18n/messages/detail.ts
@@ -200,6 +200,16 @@ export const detail = {
     ko: '접기',
     ja: '少なく表示',
   },
+  'detail.showCompletedChildren': {
+    en: 'Show completed',
+    ko: '완료 항목 표시',
+    ja: '完了した課題を表示',
+  },
+  'detail.noIncompleteChildren': {
+    en: 'No incomplete child issues.',
+    ko: '미완료 하위 이슈가 없습니다.',
+    ja: '未完了の子課題はありません。',
+  },
   'detail.deploy': {
     en: 'Deploy status',
     ko: '배포 상태',


### PR DESCRIPTION
## What / why

- Add a native **Show completed** checkbox to the existing issue-detail child list, covering both epic descendants and direct children. It starts checked to preserve the current initial view; unchecking hides completed children and checking restores them.
- Reuse existing UI tokens and canonical status categories, not localized status names. Filtering stays entirely in memory and local to the selected issue.
- Keep the section count, done/total text, and progress meter based on all children. Apply filtering before the 20-row preview, and distinguish an all-filtered list from an issue with no children.
- Localize the label and filtered-empty message in English, Korean, and Japanese.
- **Contracts:** UI-only; no changes to HTTP, sync, schema, agent/CLI interfaces, or persisted preferences. Their documentation and runtime defaults remain unchanged.

## How to test

Commands run locally:

```bash
npx vitest run web/src/components/detail/EpicProgress.test.ts
npm run typecheck
npm run build
go build ./...
go vet ./...
gofmt -l .
env -u NO_COLOR TERM=xterm-256color go test ./...
GADAK_E2E_PORT=7917 npm run test:e2e
GADAK_E2E_PORT=7917 npx playwright test --config e2e/playwright.config.ts e2e/epics.spec.ts
bash scripts/scan-internal.sh
bash desktop/build-app.sh
```

- Focused unit suite: **11 passed**. Includes category/display-name disagreement, epic/direct-child membership, full-set progress, filtered-empty behavior, and preview boundaries at 19/20/21 incomplete children.
- Focused browser suite: **6 passed**. Covers native Space-key toggling, restoration, stable progress, all-completed direct children, navigation, and another parent's default state.
- Full browser suite: **511 passed, 15 skipped**. This ran before the final behavior-neutral checkbox test-id addition; focused unit/browser tests, typecheck/build, and live Korean browser verification were repeated after that addition.
- Typecheck: no errors or warnings. Go build/vet/tests passed; gofmt output was empty. Existing QR tests initially failed under inherited terminal environment variables and passed with the explicit environment shown above, without test changes or exclusions.
- Live Korean GUI verification: the demo epic's children change **12 → 8 → 12**, while progress remains **4/12 (33%)**. Native macOS application also built and launched using demo data.
- Existing Vite chunk/dynamic-import and native macOS linker warnings remain. Secret/tenant-host/path scan passed; the optional custom-word check was skipped because no word list is configured.

Manual check: open a parent with mixed completed/incomplete children, toggle **Show completed** with the label or Space, and confirm that only rows change—not the overall count/progress. For a parent with only completed children, hiding them should leave the control and progress visible with an explicit empty message.

## Checks

- [x] `go build ./... && go vet ./... && go test ./...` (test environment normalized as documented above)
- [x] `npm run typecheck && npm run build` (if UI touched)
- [x] `bash scripts/scan-internal.sh` (or `make scan`) passes
- [x] Nothing installation-specific (site URL, token, real issue data, company string)

Only four source/test/catalog files are included; demo database, generated build output, and local verification artifacts are not committed. Local results are not a claim of upstream CI success.